### PR TITLE
feat: add onApproval support to request and direct PR approval flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ## Added
+
 - onApproval hook support for request and direct PR flows
 - automatic PR approval for direct PRs when onApproval returns approved
 - machine-readable metadata in PR validation comments
 
 ## Changed
+
 - unified error structure (`field` + `message`) across hooks and validation
 - approval flow now prioritizes onApproval over default reviewer assignment
 - improved consistency between issue and PR validation outputs
 
 ## Behavior
+
 - approved → auto-approve + merge flow continues
 - rejected → PR/issue closed with structured feedback
 - no decision → fallback to existing manual review flow
 
 ## Notes
+
 - fully backward compatible if onApproval is not configured
 - no changes to existing validation, routing, or CI logic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Added
+- onApproval hook support for request and direct PR flows
+- automatic PR approval for direct PRs when onApproval returns approved
+- machine-readable metadata in PR validation comments
+
+## Changed
+- unified error structure (`field` + `message`) across hooks and validation
+- approval flow now prioritizes onApproval over default reviewer assignment
+- improved consistency between issue and PR validation outputs
+
+## Behavior
+- approved → auto-approve + merge flow continues
+- rejected → PR/issue closed with structured feedback
+- no decision → fallback to existing manual review flow
+
+## Notes
+- fully backward compatible if onApproval is not configured
+- no changes to existing validation, routing, or CI logic
+
 ## [[0.0.4](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/rel/0.0.4)] - 2026-03-31
 
 - accept approval only for explicit approval commands

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Registry Bot
 
-[![CI](../../actions/workflows/ci-check.yml/badge.svg)](../../actions/workflows/ci-check.yml)
-[![REUSE status](https://api.reuse.software/badge/github.com/open-resource-discovery/global-registry-bot)](https://api.reuse.software/info/github.com/open-resource-discovery/global-registry-bot)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-
 Registry Bot is a configuration-driven GitHub App built with Probot.
 It automates registry requests in a target repository.
 A user opens an issue based on a repo template.
@@ -26,6 +22,7 @@ All behavior is defined per repository:
 - The bot parses the issue body into form data.
 - Validation uses JSON Schema draft 2020-12 with AJV.
 - Optional hooks can change form data and add extra validation rules.
+- Optional approval hooks can auto-approve requests after validation.
 - Hook HTTP calls are restricted. HTTPS only. Host allowlist. Timeouts.
 - The bot blocks duplicates. It checks if the YAML entry already exists.
 - For valid requests, it creates a branch, writes a YAML file, and opens a pull request.
@@ -50,8 +47,8 @@ All behavior is defined per repository:
 The bot is designed to operate against a dedicated **registry repository** that stores structured YAML entries such as namespaces, products, or vendors.
 A preconfigured testing setup is available for local development and integration testing:
 
-- [`registry-bot`](https://github.com/open-resource-discovery/global-registry-bot) → GitHub App source code (this repository)
-- [`example-registry`](https://github.com/open-resource-discovery/example-registry) → sample registry repository used for validation, PR creation, and schema testing
+- [`registry-bot`](https://github.tools.sap/ORD/github-registry-bot) → GitHub App source code (this repository)
+- [`example-registry`](https://github.tools.sap/cpa-namespace-registry-bot/example-registry) → sample registry repository used for validation, PR creation, and schema testing
 
 ⚠️ **Important:**
 Because this is a GitHub App, it must be **installed on the target repository** to receive webhook events.
@@ -84,6 +81,7 @@ Without installation, events like `issues.opened`, `issue_comment.created`, or `
 ### Review and merge
 
 - Review and approve the pull request.
+- Optionally, `onApproval` can auto-approve eligible requests after validation.
 - With auto-merge enabled, GitHub merges when all checks pass.
 - If auto-merge is not enabled, the bot adds a merge-candidate label.
 
@@ -259,6 +257,11 @@ Use it for repo-specific rules or external lookups.
   - Receives `requestType`, `form`, and `log` (plus other context values).
   - Must return an array of validation errors.
   - Return `[]` if everything is fine.
+- `onApproval(args)`
+  - Runs after validation and parent checks passed.
+  - Receives request context similar to `onValidate`.
+  - Can return an approval decision for automatic approval handling.
+  - If omitted, the normal manual review flow stays unchanged.
 
 #### Example (product lookup)
 
@@ -288,7 +291,21 @@ export async function onValidate({ requestType, log, ...rest }) {
   }
 }
 
-export default { onValidate };
+export async function onApproval({ requestType, log, ...rest }) {
+  try {
+    switch (requestType) {
+      case 'product':
+        return { approved: false };
+      default:
+        return { approved: false };
+    }
+  } catch (e) {
+    log.error({ err: e?.message ?? String(e) }, 'hook:onApproval:error');
+    return { approved: false };
+  }
+}
+
+export default { onValidate, onApproval };
 ```
 
 If config.js is missing, the bot runs with built-in validation only.
@@ -316,29 +333,6 @@ Shows the happy path call sequence.
 ![Sequence v0](docs/Sequence%20v0.svg)
 
 > Source file: [docs/Sequence v0.svg](docs/Sequence%20v0.svg)
-
-## Communication, Feedback & FAQ
-
-If you have feedback, questions, or problems, please open a GitHub issue in this repository.
-
-## Ownership and Governance
-
-This project is part of the Open Resource Discovery (ORD) ecosystem.
-ORD is governed under neutral governance by the Linux Foundation / NeoNephos.
-For governance details, see the ORD steering committee information.
-
-## License
-
-This project is licensed under Apache 2.0. See [LICENSE](LICENSE).
-Detailed third-party licensing and copyright information is available via the REUSE metadata.
-
-## Security
-
-For security-related topics, please see [SECURITY.md](SECURITY.md).
-
-## Contributing
-
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Acknowledgements
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -13,6 +13,9 @@ module.exports = {
       {
         useESM: true,
         tsconfig: '<rootDir>/tsconfig.test.json',
+        diagnostics: {
+          ignoreCodes: [2823, 1343],
+        },
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,23 @@ type LogLike = {
   info?: (obj: unknown, msg?: string) => void;
 };
 
-export type RegistryBotHooks = Record<string, unknown>;
+export type ApprovalHookStatus = 'approved' | 'rejected' | 'unknown';
+
+export type ApprovalHookDecision = {
+  status?: ApprovalHookStatus;
+  path?: string;
+  reason?: string;
+  comment?: string;
+};
+
+export type RegistryBotHooks = {
+  ajvPlugins?: unknown;
+  beforeValidate?: unknown;
+  customValidate?: unknown;
+  onValidate?: unknown;
+  onApproval?: unknown;
+  [k: string]: unknown;
+};
 
 type RegistryBotContextLike = {
   octokit: OctokitLike;

--- a/src/handlers/request/comments.ts
+++ b/src/handlers/request/comments.ts
@@ -148,7 +148,7 @@ function resolveCommentTarget(
   const repo = toStringTrim(params.repo ?? context.payload?.repository?.name);
   const issueNumber =
     typeof (params.issue_number ?? params.pull_number) === 'number'
-      ? (params.issue_number ?? params.pull_number)!
+      ? ((params.issue_number ?? params.pull_number) as number)
       : null;
 
   return { owner, repo, issueNumber };

--- a/src/handlers/request/constants.ts
+++ b/src/handlers/request/constants.ts
@@ -285,7 +285,7 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
               enum: ['merge', 'squash', 'rebase', 'MERGE', 'SQUASH', 'REBASE', null],
               errorMessage: {
                 type: 'pr.autoMerge.method must be a string.',
-                enum: 'pr.autoMerge.method must be one of: merge, squash, rebase, MERGE, SQUASH, REBASE, or null.',
+                enum: 'pr.autoMerge.method must be one of: merge, squash, rebase.',
               },
             },
           },
@@ -428,7 +428,7 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
       },
       errorMessage: {
         type: 'workflow must be an object when provided.',
-        additionalProperties: "Only 'labels', 'approvers' and 'links' are allowed inside workflow.",
+        additionalProperties: "Only 'labels', 'approvers', 'links' and 'assignees' are allowed inside workflow.",
       },
     },
   },

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1,7 +1,10 @@
 import { setStateLabel as setStateLabelRaw, ensureAssigneesOnce as ensureAssigneesOnceRaw } from './state.js';
 import { postOnce as postOnceRaw, collapseBotCommentsByPrefix as collapseBotCommentsByPrefixRaw } from './comments.js';
 import { loadTemplate as loadTemplateRaw, parseForm as parseFormRaw } from './template.js';
-import { validateRequestIssue as validateRequestIssueRaw } from './validation/run.js';
+import {
+  validateRequestIssue as validateRequestIssueRaw,
+  runApprovalHook as runApprovalHookRaw,
+} from './validation/run.js';
 import {
   calcSnapshotHash as calcSnapshotHashRaw,
   extractHashFromPrBody as extractHashFromPRBodyRaw,
@@ -91,8 +94,16 @@ type CollapseBotCommentsByPrefixOptions = {
 
 type PullRequestLike = {
   number: number;
+  title?: string | null;
   body?: string | null;
+  state?: string | null;
+  user?: UserLike | null;
   head: { ref: string; sha: string };
+};
+
+type PullRequestFileLike = {
+  filename?: string | null;
+  status?: string | null;
 };
 
 type CheckRunPullRequestRef = { number?: number | null };
@@ -117,6 +128,7 @@ type ValidateRequestIssueResult = {
   errorsGrouped?: unknown;
   errorsFormatted: string;
   errorsFormattedSingle: string;
+  validationIssues?: { message: string; path: string }[];
   formData?: FormData;
   template?: TemplateLike;
   namespace: string;
@@ -132,6 +144,144 @@ type EffectiveConstants = {
   labelAutoMergeCandidate: string | null;
   approverUsernames: string[];
 };
+
+type MachineReadableIssue = Readonly<{
+  field: string;
+  message: string;
+  filePath?: string;
+}>;
+
+function normalizeMachineReadableIssues(value: unknown): MachineReadableIssue[] {
+  const items = Array.isArray(value) ? value : [];
+  const out: MachineReadableIssue[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    if (!isPlainObject(item)) continue;
+
+    const message = toStringTrim(item['message']);
+    const field = toStringTrim(item['field'] ?? item['path']) || 'details';
+    const filePath = toStringTrim(item['filePath']);
+
+    if (!message) continue;
+
+    const key = `${field}\u0000${filePath}\u0000${message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      field,
+      message,
+      ...(filePath ? { filePath } : {}),
+    });
+  }
+
+  return out;
+}
+
+function buildMachineReadableMetadataBlock(issues: MachineReadableIssue[]): string {
+  const normalized = normalizeMachineReadableIssues(issues);
+  if (!normalized.length) return '';
+
+  return `
+
+<details>
+<summary>Show as JSON (Robots Friendly)</summary>
+
+\`\`\`json
+${JSON.stringify(normalized, null, 2)}
+\`\`\`
+</details>`;
+}
+
+function buildDetectedIssuesBody(message: string, issues: MachineReadableIssue[] = []): string {
+  return `## Detected issues
+
+${message}${buildMachineReadableMetadataBlock(issues)}`;
+}
+
+function singleMachineReadableIssue(field: string, message: string, filePath = ''): MachineReadableIssue[] {
+  const normalizedMessage = toStringTrim(message);
+  const normalizedField = toStringTrim(field) || 'details';
+  const normalizedFilePath = toStringTrim(filePath);
+
+  return normalizedMessage
+    ? [
+        {
+          field: normalizedField,
+          message: normalizedMessage,
+          ...(normalizedFilePath ? { filePath: normalizedFilePath } : {}),
+        },
+      ]
+    : [];
+}
+
+function buildRegistryValidationMachineReadableIssues(filePath: string, messages: string[]): MachineReadableIssue[] {
+  const out: MachineReadableIssue[] = [];
+  const normalizedFilePath = toStringTrim(filePath);
+
+  for (const raw of messages || []) {
+    const message = normalizeMsg(raw);
+    if (!message) continue;
+
+    const field = extractFieldFromMsg(raw) || 'details';
+    out.push({
+      field,
+      message,
+      ...(normalizedFilePath ? { filePath: normalizedFilePath } : {}),
+    });
+  }
+
+  return normalizeMachineReadableIssues(out);
+}
+
+function normalizeApprovalHookErrorsForComment(decision: ApprovalDecision): MachineReadableIssue[] {
+  const raw = Array.isArray(decision.errors) ? decision.errors : [];
+  const mapped = raw.map((entry) => ({
+    field: toStringTrim(entry?.field) || 'details',
+    message: toStringTrim(entry?.message),
+  }));
+
+  const normalized = normalizeMachineReadableIssues(mapped);
+  if (normalized.length) return normalized;
+
+  const fallbackMessage =
+    toStringTrim(decision.message) || toStringTrim(decision.reason) || toStringTrim(decision.comment);
+  const fallbackField = toStringTrim(decision.path) || 'details';
+
+  return fallbackMessage ? [{ field: fallbackField, message: fallbackMessage }] : [];
+}
+
+function buildApprovalHookIssueList(issues: MachineReadableIssue[]): string {
+  const normalized = normalizeMachineReadableIssues(issues);
+  if (!normalized.length) return '';
+
+  const grouped = new Map<string, string[]>();
+
+  for (const issue of normalized) {
+    const key = toStringTrim(issue.field) || 'details';
+    const arr = grouped.get(key) ?? [];
+    if (!arr.includes(issue.message)) arr.push(issue.message);
+    grouped.set(key, arr);
+  }
+
+  const keys = Array.from(grouped.keys()).sort((a, b) => {
+    if (a === 'details') return 1;
+    if (b === 'details') return -1;
+    return a.localeCompare(b);
+  });
+
+  const lines: string[] = [];
+  for (const key of keys) {
+    lines.push(`### ${toSectionTitle(key)}`);
+    for (const msg of grouped.get(key) ?? []) {
+      lines.push(`- ${msg}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
+}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -641,7 +791,6 @@ function buildRegistryValidationPrCommentBody(filePath: string, messages: string
   lines.push(`## Detected issues: ${filePath}`);
   lines.push('');
 
-  // group by field
   const grouped = new Map<string, string[]>();
 
   for (const raw of messages) {
@@ -650,12 +799,11 @@ function buildRegistryValidationPrCommentBody(filePath: string, messages: string
     if (!msg) continue;
 
     const arr = grouped.get(field) ?? [];
-    if (!arr.includes(msg)) arr.push(msg); // dedupe within section
+    if (!arr.includes(msg)) arr.push(msg);
     grouped.set(field, arr);
   }
 
   const keys = Array.from(grouped.keys()).sort((a, b) => {
-    // put "details" last
     if (a === 'details') return 1;
     if (b === 'details') return -1;
     return a.localeCompare(b);
@@ -669,7 +817,12 @@ function buildRegistryValidationPrCommentBody(filePath: string, messages: string
     lines.push('');
   }
 
-  return lines.join('\n').trimEnd();
+  const body = lines.join('\n').trimEnd();
+  const machineReadable = buildRegistryValidationMachineReadableIssues(filePath, messages);
+
+  return `${body}
+
+${buildMachineReadableMetadataBlock(machineReadable)}`;
 }
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -722,7 +875,7 @@ function normalizeApprovalCommandToken(value: unknown): string {
   const trailingTrimChars = new Set(['"', "'", '`', ')', ']', '}', '>', '.', ',', '!', '?', ';', ':']);
 
   while (s && leadingTrimChars.has(s[0])) s = s.slice(1).trim();
-  while (s && trailingTrimChars.has(s[s.length - 1])) s = s.slice(0, -1).trim();
+  while (s && trailingTrimChars.has(s.at(-1) || '')) s = s.slice(0, -1).trim();
 
   return s;
 }
@@ -943,6 +1096,32 @@ type ValidateRequestIssueFn = (
   options?: { template?: TemplateLike; formData?: FormData }
 ) => Promise<ValidateRequestIssueResult>;
 
+type ApprovalDecision = {
+  status?: 'approved' | 'rejected' | 'unknown';
+  path?: string;
+  reason?: string;
+  comment?: string;
+  message?: string;
+  errors?: {
+    field?: string;
+    message?: string;
+  }[];
+};
+
+type ApprovalHandlingResult = 'approved' | 'rejected' | 'continue';
+
+type RunApprovalHookFn = (
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  args: {
+    requestType: string;
+    namespace?: string | null;
+    resourceName?: string | null;
+    formData: FormData;
+    issue: IssueLike;
+  }
+) => Promise<ApprovalDecision | boolean>;
+
 type CalcSnapshotHashFn = (formData: FormData, template: TemplateLike, rawBody: string) => string;
 
 type ExtractHashFromPrBodyFn = (body: string) => string;
@@ -979,6 +1158,7 @@ const collapseBotCommentsByPrefix = collapseBotCommentsByPrefixRaw as unknown as
 const loadTemplate = loadTemplateRaw as unknown as LoadTemplateFn;
 const parseForm = parseFormRaw as unknown as ParseFormFn;
 const validateRequestIssue = validateRequestIssueRaw as unknown as ValidateRequestIssueFn;
+const runApprovalHook = runApprovalHookRaw as unknown as RunApprovalHookFn;
 const calcSnapshotHash = calcSnapshotHashRaw as unknown as CalcSnapshotHashFn;
 const extractHashFromPrBody = extractHashFromPRBodyRaw as unknown as ExtractHashFromPrBodyFn;
 const findOpenIssuePrs = findOpenIssuePRsRaw as unknown as FindOpenIssuePrsFn;
@@ -1248,6 +1428,647 @@ function isAuthorizedApprover(
   return Boolean(commenterLc && commenterLc !== issueAuthorLc);
 }
 
+function buildApprovalDecisionJson(decision: ApprovalDecision): string {
+  const payload: Record<string, unknown> = {};
+  if (decision.status) payload.status = decision.status;
+  if (decision.path) payload.path = decision.path;
+  if (decision.reason) payload.reason = decision.reason;
+  if (decision.comment) payload.comment = decision.comment;
+  if (decision.message) payload.message = decision.message;
+  if (Array.isArray(decision.errors) && decision.errors.length) payload.errors = decision.errors;
+  return JSON.stringify(payload, null, 2);
+}
+
+function normalizeApprovalDecision(decision: ApprovalDecision | boolean): ApprovalDecision {
+  if (decision === true) return { status: 'approved' };
+  if (decision === false) return {};
+  return decision || {};
+}
+
+function buildApprovalUnknownBody(decision: ApprovalDecision): string {
+  const lead = toStringTrim(decision.message) || toStringTrim(decision.comment) || toStringTrim(decision.reason);
+  const leadBlock = lead ? `${lead}\n\n` : '';
+
+  return `## onApproval feedback
+
+${leadBlock}\`\`\`json
+${buildApprovalDecisionJson({ status: 'unknown', ...decision })}
+\`\`\`
+
+Continuing with the standard review flow.`;
+}
+
+function buildApprovalRejectedBody(decision: ApprovalDecision): string {
+  const issues = normalizeApprovalHookErrorsForComment(decision);
+  const groupedIssues = buildApprovalHookIssueList(issues);
+  const detectedIssuesBlock = groupedIssues ? buildDetectedIssuesBody(groupedIssues, issues) : '';
+
+  const lead = toStringTrim(decision.message) || toStringTrim(decision.comment) || toStringTrim(decision.reason);
+  const leadBlock = lead && !detectedIssuesBlock ? `${lead}\n\n` : '';
+  const issuesBlock = detectedIssuesBlock ? `${detectedIssuesBlock}\n\n` : '';
+
+  return `## onApproval rejected this request
+
+${leadBlock}${issuesBlock}Closing this request automatically.`;
+}
+
+async function applyApprovedRequestState(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  eff: EffectiveConstants
+): Promise<void> {
+  try {
+    if (eff.labelOnApproved) {
+      await context.octokit.issues.addLabels({ ...params, labels: [eff.labelOnApproved] });
+    }
+  } catch {
+    // ignore
+  }
+
+  await removeReviewPendingLabelsAfterApproval(context, params, eff);
+
+  try {
+    const labelsAfter = await fetchIssueLabels(context, params);
+    const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+    if (labelsMatching(labelsAfter, approvedLabel).length) {
+      await removeProgressStatusLabels(context, params, labelsAfter);
+      await removeRejectedStatusLabel(context, params, labelsAfter);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+async function createAutomatedApprovalReview(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  decision: ApprovalDecision
+): Promise<boolean> {
+  const body =
+    toStringTrim(decision.comment) || toStringTrim(decision.message) || 'Approved automatically by onApproval hook.';
+
+  try {
+    await (
+      context.octokit.pulls as unknown as {
+        createReview: (args: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          event: 'APPROVE';
+          body: string;
+        }) => Promise<unknown>;
+      }
+    ).createReview({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: pr.number,
+      event: 'APPROVE',
+      body,
+    });
+
+    return true;
+  } catch (e: unknown) {
+    log(
+      context,
+      'warn',
+      { err: e instanceof Error ? e.message : String(e), prNumber: pr.number },
+      'failed to create automated PR approval review'
+    );
+
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      `## onApproval matched, but automatic PR approval failed
+
+${body}
+
+The PR could not be approved automatically, so merge remains blocked until a review is added manually.`,
+      { minimizeTag: 'nsreq:on-approval:approve-failed' }
+    );
+
+    return false;
+  }
+}
+
+function normalizeRepoPath(path: unknown): string {
+  return toStringTrim(path)
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/{2,}/g, '/');
+}
+
+function isYamlPath(path: string): boolean {
+  const p = path.toLowerCase();
+  return p.endsWith('.yaml') || p.endsWith('.yml');
+}
+
+function normalizeTypeToken(value: unknown): string {
+  return toStringTrim(value)
+    .replace(/[\s_-]/g, '')
+    .toLowerCase();
+}
+
+function mapRegistryDocTypeToRequestType(value: unknown): string {
+  const type = normalizeTypeToken(value);
+
+  if (type === 'system') return 'systemNamespace';
+  if (type === 'authority') return 'authorityNamespace';
+  if (type === 'subcontext') return 'subContextNamespace';
+  if (type === 'product') return 'product';
+  if (type === 'vendor') return 'vendor';
+
+  return '';
+}
+
+function matchRequestTypesForFile(context: BotContext<RequestEvents>, filePath: string): string[] {
+  const fp = normalizeRepoPath(filePath);
+  const cfg = context.resourceBotConfig ?? DEFAULT_CONFIG;
+  const reqs = isPlainObject(cfg.requests) ? cfg.requests : {};
+  const matches: string[] = [];
+
+  for (const [requestType, entry] of Object.entries(reqs)) {
+    if (!isPlainObject(entry)) continue;
+
+    const folder = normalizeRepoPath(entry['folderName']);
+    if (!folder) continue;
+
+    if (fp === folder || fp.startsWith(`${folder}/`)) {
+      matches.push(requestType);
+    }
+  }
+
+  return matches;
+}
+
+function pickRequestTypeForChangedResource(
+  context: BotContext<RequestEvents>,
+  filePath: string,
+  doc: Record<string, unknown>
+): string {
+  const candidates = matchRequestTypesForFile(context, filePath);
+  if (candidates.length === 0) return '';
+  if (candidates.length === 1) return candidates[0];
+
+  const byDocType = mapRegistryDocTypeToRequestType(doc['type']);
+  if (byDocType && candidates.includes(byDocType)) return byDocType;
+
+  return '';
+}
+
+function buildFormDataFromRegistryDoc(doc: Record<string, unknown>): FormData {
+  const out: FormData = {};
+
+  const name = toStringTrim(doc['name']);
+  if (name) {
+    out.name = name;
+    out.identifier = name;
+    out.namespace = name;
+  }
+
+  const description = toStringTrim(doc['description']);
+  if (description) out.description = description;
+
+  const title = toStringTrim(doc['title']);
+  if (title) out.title = title;
+
+  const vendor = toStringTrim(doc['vendor']);
+  if (vendor) out.vendor = vendor;
+
+  const contacts = Array.isArray(doc['contact'])
+    ? doc['contact']
+        .map((v) => toStringTrim(v))
+        .filter(Boolean)
+        .join('\n')
+    : toStringTrim(doc['contact']);
+
+  if (contacts) out.contact = contacts;
+
+  return out;
+}
+
+async function listChangedYamlFilesForPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<string[]> {
+  const out: string[] = [];
+  let page = 1;
+
+  while (true) {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        listFiles: (args: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          per_page?: number;
+          page?: number;
+        }) => Promise<{ data?: PullRequestFileLike[] }>;
+      }
+    ).listFiles({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page,
+    });
+
+    const files = Array.isArray(res?.data) ? res.data : [];
+    if (!files.length) break;
+
+    for (const file of files) {
+      const filename = normalizeRepoPath(file?.filename);
+      const status = toStringTrim(file?.status).toLowerCase();
+
+      if (!filename) continue;
+      if (!isYamlPath(filename)) continue;
+      if (status === 'removed') continue;
+
+      out.push(filename);
+    }
+
+    if (files.length < 100) break;
+    page += 1;
+    if (page > 20) break;
+  }
+
+  return Array.from(new Set(out));
+}
+
+async function readRepoFileTextAtRef(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  path: string,
+  ref: string
+): Promise<string | null> {
+  const p = normalizeRepoPath(path);
+  const branchRef = toStringTrim(ref);
+  if (!p || !branchRef) return null;
+
+  try {
+    const res = await (
+      context.octokit.repos as unknown as {
+        getContent: (args: { owner: string; repo: string; path: string; ref?: string }) => Promise<{ data?: unknown }>;
+      }
+    ).getContent({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      path: p,
+      ref: branchRef,
+    });
+
+    const data = (res as { data?: unknown }).data;
+    if (Array.isArray(data) || !isRepoContentFile(data)) return null;
+
+    const enc = typeof data.encoding === 'string' ? data.encoding : 'base64';
+    return Buffer.from(String(data.content || ''), enc as BufferEncoding).toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function evaluateDirectPrOnApproval(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<ApprovalDecision> {
+  const changedFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+  if (!changedFiles.length) return {};
+
+  let sawApproved = false;
+  let sawUnknown = false;
+  let approvedComment = '';
+
+  for (const filePath of changedFiles) {
+    const raw = await readRepoFileTextAtRef(context, repoInfo, filePath, pr.head.ref);
+    if (!raw) {
+      sawUnknown = true;
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = YAML.parse(raw);
+    } catch {
+      sawUnknown = true;
+      continue;
+    }
+
+    if (!isPlainObject(parsed)) {
+      sawUnknown = true;
+      continue;
+    }
+
+    const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
+    if (!requestType) {
+      sawUnknown = true;
+      continue;
+    }
+
+    const resourceName = toStringTrim(parsed['name']);
+    if (!resourceName) {
+      sawUnknown = true;
+      continue;
+    }
+
+    const formData = buildFormDataFromRegistryDoc(parsed);
+
+    const decision = normalizeApprovalDecision(
+      await runApprovalHook(context, repoInfo, {
+        requestType,
+        namespace: resourceName,
+        resourceName,
+        formData,
+        issue: {
+          number: pr.number,
+          title: pr.title,
+          body: pr.body,
+          state: pr.state,
+          user: pr.user,
+          labels: [],
+        },
+      })
+    );
+
+    if (decision.status === 'rejected') {
+      return decision;
+    }
+
+    if (decision.status === 'approved') {
+      sawApproved = true;
+      if (!approvedComment) approvedComment = toStringTrim(decision.comment);
+      continue;
+    }
+
+    sawUnknown = true;
+  }
+
+  if (sawApproved && !sawUnknown) {
+    return {
+      status: 'approved',
+      ...(approvedComment ? { comment: approvedComment } : {}),
+    };
+  }
+
+  return {};
+}
+
+async function maybeHandleStandaloneDirectPrApproval(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<ApprovalHandlingResult> {
+  const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr);
+
+  if (decision.status === 'approved') {
+    const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
+    return approved ? 'approved' : 'continue';
+  }
+
+  if (decision.status === 'rejected') {
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      buildApprovalRejectedBody(decision),
+      { minimizeTag: 'nsreq:on-approval:rejected' }
+    );
+
+    try {
+      await context.octokit.pulls.update({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        pull_number: pr.number,
+        state: 'closed',
+      });
+    } catch {
+      // ignore
+    }
+
+    return 'rejected';
+  }
+
+  return 'continue';
+}
+
+async function closeLinkedIssuePrs(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  issueNumber: number
+): Promise<number[]> {
+  const prs = await findOpenIssuePrs(context, repoInfo, issueNumber);
+  const closed: number[] = [];
+
+  for (const pr of prs) {
+    try {
+      await context.octokit.pulls.update({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        pull_number: pr.number,
+        state: 'closed',
+      });
+      closed.push(pr.number);
+    } catch {
+      // ignore
+    }
+  }
+
+  return closed;
+}
+
+async function rejectRequestFromApprovalHook(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  issue: IssueLike,
+  decision: ApprovalDecision,
+  options: { closeLinkedPrs?: boolean; minimizeTag?: string } = {}
+): Promise<void> {
+  const repoInfo = { owner: params.owner, repo: params.repo };
+
+  let closedPrs: number[] = [];
+  if (options.closeLinkedPrs) {
+    try {
+      closedPrs = await closeLinkedIssuePrs(context, repoInfo, issue.number);
+    } catch {
+      // ignore
+    }
+  }
+
+  const closedPrSection = closedPrs.length
+    ? `\n\nClosed linked PR(s): ${closedPrs.map((n) => `#${n}`).join(', ')}.`
+    : '';
+
+  await postOnce(context, params, `${buildApprovalRejectedBody(decision)}${closedPrSection}`, {
+    minimizeTag: options.minimizeTag || 'nsreq:on-approval:rejected',
+  });
+
+  try {
+    await context.octokit.issues.update({ ...params, state: 'closed' });
+    issue.state = 'closed';
+  } catch {
+    // ignore
+  }
+}
+
+async function finalizeApprovedRequest(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  issue: IssueLike,
+  template: TemplateLike,
+  parsedFormData: FormData,
+  approvalPrefix: string,
+  approvalComment = ''
+): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+
+  const resourceName = extractResourceNameFromForm(parsedFormData, template).replaceAll('\u00a0', ' ').trim();
+  if (!resourceName) {
+    await postOnce(
+      context,
+      params,
+      'Cannot create PR: missing resource name in the form (expected identifier, product-id or namespace).',
+      { minimizeTag: 'nsreq:config' }
+    );
+    return;
+  }
+
+  const existing = await findOpenIssuePrs(context, { owner: params.owner, repo: params.repo }, issue.number);
+  if (existing.length) {
+    await applyApprovedRequestState(context, params, eff);
+
+    const lead = [toStringTrim(approvalPrefix), toStringTrim(approvalComment)].filter(Boolean).join('. ');
+    const body = lead ? `${lead}. PR already open: #${existing[0].number}` : `PR already open: #${existing[0].number}`;
+
+    await postOnce(context, params, body, {
+      minimizeTag: 'nsreq:approval-info',
+    });
+    return;
+  }
+
+  try {
+    const pr = await createRequestPr(context, { owner: params.owner, repo: params.repo }, issue, parsedFormData, {
+      template,
+    });
+
+    await applyApprovedRequestState(context, params, eff);
+
+    const lead = [toStringTrim(approvalPrefix), toStringTrim(approvalComment)].filter(Boolean).join('. ');
+    const body = lead ? `${lead}. Opened PR: #${pr.number}` : `Opened PR: #${pr.number}`;
+
+    await postOnce(context, params, body, {
+      minimizeTag: 'nsreq:approval-info',
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+
+    await postOnce(
+      context,
+      params,
+      /^Failed to create PR automatically:/i.test(msg) ? msg : `Failed to create PR automatically: ${msg}`,
+      { minimizeTag: 'nsreq:approval-info' }
+    );
+  }
+}
+
+async function maybeHandleApprovalDecision(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  issue: IssueLike,
+  template: TemplateLike,
+  parsedFormData: FormData,
+  requestType: string,
+  namespace: string
+): Promise<ApprovalHandlingResult> {
+  const decision = normalizeApprovalDecision(
+    await runApprovalHook(
+      context,
+      { owner: params.owner, repo: params.repo },
+      {
+        requestType,
+        namespace,
+        resourceName: extractResourceNameFromForm(parsedFormData, template),
+        formData: parsedFormData,
+        issue,
+      }
+    )
+  );
+
+  if (decision.status === 'approved') {
+    await finalizeApprovedRequest(context, params, issue, template, parsedFormData, '', toStringTrim(decision.comment));
+    return 'approved';
+  }
+
+  if (decision.status === 'rejected') {
+    await rejectRequestFromApprovalHook(context, params, issue, decision, {
+      closeLinkedPrs: true,
+    });
+    return 'rejected';
+  }
+
+  if (decision.status === 'unknown') {
+    await postOnce(context, params, buildApprovalUnknownBody(decision), {
+      minimizeTag: 'nsreq:on-approval:unknown',
+    });
+  }
+
+  return 'continue';
+}
+
+async function maybeHandleDirectPrApprovalForMerge(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  issueParams: IssueParams,
+  issue: IssueLike,
+  template: TemplateLike,
+  parsedFormData: FormData,
+  pr: PullRequestLike
+): Promise<ApprovalHandlingResult> {
+  const decision = normalizeApprovalDecision(
+    await runApprovalHook(context, repoInfo, {
+      requestType: resolveEffectiveRequestType(template, parsedFormData),
+      namespace: toStringTrim(parsedFormData['namespace'] || parsedFormData['identifier']),
+      resourceName: extractResourceNameFromForm(parsedFormData, template),
+      formData: parsedFormData,
+      issue,
+    })
+  );
+
+  if (decision.status === 'approved') {
+    const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
+    if (!approved) return 'continue';
+
+    await applyApprovedRequestState(context, issueParams, resolveEffectiveConstants(context));
+    return 'approved';
+  }
+
+  if (decision.status === 'rejected') {
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      buildApprovalRejectedBody(decision),
+      { minimizeTag: 'nsreq:on-approval:rejected' }
+    );
+
+    await rejectRequestFromApprovalHook(context, issueParams, issue, decision, {
+      closeLinkedPrs: true,
+      minimizeTag: 'nsreq:on-approval:issue-rejected',
+    });
+
+    return 'rejected';
+  }
+
+  if (decision.status === 'unknown') {
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      buildApprovalUnknownBody(decision),
+      { minimizeTag: 'nsreq:on-approval:unknown' }
+    );
+  }
+
+  return 'continue';
+}
+
 async function processIssueEvent(
   app: Probot,
   context: BotContext<'issues.opened' | 'issues.edited' | 'issues.reopened'>,
@@ -1337,9 +2158,14 @@ async function processIssueEvent(
     const message =
       errorsFormattedSingle?.trim() || errorsFormatted?.trim() || listFallback || 'Unknown validation error.';
 
-    await postOnce(context, params, `## Detected issues\n\n${message}`, {
-      minimizeTag: 'nsreq:validation',
-    });
+    await postOnce(
+      context,
+      params,
+      buildDetectedIssuesBody(message, normalizeMachineReadableIssues(result.validationIssues || [])),
+      {
+        minimizeTag: 'nsreq:validation',
+      }
+    );
     await setStateLabel(context, params, issue, 'author');
     return;
   }
@@ -1354,9 +2180,14 @@ async function processIssueEvent(
     );
 
     if (parentError) {
-      await postOnce(context, params, `## Detected issues\n\n- ${parentError}`, {
-        minimizeTag: 'nsreq:validation',
-      });
+      await postOnce(
+        context,
+        params,
+        buildDetectedIssuesBody(`- ${parentError}`, singleMachineReadableIssue('name', parentError)),
+        {
+          minimizeTag: 'nsreq:validation',
+        }
+      );
       await setStateLabel(context, params, issue, 'author');
       return;
     }
@@ -1386,6 +2217,18 @@ async function processIssueEvent(
 
   if (gated) return;
 
+  const approvalOutcome = await maybeHandleApprovalDecision(
+    context,
+    params,
+    issue,
+    result.template || template,
+    parsedFormData,
+    effectiveRequestType,
+    validatedNamespace
+  );
+
+  if (approvalOutcome !== 'continue') return;
+
   await handoverToCpa(context, params, issue, nsType, validatedNamespace, [], {
     snapshotHash: currentHash,
     requestType: effectiveRequestType,
@@ -1393,7 +2236,7 @@ async function processIssueEvent(
 }
 
 async function handleApprovalComment(
-  context: BotContext<'issue_comment.created' | 'issue_comment.edited'>,
+  context: BotContext<RequestEvents>,
   params: IssueParams,
   issue: IssueLike,
   template: TemplateLike,
@@ -1443,9 +2286,20 @@ async function handleApprovalComment(
       listFallback ||
       'Unknown validation error.';
 
-    await postOnce(context, params, `## Detected issues\n\n${message}`, {
-      minimizeTag: 'nsreq:validation',
-    });
+    const normalizedIssues = (reval.validationIssues || []).map((issue) => ({
+      field: toStringTrim(issue.path) || 'details',
+      message: toStringTrim(issue.message),
+      ...(issue.path ? { filePath: toStringTrim(issue.path) } : {}),
+    }));
+
+    await postOnce(
+      context,
+      params,
+      buildDetectedIssuesBody(message, normalizeMachineReadableIssues(normalizedIssues)),
+      {
+        minimizeTag: 'nsreq:validation',
+      }
+    );
     await setStateLabel(context, params, issue, 'author');
     return;
   }
@@ -1460,9 +2314,14 @@ async function handleApprovalComment(
     );
 
     if (parentError) {
-      await postOnce(context, params, `## Detected issues\n\n- ${parentError}`, {
-        minimizeTag: 'nsreq:validation',
-      });
+      await postOnce(
+        context,
+        params,
+        buildDetectedIssuesBody(`- ${parentError}`, singleMachineReadableIssue('name', parentError)),
+        {
+          minimizeTag: 'nsreq:validation',
+        }
+      );
       await setStateLabel(context, params, issue, 'author');
       return;
     }
@@ -1475,67 +2334,12 @@ async function handleApprovalComment(
     );
   }
 
-  const resourceName = extractResourceNameFromForm(parsedFormData, template).replaceAll('\u00a0', ' ').trim();
-  if (!resourceName) {
-    await postOnce(
-      context,
-      params,
-      'Cannot create PR: missing resource name in the form (expected identifier, product-id or namespace).',
-      { minimizeTag: 'nsreq:config' }
-    );
-    return;
-  }
-
-  const existing = await findOpenIssuePrs(context, { owner: params.owner, repo: params.repo }, issue.number);
-  if (existing.length) {
-    await postOnce(context, params, `Approved by @${commenter}. PR already open: #${existing[0].number}`, {
-      minimizeTag: 'nsreq:approval-info',
-    });
-    return;
-  }
-
-  try {
-    const pr = await createRequestPr(context, { owner: params.owner, repo: params.repo }, issue, parsedFormData, {
-      template,
-    });
-
-    try {
-      if (eff.labelOnApproved) {
-        await context.octokit.issues.addLabels({ ...params, labels: [eff.labelOnApproved] });
-      }
-    } catch {
-      // ignore
-    }
-
-    await removeReviewPendingLabelsAfterApproval(context, params, eff);
-
-    try {
-      const labelsAfter = await fetchIssueLabels(context, params);
-      const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
-      if (labelsMatching(labelsAfter, approvedLabel).length) {
-        await removeProgressStatusLabels(context, params, labelsAfter);
-        await removeRejectedStatusLabel(context, params, labelsAfter);
-      }
-    } catch {
-      // ignore
-    }
-
-    await postOnce(context, params, `Approved by @${commenter}. Opened PR: #${pr.number}`, {
-      minimizeTag: 'nsreq:approval-info',
-    });
-  } catch (e: unknown) {
-    await postOnce(
-      context,
-      params,
-      `Failed to create PR automatically: ${e instanceof Error ? e.message : String(e)}`,
-      { minimizeTag: 'nsreq:approval-info' }
-    );
-  }
+  await finalizeApprovedRequest(context, params, issue, template, parsedFormData, `Approved by @${commenter}`);
 }
 
 async function handleAuthorUpdateComment(
   app: Probot,
-  context: BotContext<'issue_comment.created' | 'issue_comment.edited'>,
+  context: BotContext<RequestEvents>,
   params: IssueParams,
   issue: IssueLike,
   template: TemplateLike,
@@ -1568,9 +2372,14 @@ async function handleAuthorUpdateComment(
           namespace
         );
         if (parentError) {
-          await postOnce(context, params, `## Detected issues\n\n- ${parentError}`, {
-            minimizeTag: 'nsreq:validation',
-          });
+          await postOnce(
+            context,
+            params,
+            buildDetectedIssuesBody(`- ${parentError}`, singleMachineReadableIssue('name', parentError)),
+            {
+              minimizeTag: 'nsreq:validation',
+            }
+          );
           await setStateLabel(context, params, issue, 'author');
           return;
         }
@@ -1602,9 +2411,21 @@ async function handleAuthorUpdateComment(
 
       if (gated) return;
 
+      const approvalOutcome = await maybeHandleApprovalDecision(
+        context,
+        params,
+        issue,
+        tpl,
+        parsedAfterUpdate,
+        effectiveRequestType,
+        namespace
+      );
+
+      if (approvalOutcome !== 'continue') return;
+
       await handoverToCpa(context, params, issue, nsType, namespace, [], {
         snapshotHash,
-        requestType: toStringTrim(tpl?._meta?.requestType),
+        requestType: effectiveRequestType,
       });
       return;
     }
@@ -1612,9 +2433,23 @@ async function handleAuthorUpdateComment(
     const listFallback = (revalErrors || []).map((e) => `- ${e}`).join('\n');
     const message =
       revalErrorsFormattedSingle?.trim() || revalErrorsFormatted?.trim() || listFallback || 'Unknown validation error.';
-    await postOnce(context, params, `## Detected issues\n\n${message}`, {
-      minimizeTag: 'nsreq:validation',
-    });
+    await postOnce(
+      context,
+      params,
+      buildDetectedIssuesBody(
+        message,
+        normalizeMachineReadableIssues(
+          (reval.validationIssues || []).map((validationIssue) => ({
+            field: toStringTrim(validationIssue.path) || 'details',
+            message: toStringTrim(validationIssue.message),
+            ...(validationIssue.path ? { filePath: toStringTrim(validationIssue.path) } : {}),
+          }))
+        )
+      ),
+      {
+        minimizeTag: 'nsreq:validation',
+      }
+    );
     await setStateLabel(context, params, issue, 'author');
   } catch (e: unknown) {
     (app.log || console).warn?.(`Revalidation failed: ${e instanceof Error ? e.message : String(e)}`);
@@ -1902,7 +2737,7 @@ Please confirm by commenting \`Approved\`. After that, the bot will continue wit
 }
 
 async function handleParentOwnerApprovalIfNeeded(
-  context: BotContext<'issue_comment.created' | 'issue_comment.edited'>,
+  context: BotContext<RequestEvents>,
   params: IssueParams,
   issue: IssueLike,
   template: TemplateLike,
@@ -1940,7 +2775,23 @@ ${mentions}`,
       reval.errorsFormatted?.trim() ||
       listFallback ||
       'Unknown validation error.';
-    await postOnce(context, params, `## Detected issues\n\n${message}`, { minimizeTag: 'nsreq:validation' });
+    await postOnce(
+      context,
+      params,
+      buildDetectedIssuesBody(
+        message,
+        normalizeMachineReadableIssues(
+          (reval.validationIssues || []).map((validationIssue) => ({
+            field: toStringTrim(validationIssue.path) || 'details',
+            message: toStringTrim(validationIssue.message),
+            ...(validationIssue.path ? { filePath: toStringTrim(validationIssue.path) } : {}),
+          }))
+        )
+      ),
+      {
+        minimizeTag: 'nsreq:validation',
+      }
+    );
     await setStateLabel(context, params, issue, 'author');
     return true;
   }
@@ -1959,6 +2810,18 @@ ${mentions}`,
     approvedBy: commenterLogin,
     approvedAt: new Date().toISOString(),
   });
+
+  const approvalOutcome = await maybeHandleApprovalDecision(
+    context,
+    params,
+    issue,
+    tpl,
+    parsedNow,
+    effRt,
+    reval.namespace
+  );
+
+  if (approvalOutcome !== 'continue') return true;
 
   await postOnce(context, params, `Parent namespace approved by @${commenterLogin}. Continuing with standard review.`, {
     minimizeTag: `${tagBase}:approved`,
@@ -2229,7 +3092,11 @@ async function closeOutdatedRequestPrs(
 
   for (const pr of prs) {
     const prHash = extractHashFromPrBody(toStringTrim(pr.body));
-    if (prHash && prHash === currentHash) continue;
+
+    // Direct/manual PRs without request snapshot hash must not be treated as outdated
+    if (!prHash) continue;
+    if (prHash === currentHash) continue;
+
     await closePr(pr.number, pr.head.ref);
     closed.push(pr.number);
   }
@@ -2778,7 +3645,20 @@ export default function requestHandler(app: Probot): void {
     for (const pr of candidates) {
       const body = String(pr.body || '');
       const m = /source:\s*#(\d+)/i.exec(body) ?? /issue\s*#(\d+)/i.exec(body);
-      if (!m) continue;
+
+      if (!m) {
+        const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, { owner, repo }, pr);
+        if (standaloneOutcome !== 'approved') continue;
+
+        await tryMergeIfGreen(context, {
+          owner,
+          repo,
+          prNumber: pr.number,
+          mergeMethod: 'squash',
+          prData: pr,
+        });
+        continue;
+      }
 
       const issueNumber = Number.parseInt(m[1], 10);
       const params: IssueParams = { owner, repo, issue_number: issueNumber };
@@ -2808,10 +3688,33 @@ export default function requestHandler(app: Probot): void {
       const currentHash = calcSnapshotHash(parsedFormData, template, readIssueBodyForProcessing(issue.body));
       const prHash = extractHashFromPrBody(body);
 
-      if (!prHash || prHash !== currentHash) {
-        await closeOutdatedRequestPrs(context, params, template, { parsedFormData, currentHash });
+      if (prHash) {
+        if (prHash !== currentHash) {
+          await closeOutdatedRequestPrs(context, params, template, { parsedFormData, currentHash });
+          continue;
+        }
+
+        await tryMergeIfGreen(context, {
+          owner,
+          repo,
+          prNumber: pr.number,
+          mergeMethod: 'squash',
+          prData: pr,
+        });
         continue;
       }
+
+      const directPrOutcome = await maybeHandleDirectPrApprovalForMerge(
+        context,
+        { owner, repo },
+        params,
+        issue,
+        template,
+        parsedFormData,
+        pr
+      );
+
+      if (directPrOutcome !== 'approved') continue;
 
       await tryMergeIfGreen(context, {
         owner,

--- a/src/handlers/request/pr/snapshot.ts
+++ b/src/handlers/request/pr/snapshot.ts
@@ -55,8 +55,7 @@ export const SNAPSHOT_HASH_MARKER_KEY = 'nsreq:snapshot-hash';
 // Stable stringify with sorted keys and deterministic recursion
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') {
-    const json = JSON.stringify(value);
-    return json === undefined ? 'null' : json;
+    return JSON.stringify(value);
   }
 
   if (Array.isArray(value)) {

--- a/src/handlers/request/template.ts
+++ b/src/handlers/request/template.ts
@@ -377,6 +377,8 @@ export async function loadTemplate(
     throw new Error('Configuration error: owner/repo are required to load templates.');
   }
 
+  const octokit = context.octokit;
+
   const labels = toLabelStrings(issueLabels);
 
   if (DBG && context.log?.debug) {
@@ -402,7 +404,7 @@ export async function loadTemplate(
       return fh.data;
     }
 
-    const { data } = await context.octokit!.repos.getContent({ owner, repo, path });
+    const { data } = await octokit.repos.getContent({ owner, repo, path });
 
     type RepoFile = { content?: unknown; encoding?: unknown } & Record<string, unknown>;
     const file = data as RepoFile;

--- a/src/handlers/request/validation/hook-pool.ts
+++ b/src/handlers/request/validation/hook-pool.ts
@@ -1,12 +1,33 @@
 import { Piscina } from 'piscina';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 let pool: Piscina | null = null;
+
+const defaultModuleFileName = resolve(process.cwd(), 'dist', 'handlers', 'request', 'validation', 'hook-pool.js');
+const moduleFileName = typeof __filename === 'string' ? __filename : defaultModuleFileName;
+
+function resolveWorkerFilePath(): string | null {
+  const candidates = [
+    resolve(process.cwd(), 'dist', 'handlers', 'request', 'validation', 'hook-worker.js'),
+    resolve(dirname(moduleFileName), 'hook-worker.js'),
+    resolve(process.cwd(), 'src', 'handlers', 'request', 'validation', 'hook-worker.js'),
+  ];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
 
 function getPool(): Piscina {
   if (pool) return pool;
 
+  const workerFilePath = resolveWorkerFilePath();
+  if (!workerFilePath) {
+    throw new Error('Hook worker runtime artifact not found');
+  }
+
   pool = new Piscina({
-    filename: new URL('./hook-worker.js', import.meta.url).href,
+    filename: pathToFileURL(workerFilePath).href,
 
     // Critical for CF memory quotas:
     minThreads: 1,
@@ -59,12 +80,12 @@ export type HookWorkerResult = {
 };
 
 export async function runHookInWorker(task: HookWorkerTask, opts: { timeoutMs: number }): Promise<HookWorkerResult> {
-  const p = getPool();
-
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), Math.max(1, opts.timeoutMs));
 
   try {
+    const p = getPool();
+
     const runOpts: { abortSignal: AbortSignal; signal: AbortSignal } = {
       abortSignal: ac.signal,
       signal: ac.signal,

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -1,8 +1,8 @@
 import { parseForm as parseFormRaw, loadTemplate as loadTemplateRaw } from '../template.js';
 import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
-import { loadStaticConfig } from '../../../config.js';
+import { loadStaticConfig, type RegistryBotHooks as StaticRegistryBotHooks } from '../../../config.js';
 import { loadSecrets } from '../../../utils/secrets.js';
 import { createHookApi as createHookApiRaw } from './hook-api.js';
 import Ajv2020Module from 'ajv/dist/2020.js';
@@ -11,12 +11,16 @@ import { runHookInWorker } from './hook-pool.js';
 import addFormatsModule from 'ajv-formats';
 import ajvErrorsModule from 'ajv-errors';
 
-import meta2020_12 from 'ajv/dist/refs/json-schema-2020-12/schema.json' with { type: 'json' };
-
 const META_2020_12_ID = 'https://json-schema.org/draft/2020-12/schema';
 
-const fileName = fileURLToPath(import.meta.url);
-const dirName = dirname(fileName);
+const defaultModuleFileName = resolve(process.cwd(), 'src', 'handlers', 'request', 'validation', 'run.ts');
+let moduleFileName = defaultModuleFileName;
+if (typeof __filename === 'string') {
+  moduleFileName = __filename;
+}
+const moduleRequire = createRequire(moduleFileName);
+const meta202012Schema = moduleRequire('ajv/dist/refs/json-schema-2020-12/schema.json');
+const dirName = dirname(moduleFileName);
 
 const DBG = process.env.DEBUG_NS === '1';
 
@@ -135,6 +139,65 @@ type CustomValidateArgs = Readonly<{
   log?: LoggerLike | undefined;
 }>;
 
+export type ApprovalHookStatus = 'approved' | 'rejected' | 'unknown';
+
+export type ApprovalHookDecision = Readonly<{
+  status?: ApprovalHookStatus;
+  path?: string;
+  reason?: string;
+  comment?: string;
+  message?: string;
+  error?: readonly {
+    field?: string;
+    message?: string;
+  }[];
+  errors?: readonly {
+    field?: string;
+    message?: string;
+  }[];
+}>;
+
+type ApprovalHookResult =
+  | ApprovalHookStatus
+  | boolean
+  | {
+      status?: unknown;
+      path?: unknown;
+      reason?: unknown;
+      comment?: unknown;
+      message?: unknown;
+      error?: unknown;
+      errors?: unknown;
+      approved?: unknown;
+    }
+  | undefined
+  | void;
+
+type OnApprovalArgs = Readonly<{
+  requestType: string;
+  namespace: string;
+  resourceName: string;
+  form: FormData;
+  data: Readonly<Record<string, unknown>>;
+  requestAuthor: Readonly<{
+    id: string;
+    email: string;
+  }>;
+  config: Readonly<{
+    raw: Readonly<Record<string, unknown>>;
+    approvers: string[];
+  }>;
+  issue: Readonly<{
+    number: number;
+    title: string;
+    body: string;
+    state: string;
+    author: string;
+    labels: string[];
+  }>;
+  log?: LoggerLike | undefined;
+}>;
+
 type AjvPluginsArgs = Readonly<{
   ajv: unknown;
   context: ValidationContext;
@@ -156,6 +219,8 @@ type ResourceBotHooks = {
   customValidate?: (args: CustomValidateArgs) => HookValidationResult | Promise<HookValidationResult>;
 
   onValidate?: (args: CustomValidateArgs) => HookValidationResult | Promise<HookValidationResult>;
+
+  onApproval?: (args: OnApprovalArgs) => ApprovalHookResult | Promise<ApprovalHookResult>;
 
   [k: string]: unknown;
 };
@@ -184,14 +249,17 @@ type ValidationContext = {
   issue: () => IssueRef;
 
   resourceBotConfig?: ResourceBotConfig;
-  resourceBotHooks?: ResourceBotHooks | null;
+  resourceBotHooks?: ResourceBotHooks | StaticRegistryBotHooks | null;
   resourceBotHooksSource?: string | null;
 };
 
 type IssueLike = {
+  number?: number;
   body?: string | null;
   title?: string | null;
+  state?: string | null;
   labels?: (string | { name?: string | null })[] | null;
+  user?: { login?: string | null } | null;
 };
 
 type TemplateField = {
@@ -228,6 +296,11 @@ type ValidationBuckets = {
   schema: string[];
 };
 
+export type ValidationIssue = Readonly<{
+  message: string;
+  path: string;
+}>;
+
 type ValidateRequestIssueOptions = Readonly<{
   mode?: 'request' | 'modify';
   template?: TemplateLike;
@@ -261,6 +334,7 @@ export type ValidateRequestIssueResult = Readonly<{
   errorsGrouped: ValidationBuckets;
   errorsFormatted: string;
   errorsFormattedSingle: string;
+  validationIssues: ValidationIssue[];
   formData: FormData;
   template: TemplateLike | null;
   namespace: string;
@@ -395,6 +469,250 @@ function normalizeHookErrors(value: unknown): string[] {
   return out;
 }
 
+function normalizeApprovalHookResult(value: unknown): ApprovalHookDecision {
+  if (value === true) return { status: 'approved' };
+  if (value === false || value === undefined || value === null) return {};
+
+  const token = toStringSafe(value).toLowerCase();
+  if (token === 'approved' || token === 'rejected' || token === 'unknown') {
+    return { status: token as ApprovalHookStatus };
+  }
+
+  if (!isPlainObject(value)) return {};
+
+  if (value['approved'] === true) {
+    const comment = toStringSafe(value['comment']);
+    const message = toStringSafe(value['message']);
+
+    return {
+      status: 'approved',
+      ...(comment ? { comment } : {}),
+      ...(message ? { message } : {}),
+    };
+  }
+
+  const status = toStringSafe(value['status']).toLowerCase();
+  const path = toStringSafe(value['path']);
+  const reason = toStringSafe(value['reason']);
+  const comment = toStringSafe(value['comment']);
+  const message = toStringSafe(value['message']);
+  const errors = normalizeApprovalHookErrors(value['errors'] ?? value['error']);
+
+  if (status === 'approved' || status === 'rejected' || status === 'unknown') {
+    return {
+      status: status as ApprovalHookStatus,
+      ...(path ? { path } : {}),
+      ...(reason ? { reason } : {}),
+      ...(comment ? { comment } : {}),
+      ...(message ? { message } : {}),
+      ...(errors.length ? { errors } : {}),
+    };
+  }
+
+  return {};
+}
+
+function approvalIssueLabelName(value: unknown): string {
+  if (typeof value === 'string') return toStringSafe(value);
+  if (isPlainObject(value)) return toStringSafe(value['name']);
+  return '';
+}
+
+function toApprovalIssueLabelNames(labels: IssueLike['labels']): string[] {
+  const items = Array.isArray(labels) ? labels : [];
+  return items.map((label) => approvalIssueLabelName(label)).filter(Boolean);
+}
+
+function normalizeApprovalHookErrors(value: unknown): readonly {
+  field?: string;
+  message?: string;
+}[] {
+  if (!Array.isArray(value)) return [];
+
+  const out: { field?: string; message?: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const item of value) {
+    if (!isPlainObject(item)) continue;
+
+    const field = toStringSafe(item['field']);
+    const message = toStringSafe(item['message']);
+    if (!message) continue;
+
+    const key = `${field}\u0000${message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      ...(field ? { field } : {}),
+      message,
+    });
+  }
+
+  return out;
+}
+
+function getApprovalHookApprovers(context: ValidationContext, requestType: string): string[] {
+  const cfg = context.resourceBotConfig ?? {};
+  const reqs = isPlainObject(cfg.requests) ? cfg.requests : {};
+  const entry = isPlainObject(reqs[requestType]) ? (reqs[requestType] as Record<string, unknown>) : null;
+
+  const localApprovers = Array.isArray(entry?.['approvers'])
+    ? entry['approvers'].map((v) => toStringSafe(v)).filter(Boolean)
+    : [];
+
+  if (localApprovers.length) return localApprovers;
+
+  const workflow = isPlainObject(cfg.workflow) ? cfg.workflow : {};
+  return Array.isArray(workflow['approvers']) ? workflow['approvers'].map((v) => toStringSafe(v)).filter(Boolean) : [];
+}
+
+function buildApprovalHookData(
+  args: {
+    namespace?: string | null;
+    resourceName?: string | null;
+    formData: FormData;
+  },
+  namespace: string,
+  resourceName: string
+): Readonly<Record<string, unknown>> {
+  return {
+    ...args.formData,
+    name: resourceName || namespace,
+    identifier: toStringSafe(args.formData['identifier']) || resourceName || namespace,
+    namespace: toStringSafe(args.formData['namespace']) || namespace || resourceName,
+  };
+}
+
+function toMachineReadablePath(value: unknown, fallback = 'general'): string {
+  const path = toStringSafe(value);
+  return path || fallback;
+}
+
+function makeValidationIssue(path: unknown, message: unknown, fallbackPath = 'general'): ValidationIssue | null {
+  const msg = toStringSafe(message);
+  if (!msg) return null;
+
+  return {
+    path: toMachineReadablePath(path, fallbackPath),
+    message: msg,
+  };
+}
+
+function dedupeValidationIssues(issues: ValidationIssue[]): ValidationIssue[] {
+  const out: ValidationIssue[] = [];
+  const seen = new Set<string>();
+
+  for (const issue of issues) {
+    const key = `${issue.path}\u0000${issue.message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(issue);
+  }
+
+  return out;
+}
+
+function buildLabelToFieldIdMap(template: TemplateLike): Map<string, string> {
+  const out = new Map<string, string>();
+  const fields = Array.isArray(template?.body) ? template.body : [];
+
+  for (const field of fields) {
+    const id = toStringSafe(field?.id);
+    if (!id) continue;
+
+    const label = toStringSafe(field?.attributes?.label);
+    if (label) out.set(label.toLowerCase(), id);
+
+    const humanized = humanizeKey(id);
+    if (humanized) out.set(humanized.toLowerCase(), id);
+  }
+
+  return out;
+}
+
+function parseRuleValidationIssue(raw: string): ValidationIssue | null {
+  const m = /^([A-Za-z0-9_.-]+)\s*:\s*(.+)$/.exec(raw);
+  if (!m?.[1] || !m?.[2]) return null;
+
+  return makeValidationIssue(m[1], m[2], 'rules');
+}
+
+function buildMachineReadableValidationIssues(
+  buckets: ValidationBuckets,
+  template: TemplateLike,
+  ajvErrors: AjvErrorLike[] = []
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const labelToFieldId = buildLabelToFieldIdMap(template);
+  const { idToLabel } = buildTemplateLabelMaps(template);
+  const primaryFieldId = guessPrimaryFieldId(template) || 'identifier';
+  const primaryLabel = idToLabel.get(primaryFieldId) || humanizeKey(primaryFieldId);
+  const ajvMessages = new Set<string>();
+
+  for (const err of Array.isArray(ajvErrors) ? ajvErrors : []) {
+    const msg = normalizeAjvMessage(err?.message);
+    if (!msg) continue;
+
+    ajvMessages.add(msg);
+
+    const fieldIds = fieldIdsFromAjvError(err);
+    if (fieldIds.length) {
+      for (const fieldId of fieldIds) {
+        const issue = makeValidationIssue(fieldId, msg, 'schema');
+        if (issue) issues.push(issue);
+      }
+      continue;
+    }
+
+    const instancePath = toStringSafe(err?.instancePath).replace(/^\/+/, '');
+    const issue = makeValidationIssue(instancePath || 'schema', msg, 'schema');
+    if (issue) issues.push(issue);
+  }
+
+  for (const raw of dedupe(buckets.form || [])) {
+    const requiredMatch = /^Required field is missing in form:\s*(.+)$/i.exec(raw);
+    if (requiredMatch?.[1]) {
+      const label = toStringSafe(requiredMatch[1]).toLowerCase();
+      const fieldId = labelToFieldId.get(label) || primaryFieldId;
+      const issue = makeValidationIssue(fieldId, 'Required field is missing.', 'form');
+      if (issue) issues.push(issue);
+      continue;
+    }
+
+    const issue = makeValidationIssue('form', raw, 'form');
+    if (issue) issues.push(issue);
+  }
+
+  for (const raw of dedupe(buckets.rules || [])) {
+    const structured = parseRuleValidationIssue(raw);
+    if (structured) {
+      issues.push(structured);
+      continue;
+    }
+
+    const inferredLabel = inferFieldLabelFromRuleMsg(raw, primaryLabel, idToLabel);
+    const inferredFieldId = inferredLabel ? labelToFieldId.get(inferredLabel.toLowerCase()) || 'rules' : 'rules';
+    const issue = makeValidationIssue(inferredFieldId, raw, 'rules');
+    if (issue) issues.push(issue);
+  }
+
+  for (const raw of dedupe(buckets.registry || [])) {
+    const issue = makeValidationIssue(primaryFieldId, raw, primaryFieldId);
+    if (issue) issues.push(issue);
+  }
+
+  for (const raw of dedupe(buckets.schema || [])) {
+    const normalized = normalizeAjvMessage(raw);
+    if (ajvMessages.has(normalized)) continue;
+
+    const issue = makeValidationIssue('schema', raw, 'schema');
+    if (issue) issues.push(issue);
+  }
+
+  return dedupeValidationIssues(issues);
+}
+
 function formatBuckets(b: ValidationBuckets): string {
   const sections: string[] = [];
   if (b.registry.length)
@@ -467,8 +785,12 @@ function addGrouped(grouped: Map<string, string[]>, key: unknown, msg: unknown):
   const m = toStringSafe(msg);
   if (!m) return;
 
-  if (!grouped.has(k)) grouped.set(k, []);
-  grouped.get(k)!.push(m);
+  let items = grouped.get(k);
+  if (!items) {
+    items = [];
+    grouped.set(k, items);
+  }
+  items.push(m);
 }
 
 function fieldIdFromAjvError(e: unknown): string {
@@ -828,80 +1150,100 @@ function normalizePrimaryResourceToken(v: unknown): string {
     .toLowerCase();
 }
 
+const PRIMARY_RESOURCE_FIELDS = new Set(['identifier', 'namespace', 'productid', 'id', 'name', 'vendor']);
+
 function isPrimaryResourceField(v: unknown): boolean {
-  const t = normalizePrimaryResourceToken(v);
-  return t === 'identifier' || t === 'namespace' || t === 'productid' || t === 'id' || t === 'name' || t === 'vendor';
+  return PRIMARY_RESOURCE_FIELDS.has(normalizePrimaryResourceToken(v));
+}
+
+function readFirstPrimaryValue(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = toStringSafe(record[key]).replaceAll('\u00a0', ' ').trim();
+    if (value) return value;
+  }
+
+  return '';
+}
+
+function readPrimaryValueFromSchemaFields(
+  schemaProps: Record<string, unknown>,
+  record: Record<string, unknown>
+): string {
+  for (const [propName, propDef] of Object.entries(schemaProps)) {
+    if (!isPlainObject(propDef)) continue;
+
+    const formField = toStringSafe(propDef['x-form-field']);
+    if (!isPrimaryResourceField(formField)) continue;
+
+    const match = readFirstPrimaryValue(record, [formField, propName]);
+    if (match) return match;
+  }
+
+  return '';
+}
+
+function readPrimaryValueFromSchemaPropertyNames(
+  schemaProps: Record<string, unknown>,
+  record: Record<string, unknown>
+): string {
+  for (const propName of Object.keys(schemaProps)) {
+    if (!isPrimaryResourceField(propName)) continue;
+
+    const value = readFirstPrimaryValue(record, [propName]);
+    if (value) return value;
+  }
+
+  return '';
 }
 
 function resolvePrimaryIdFromRecord(schemaObj: unknown, record: Record<string, unknown>): string {
-  const asTrimmed = (v: unknown): string => toStringSafe(v).replaceAll('\u00a0', ' ').trim();
-
   const directKeys = ['identifier', 'namespace', 'product-id', 'productId', 'id', 'name', 'vendor'];
-  for (const key of directKeys) {
-    const value = asTrimmed(record[key]);
-    if (value) return value;
-  }
+  const directValue = readFirstPrimaryValue(record, directKeys);
+  if (directValue) return directValue;
 
   const schemaProps = getObjectProp(schemaObj, 'properties');
   if (!schemaProps) return '';
 
-  for (const [propName, propDef] of Object.entries(schemaProps)) {
-    if (!isPlainObject(propDef)) continue;
+  const schemaFieldValue = readPrimaryValueFromSchemaFields(schemaProps, record);
+  if (schemaFieldValue) return schemaFieldValue;
 
-    const ff = toStringSafe(propDef['x-form-field']);
-    if (!isPrimaryResourceField(ff)) continue;
-
-    const viaField = asTrimmed(record[ff]);
-    if (viaField) return viaField;
-
-    const viaProp = asTrimmed(record[propName]);
-    if (viaProp) return viaProp;
-  }
-
-  for (const propName of Object.keys(schemaProps)) {
-    if (!isPrimaryResourceField(propName)) continue;
-
-    const viaProp = asTrimmed(record[propName]);
-    if (viaProp) return viaProp;
-  }
-
-  return '';
+  return readPrimaryValueFromSchemaPropertyNames(schemaProps, record);
 }
 
 export function resolvePrimaryIdFromCandidate(candidate: Record<string, unknown>, schemaObj: unknown): string {
   return resolvePrimaryIdFromRecord(schemaObj, candidate);
 }
 
-export function resolvePrimaryIdFromTemplate(template: TemplateLike, formData: FormData, schemaObj: unknown): string {
-  if (!template) return '';
-  const asTrimmed = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+function readDirectPrimaryIdFromForm(formData: FormData): string {
+  return readFirstPrimaryValue(formData as Record<string, unknown>, [
+    'identifier',
+    'namespace',
+    'product-id',
+    'productId',
+  ]);
+}
 
-  const directIdentifier = asTrimmed(formData.identifier);
-  if (directIdentifier) return directIdentifier;
-
-  const directNamespace = asTrimmed(formData.namespace);
-  if (directNamespace) return directNamespace;
-
-  const directProductId = asTrimmed(formData['product-id'] || formData.productId);
-  if (directProductId) return directProductId;
-
+function readIdentifierMappedSchemaValue(formData: FormData, schemaObj: unknown): string {
   const schemaProps = getObjectProp(schemaObj, 'properties');
-  if (schemaProps) {
-    for (const [propName, propDef] of Object.entries(schemaProps)) {
-      if (isPlainObject(propDef) && propDef['x-form-field'] === 'identifier') {
-        const viaIdentifier = asTrimmed(formData.identifier);
-        if (viaIdentifier) return viaIdentifier;
-        const viaProp = asTrimmed((formData as Record<string, unknown>)[propName]);
-        if (viaProp) return viaProp;
-        break;
-      }
-    }
+  if (!schemaProps) return '';
+
+  for (const [propName, propDef] of Object.entries(schemaProps)) {
+    if (!isPlainObject(propDef) || propDef['x-form-field'] !== 'identifier') continue;
+    return readFirstPrimaryValue(formData as Record<string, unknown>, ['identifier', propName]);
   }
 
-  const viaGeneric = resolvePrimaryIdFromRecord(schemaObj, formData as Record<string, unknown>);
-  if (viaGeneric) return viaGeneric;
+  return '';
+}
 
-  return pickIdentifierFromFields(template, formData);
+export function resolvePrimaryIdFromTemplate(template: TemplateLike, formData: FormData, schemaObj: unknown): string {
+  if (!template) return '';
+
+  return (
+    readDirectPrimaryIdFromForm(formData) ||
+    readIdentifierMappedSchemaValue(formData, schemaObj) ||
+    resolvePrimaryIdFromRecord(schemaObj, formData as Record<string, unknown>) ||
+    pickIdentifierFromFields(template, formData)
+  );
 }
 
 function resolvePrimaryIdFromSchemaAndForm(formData: FormData, schemaObj: unknown): string {
@@ -971,6 +1313,34 @@ async function stringifyCandidateValueForForm(v: unknown): Promise<string> {
   }
 }
 
+async function writeSerializedFormValue(target: FormData, key: string, value: unknown): Promise<string> {
+  if (value === undefined || value === null || target[key]) return '';
+
+  const serialized = await stringifyCandidateValueForForm(value);
+  if (serialized) target[key] = serialized;
+  return serialized;
+}
+
+async function mapSchemaCandidatePropsToForm(
+  out: FormData,
+  props: Record<string, unknown>,
+  candidateRec: Record<string, unknown>
+): Promise<void> {
+  for (const [propName, propDef] of Object.entries(props)) {
+    const serialized = await writeSerializedFormValue(out, propName, getRecordProp(candidateRec, propName));
+    if (!serialized) continue;
+
+    const ff = isPlainObject(propDef) ? toStringSafe(propDef['x-form-field']).trim() : '';
+    if (ff && !out[ff]) out[ff] = serialized;
+  }
+}
+
+async function mapRemainingCandidatePropsToForm(out: FormData, candidateRec: Record<string, unknown>): Promise<void> {
+  for (const [k, v] of Object.entries(candidateRec)) {
+    await writeSerializedFormValue(out, k, v);
+  }
+}
+
 async function buildFormDataForHookValidationFromCandidate(
   requestType: string,
   schemaObj: unknown,
@@ -980,27 +1350,8 @@ async function buildFormDataForHookValidationFromCandidate(
   const props = getObjectProp(schemaObj, 'properties') || {};
   const candidateRec = isPlainObject(candidate) ? candidate : {};
 
-  for (const [propName, propDef] of Object.entries(props)) {
-    const raw = getRecordProp(candidateRec, propName);
-    if (raw === undefined || raw === null) continue;
-
-    const serialized = await stringifyCandidateValueForForm(raw);
-    if (!serialized) continue;
-
-    const ff = isPlainObject(propDef) ? toStringSafe(propDef['x-form-field']).trim() : '';
-
-    if (ff && !out[ff]) out[ff] = serialized;
-    if (!out[propName]) out[propName] = serialized;
-  }
-
-  for (const [k, v] of Object.entries(candidateRec)) {
-    if (v === undefined || v === null) continue;
-    if (out[k]) continue;
-
-    const serialized = await stringifyCandidateValueForForm(v);
-    if (!serialized) continue;
-    out[k] = serialized;
-  }
+  await mapSchemaCandidatePropsToForm(out, props, candidateRec);
+  await mapRemainingCandidatePropsToForm(out, candidateRec);
 
   return normalizeFormDataForHookValidation(requestType, out, schemaObj, null);
 }
@@ -1014,7 +1365,7 @@ function initAjvInstance(ajv: AjvInstance, context: ValidationContext): void {
   // Ensure draft 2020-12 meta-schema is present so "$schema: .../2020-12/schema" works.
   try {
     if (!ajv.getSchema(META_2020_12_ID)) {
-      ajv.addMetaSchema(meta2020_12);
+      ajv.addMetaSchema(meta202012Schema);
       ajv.defaultMeta = META_2020_12_ID;
     }
   } catch {
@@ -1034,6 +1385,176 @@ function initAjvInstance(ajv: AjvInstance, context: ValidationContext): void {
         { err: err instanceof Error ? err.message : String(err) },
         'resource-bot hooks.ajvPlugins failed'
       );
+    }
+  }
+}
+
+function buildValidateRequestIssueResult(
+  errors: string[],
+  buckets: ValidationBuckets,
+  template: TemplateLike,
+  ajvErrorsForUnifiedFormat: AjvErrorLike[],
+  formData: FormData,
+  namespace: string,
+  nsType: string
+): ValidateRequestIssueResult {
+  const unified = formatUnifiedIssues(buckets, template, ajvErrorsForUnifiedFormat);
+  const validationIssues = buildMachineReadableValidationIssues(buckets, template, ajvErrorsForUnifiedFormat);
+
+  return {
+    errors,
+    errorsGrouped: buckets,
+    errorsFormatted: unified || formatBuckets(buckets),
+    errorsFormattedSingle: unified || formatFirstBucket(buckets),
+    validationIssues,
+    formData,
+    template,
+    namespace,
+    nsType,
+  };
+}
+
+function buildValidateRequestIssueErrorResult(
+  errors: string[],
+  buckets: ValidationBuckets,
+  template: TemplateLike,
+  message: string,
+  targetBucket: string[]
+): ValidateRequestIssueResult {
+  targetBucket.push(message);
+  errors.push(message);
+
+  return buildValidateRequestIssueResult(errors, buckets, template, [], {}, '', '');
+}
+
+function resolveTemplateAndRequestType(
+  context: ValidationContext,
+  template: TemplateLike,
+  formData: FormData,
+  errors: string[],
+  buckets: ValidationBuckets
+):
+  | { template: TemplateLike; requestType: string; requestCfg: RequestConfigEntry }
+  | { result: ValidateRequestIssueResult } {
+  let requestType = String(template?._meta?.requestType || '').trim();
+
+  if (requestType && requestType.toLowerCase() === 'partnernamespace') {
+    const selected =
+      (formData as Record<string, unknown>)['requestType'] ?? (formData as Record<string, unknown>)['request-type'];
+
+    const mapped = mapPartnerNamespaceRequestTypeToConfigKey(selected);
+    if (!mapped) {
+      return {
+        result: buildValidateRequestIssueErrorResult(
+          errors,
+          buckets,
+          template,
+          `Invalid Partner Namespace 'Request Type' selection '${toStringSafe(selected) || ''}'. Expected one of: authority, system, subContext.`,
+          buckets.form
+        ),
+      };
+    }
+
+    const mappedCfg = getRequestConfig(context, mapped);
+    if (!mappedCfg) {
+      return {
+        result: buildValidateRequestIssueErrorResult(
+          errors,
+          buckets,
+          template,
+          `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests has no such entry.`,
+          buckets.schema
+        ),
+      };
+    }
+
+    const mappedSchema = toStringSafe(mappedCfg.schema);
+    if (!mappedSchema) {
+      return {
+        result: buildValidateRequestIssueErrorResult(
+          errors,
+          buckets,
+          template,
+          `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests['${mapped}'].schema is empty.`,
+          buckets.schema
+        ),
+      };
+    }
+
+    const nextMeta = template._meta
+      ? {
+          ...template._meta,
+          requestType: mapped,
+          schema: mappedSchema,
+          root: toStringSafe(mappedCfg.folderName),
+        }
+      : {
+          requestType: mapped,
+          schema: mappedSchema,
+          root: toStringSafe(mappedCfg.folderName),
+        };
+
+    template = { ...template };
+    template._meta = nextMeta;
+
+    requestType = mapped;
+  }
+
+  if (!requestType) {
+    return {
+      result: buildValidateRequestIssueErrorResult(
+        errors,
+        buckets,
+        template,
+        'Configuration error: template missing _meta.requestType (expected cfg.requests mapping via loadTemplate).',
+        buckets.schema
+      ),
+    };
+  }
+
+  const requestCfg = getRequestConfig(context, requestType);
+  if (!requestCfg) {
+    return {
+      result: buildValidateRequestIssueErrorResult(
+        errors,
+        buckets,
+        template,
+        `Configuration error: unknown requestType '${requestType}' (missing cfg.requests entry).`,
+        buckets.schema
+      ),
+    };
+  }
+
+  return { template, requestType, requestCfg };
+}
+
+async function checkRegistryDuplicate(
+  context: ValidationContext,
+  repoInfo: { owner: string; repo: string },
+  template: TemplateLike,
+  requestCfg: RequestConfigEntry,
+  normalizedFormData: FormData,
+  buckets: ValidationBuckets,
+  errors: string[]
+): Promise<void> {
+  const namespace = String(normalizedFormData.namespace || '').trim();
+  if (!namespace) return;
+
+  const resourceName = String(normalizedFormData.identifier || normalizedFormData.namespace || '').trim();
+  if (!resourceName) return;
+
+  try {
+    const structRoot = resolveRegistryRootForTemplate(context, template, requestCfg);
+    const filePath = `${structRoot}/${resourceName}.yaml`;
+
+    await context.octokit.repos.getContent({ owner: repoInfo.owner, repo: repoInfo.repo, path: filePath });
+
+    const msg = `Resource '${resourceName}' already exists in registry`;
+    buckets.registry.push(msg);
+    errors.push(msg);
+  } catch (e: unknown) {
+    if (getHttpStatus(e) !== 404) {
+      context.log?.warn?.({ err: e instanceof Error ? e.message : String(e) }, 'registry existence check failed');
     }
   }
 }
@@ -1486,6 +2007,7 @@ function buildMissingTemplateResult(msg: unknown): ValidateRequestIssueResult {
     errorsGrouped: buckets,
     errorsFormatted: `### Form\n- ${m}`,
     errorsFormattedSingle: `### Form\n- ${m}`,
+    validationIssues: [{ path: 'template', message: m }],
     formData: {},
     template: null,
     namespace: '',
@@ -1567,122 +2089,11 @@ export async function validateRequestIssue(
   // 3) form
   const formData = givenFormData || parseForm(String(issue.body || ''), template);
 
-  // 4) requestType & cfg are authoritative from template._meta (injected via cfg.requests)
-  let requestType = String(template?._meta?.requestType || '').trim();
+  const resolvedTemplate = resolveTemplateAndRequestType(context, template, formData, errors, buckets);
+  if ('result' in resolvedTemplate) return resolvedTemplate.result;
 
-  // Partner Namespace template can target multiple request types via the form enum `requestType`.
-  if (requestType && requestType.toLowerCase() === 'partnernamespace') {
-    const selected =
-      (formData as Record<string, unknown>)['requestType'] ?? (formData as Record<string, unknown>)['request-type'];
-
-    const mapped = mapPartnerNamespaceRequestTypeToConfigKey(selected);
-    if (!mapped) {
-      const msg = `Invalid Partner Namespace 'Request Type' selection '${toStringSafe(selected) || ''}'. Expected one of: authority, system, subContext.`;
-      buckets.form.push(msg);
-      errors.push(msg);
-
-      const unified = formatUnifiedIssues(buckets, template, []);
-      return {
-        errors,
-        errorsGrouped: buckets,
-        errorsFormatted: unified || formatBuckets(buckets),
-        errorsFormattedSingle: unified || formatFirstBucket(buckets),
-        formData: {},
-        template,
-        namespace: '',
-        nsType: '',
-      };
-    }
-
-    const mappedCfg = getRequestConfig(context, mapped);
-    if (!mappedCfg) {
-      const msg = `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests has no such entry.`;
-      buckets.schema.push(msg);
-      errors.push(msg);
-
-      const unified = formatUnifiedIssues(buckets, template, []);
-      return {
-        errors,
-        errorsGrouped: buckets,
-        errorsFormatted: unified || formatBuckets(buckets),
-        errorsFormattedSingle: unified || formatFirstBucket(buckets),
-        formData: {},
-        template,
-        namespace: '',
-        nsType: '',
-      };
-    }
-
-    const mappedSchema = toStringSafe(mappedCfg.schema);
-    if (!mappedSchema) {
-      const msg = `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests['${mapped}'].schema is empty.`;
-      buckets.schema.push(msg);
-      errors.push(msg);
-
-      const unified = formatUnifiedIssues(buckets, template, []);
-      return {
-        errors,
-        errorsGrouped: buckets,
-        errorsFormatted: unified || formatBuckets(buckets),
-        errorsFormattedSingle: unified || formatFirstBucket(buckets),
-        formData: {},
-        template,
-        namespace: '',
-        nsType: '',
-      };
-    }
-
-    // Clone template meta to avoid mutating cached templates across issues.
-    template = {
-      ...template,
-      _meta: {
-        ...(template._meta || {}),
-        requestType: mapped,
-        schema: mappedSchema,
-        root: toStringSafe(mappedCfg.folderName),
-      },
-    };
-
-    requestType = mapped;
-  }
-  const requestCfg = getRequestConfig(context, requestType);
-
-  if (!requestType) {
-    const msg =
-      'Configuration error: template missing _meta.requestType (expected cfg.requests mapping via loadTemplate).';
-    buckets.schema.push(msg);
-    errors.push(msg);
-
-    const unified = formatUnifiedIssues(buckets, template, []);
-    return {
-      errors,
-      errorsGrouped: buckets,
-      errorsFormatted: unified || formatBuckets(buckets),
-      errorsFormattedSingle: unified || formatFirstBucket(buckets),
-      formData: {},
-      template,
-      namespace: '',
-      nsType: '',
-    };
-  }
-
-  if (!requestCfg) {
-    const msg = `Configuration error: unknown requestType '${requestType}' (missing cfg.requests entry).`;
-    buckets.schema.push(msg);
-    errors.push(msg);
-
-    const unified = formatUnifiedIssues(buckets, template, []);
-    return {
-      errors,
-      errorsGrouped: buckets,
-      errorsFormatted: unified || formatBuckets(buckets),
-      errorsFormattedSingle: unified || formatFirstBucket(buckets),
-      formData: {},
-      template,
-      namespace: '',
-      nsType: '',
-    };
-  }
+  template = resolvedTemplate.template;
+  const { requestType, requestCfg } = resolvedTemplate;
 
   if (DBG && context.log?.info) context.log.info({ formData }, 'ns:parsedFormData');
 
@@ -1789,17 +2200,9 @@ export async function validateRequestIssue(
   if (!rawIdOrNs) {
     const msg = 'Cannot resolve primary identifier from template';
     buckets.form.push(msg);
-    const unified = formatUnifiedIssues(buckets, template, []);
-    return {
-      errors: [msg],
-      errorsGrouped: buckets,
-      errorsFormatted: unified || formatBuckets(buckets),
-      errorsFormattedSingle: unified || formatFirstBucket(buckets),
-      formData: {},
-      template,
-      namespace: '',
-      nsType: '',
-    };
+    errors.push(msg);
+
+    return buildValidateRequestIssueResult(errors, buckets, template, [], {}, '', '');
   }
 
   // 7) Normalize formData
@@ -2020,47 +2423,195 @@ export async function validateRequestIssue(
     errors.push(msg);
   }
 
-  // 9) registry existence check
   const namespace = String(normalizedFormData.namespace || '').trim();
-
-  if (namespace) {
-    const resourceName = String(normalizedFormData.identifier || normalizedFormData.namespace || '').trim();
-
-    if (resourceName) {
-      try {
-        const structRoot = resolveRegistryRootForTemplate(context, template, requestCfg);
-        const filePath = `${structRoot}/${resourceName}.yaml`;
-
-        await context.octokit.repos.getContent({ owner, repo, path: filePath });
-
-        const msg = `Resource '${resourceName}' already exists in registry`;
-        buckets.registry.push(msg);
-        errors.push(msg);
-      } catch (e: unknown) {
-        if (getHttpStatus(e) !== 404) {
-          context.log?.warn?.({ err: e instanceof Error ? e.message : String(e) }, 'registry existence check failed');
-        }
-      }
-    }
-  }
+  await checkRegistryDuplicate(context, { owner, repo }, template, requestCfg, normalizedFormData, buckets, errors);
 
   const nsType = inferNsType(requestType);
 
-  // 10) output formatting
-  const unified = formatUnifiedIssues(buckets, template, ajvErrorsForUnifiedFormat);
-  const errorsFormatted = unified || formatBuckets(buckets);
-  const errorsFormattedSingle = unified || formatFirstBucket(buckets);
+  return buildValidateRequestIssueResult(
+    errors,
+    buckets,
+    template,
+    ajvErrorsForUnifiedFormat,
+    normalizedFormData,
+    namespace,
+    nsType
+  );
+}
+
+function logApprovalHookMessages(
+  context: ValidationContext,
+  logs: { level: 'debug' | 'info' | 'warn' | 'error'; obj: unknown; msg?: string }[] | undefined
+): void {
+  if (!logs?.length) return;
+
+  for (const entry of logs) {
+    const msg = entry.msg || 'hook:onApproval';
+    if (entry.level === 'error') context.log?.error?.(entry.obj, msg);
+    else if (entry.level === 'warn') context.log?.warn?.(entry.obj, msg);
+    else if (entry.level === 'debug') context.log?.debug?.(entry.obj, msg);
+    else context.log?.info?.(entry.obj, msg);
+  }
+}
+
+function getApprovalAllowedHosts(context: ValidationContext): string[] {
+  return Array.isArray(context.resourceBotConfig?.hooks?.allowedHosts)
+    ? context.resourceBotConfig.hooks.allowedHosts
+    : [];
+}
+
+function resolveApprovalNamespace(args: {
+  namespace?: string | null;
+  resourceName?: string | null;
+  formData: FormData;
+}): string {
+  return (
+    toStringSafe(args.namespace) ||
+    toStringSafe(args.formData['namespace']) ||
+    toStringSafe(args.formData['identifier']) ||
+    toStringSafe(args.resourceName)
+  );
+}
+
+function resolveApprovalResourceName(
+  args: {
+    namespace?: string | null;
+    resourceName?: string | null;
+    formData: FormData;
+  },
+  namespace: string
+): string {
+  return (
+    toStringSafe(args.resourceName) ||
+    toStringSafe(args.formData['identifier']) ||
+    toStringSafe(args.formData['namespace']) ||
+    namespace
+  );
+}
+
+function buildApprovalHookArgs(
+  context: ValidationContext,
+  args: {
+    requestType: string;
+    namespace?: string | null;
+    resourceName?: string | null;
+    formData: FormData;
+    issue: IssueLike;
+  }
+): OnApprovalArgs {
+  const namespace = resolveApprovalNamespace(args);
+  const resourceName = resolveApprovalResourceName(args, namespace);
+  const requesterId = toStringSafe(args.issue?.user?.login);
 
   return {
-    errors,
-    errorsGrouped: buckets,
-    errorsFormatted,
-    errorsFormattedSingle,
-    formData: normalizedFormData,
-    template,
+    requestType: toStringSafe(args.requestType),
     namespace,
-    nsType,
+    resourceName,
+    form: args.formData,
+    data: buildApprovalHookData(args, namespace, resourceName),
+    requestAuthor: {
+      id: requesterId,
+      email: '',
+    },
+    config: {
+      raw: isPlainObject(context.resourceBotConfig) ? context.resourceBotConfig : {},
+      approvers: getApprovalHookApprovers(context, toStringSafe(args.requestType)),
+    },
+    issue: {
+      number: typeof args.issue?.number === 'number' ? args.issue.number : 0,
+      title: toStringSafe(args.issue?.title),
+      body: toStringSafe(args.issue?.body),
+      state: toStringSafe(args.issue?.state),
+      author: requesterId,
+      labels: toApprovalIssueLabelNames(args.issue?.labels),
+    },
+    log: undefined,
   };
+}
+
+async function runApprovalHookDescriptor(
+  context: ValidationContext,
+  repoInfo: { owner: string; repo: string },
+  hooks: HookDescriptor,
+  hookArgs: OnApprovalArgs,
+  allowedHosts: string[]
+): Promise<ApprovalHookDecision> {
+  const workerSecrets = pickHookSecretsForWorker(coreSecrets.HOOK_SECRETS || {});
+  const res = await runHookInWorker(
+    {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      path: hooks.__path,
+      hash: hooks.__hash,
+      code: hooks.__code,
+      fn: 'onApproval',
+      args: hookArgs,
+      allowedHosts,
+      secrets: workerSecrets,
+    },
+    { timeoutMs: 8000 }
+  );
+
+  logApprovalHookMessages(context, res.logs);
+
+  const hookErr = getStringProp(res.value, '__hookError');
+  if (hookErr) {
+    context.log?.warn?.({ err: hookErr }, 'resource-bot hooks.onApproval failed');
+    return {};
+  }
+
+  if (!res.found) return {};
+  return normalizeApprovalHookResult(res.value);
+}
+
+async function runApprovalHookInProcess(
+  context: ValidationContext,
+  hooks: ResourceBotHooks,
+  hookArgs: OnApprovalArgs
+): Promise<ApprovalHookDecision> {
+  const onApprovalHook = hooks.onApproval;
+  if (typeof onApprovalHook !== 'function') return {};
+
+  try {
+    const ret = await onApprovalHook({
+      ...hookArgs,
+      log: getHookLogger(context.log),
+    });
+
+    return normalizeApprovalHookResult(ret);
+  } catch (err: unknown) {
+    context.log?.warn?.(
+      { err: err instanceof Error ? err.message : String(err) },
+      'resource-bot hooks.onApproval failed'
+    );
+    return {};
+  }
+}
+
+export async function runApprovalHook(
+  context: ValidationContext,
+  repoInfo: { owner: string; repo: string },
+  args: {
+    requestType: string;
+    namespace?: string | null;
+    resourceName?: string | null;
+    formData: FormData;
+    issue: IssueLike;
+  }
+): Promise<ApprovalHookDecision> {
+  await ensureStaticConfigLoaded(context);
+
+  const hooks = getResourceBotHooks(context);
+  if (!hooks) return {};
+
+  const allowedHosts = getApprovalAllowedHosts(context);
+  const hookArgs = buildApprovalHookArgs(context, args);
+
+  if (isHookDescriptor(hooks)) {
+    return runApprovalHookDescriptor(context, repoInfo, hooks, hookArgs, allowedHosts);
+  }
+
+  return runApprovalHookInProcess(context, hooks, hookArgs);
 }
 
 // CI helper: run the same onValidate hook pipeline the bot uses,

--- a/test/request-orchestrator.coverage.test.ts
+++ b/test/request-orchestrator.coverage.test.ts
@@ -109,6 +109,7 @@ type ValidateResult = {
   errors: string[];
   errorsFormattedSingle: string;
   errorsFormatted: string;
+  validationIssues?: { path: string; message: string }[];
   namespace: string;
   nsType: string;
   template: Template;
@@ -173,6 +174,7 @@ const collapseBotCommentsByPrefix = jest.fn<CollapseBotCommentsByPrefix>(async (
 const loadTemplate = jest.fn<LoadTemplate>();
 const parseForm = jest.fn<ParseForm>();
 const validateRequestIssue = jest.fn<ValidateRequestIssue>();
+const runApprovalHook = jest.fn<() => Promise<boolean>>(() => Promise.resolve(false));
 
 const calcSnapshotHash = jest.fn<CalcSnapshotHash>();
 const extractHashFromPrBody = jest.fn<ExtractHashFromPrBody>();
@@ -184,48 +186,6 @@ const tryMergeIfGreen = jest.fn<TryMergeIfGreen>();
 const loadStaticConfig = jest.fn<LoadStaticConfig>();
 
 const getDocLinksFromConfig = jest.fn<(cfg: unknown) => string>(() => '');
-
-jest.unstable_mockModule('../src/handlers/request/state.js', () => ({
-  setStateLabel,
-  ensureAssigneesOnce,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/comments.js', () => ({
-  postOnce,
-  collapseBotCommentsByPrefix,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/template.js', () => ({
-  loadTemplate,
-  parseForm,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/validation/run.js', () => ({
-  validateRequestIssue,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/pr/snapshot.js', () => ({
-  calcSnapshotHash,
-  extractHashFromPrBody,
-  findOpenIssuePrs,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/pr/create.js', () => ({
-  createRequestPr,
-}));
-
-jest.unstable_mockModule('../src/lib/auto-merge.js', () => ({
-  tryMergeIfGreen,
-}));
-
-jest.unstable_mockModule('../src/config.js', () => ({
-  DEFAULT_CONFIG: DEFAULT_CONFIG_MOCK,
-  loadStaticConfig,
-}));
-
-jest.unstable_mockModule('../src/handlers/request/constants.js', () => ({
-  getDocLinksFromConfig,
-}));
 
 function mkApp(): { app: AppLike; handlers: Record<string, Handler> } {
   const handlers: Record<string, Handler> = {};
@@ -330,11 +290,72 @@ function mkCtx(args: {
 let requestHandler: (app: Probot) => void;
 
 beforeAll(async () => {
+  await jest.unstable_mockModule('../src/handlers/request/state.js', () => ({
+    setStateLabel,
+    ensureAssigneesOnce,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/comments.js', () => ({
+    postOnce,
+    collapseBotCommentsByPrefix,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/template.js', () => ({
+    loadTemplate,
+    parseForm,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/validation/run.js', () => ({
+    validateRequestIssue,
+    runApprovalHook,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/pr/snapshot.js', () => ({
+    calcSnapshotHash,
+    extractHashFromPrBody,
+    findOpenIssuePrs,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/pr/create.js', () => ({
+    createRequestPr,
+  }));
+
+  await jest.unstable_mockModule('../src/lib/auto-merge.js', () => ({
+    tryMergeIfGreen,
+  }));
+
+  await jest.unstable_mockModule('../src/config.js', () => ({
+    DEFAULT_CONFIG: DEFAULT_CONFIG_MOCK,
+    loadStaticConfig,
+  }));
+
+  await jest.unstable_mockModule('../src/handlers/request/constants.js', () => ({
+    getDocLinksFromConfig,
+  }));
+
   ({ default: requestHandler } = await import('../src/handlers/request/index.js'));
 });
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  for (const mock of [
+    setStateLabel,
+    ensureAssigneesOnce,
+    postOnce,
+    collapseBotCommentsByPrefix,
+    loadTemplate,
+    parseForm,
+    validateRequestIssue,
+    runApprovalHook,
+    calcSnapshotHash,
+    extractHashFromPrBody,
+    findOpenIssuePrs,
+    createRequestPr,
+    tryMergeIfGreen,
+    loadStaticConfig,
+    getDocLinksFromConfig,
+  ]) {
+    mock.mockReset();
+  }
 
   loadStaticConfig.mockResolvedValue({
     config: DEFAULT_CONFIG_MOCK,
@@ -354,6 +375,7 @@ beforeEach(() => {
     template: DEFAULT_TEMPLATE,
   });
 
+  runApprovalHook.mockResolvedValue(false);
   calcSnapshotHash.mockReturnValue('hash1');
   extractHashFromPrBody.mockReturnValue('hash1');
   findOpenIssuePrs.mockResolvedValue([]);
@@ -1175,5 +1197,94 @@ describe('request-orchestrator additional coverage', () => {
 
     expect(postOnce).toHaveBeenCalled();
     expect(setStateLabel).toHaveBeenCalled();
+  });
+  test('issues.opened: detected issues comment includes machine readable metadata', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const issue: Issue = {
+      number: 21,
+      title: 'Request',
+      body: '### Namespace\nsap.bad',
+      state: 'open',
+      labels: [],
+      user: { login: 'author' },
+    };
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: ['bad request'],
+      errorsFormattedSingle: '### Name\n- Name MUST match the expected namespace format.',
+      errorsFormatted: '### Name\n- Name MUST match the expected namespace format.',
+      validationIssues: [{ path: 'name', message: 'Vendor is incorrect because XYZ' }],
+      namespace: 'sap.bad',
+      nsType: 'system',
+      template: DEFAULT_TEMPLATE,
+    });
+
+    const ctx = mkCtx({
+      name: 'issues.opened',
+      config: DEFAULT_CONFIG_MOCK,
+      payload: { action: 'opened', issue },
+      issueNumber: 21,
+    });
+
+    await expect(handlers['issues.opened']?.(ctx)).resolves.toBeUndefined();
+
+    const body = String(postOnce.mock.calls[0]?.[2] ?? '');
+    expect(body).toContain('<summary>Show as JSON (Robots Friendly)</summary>');
+    expect(body).toContain('"field": "name"');
+    expect(body).toContain('"message": "Vendor is incorrect because XYZ"');
+  });
+  test('issues.opened: direct PR without snapshot hash is not closed as outdated and approved flow keeps existing PR', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const config: StaticConfig = {
+      requests: {},
+      workflow: {
+        labels: {
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: [],
+      },
+    };
+
+    const directPr: PullRequest = {
+      number: 88,
+      body: 'source: #22',
+      head: { sha: 'sha-direct', ref: 'manual-pr' },
+    };
+
+    findOpenIssuePrs.mockResolvedValue([directPr]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    const issue: Issue = {
+      number: 22,
+      title: 'Request',
+      body: '### Namespace\nsap.agt',
+      state: 'open',
+      labels: [],
+      user: { login: 'author' },
+    };
+
+    const octokit = mkOctokit();
+
+    const ctx = mkCtx({
+      name: 'issues.opened',
+      config,
+      octokit,
+      payload: { action: 'opened', issue },
+      issueNumber: 22,
+    });
+
+    await expect(handlers['issues.opened']?.(ctx)).resolves.toBeUndefined();
+
+    expect(octokit.pulls.update).not.toHaveBeenCalled();
+    expect(octokit.git.deleteRef).not.toHaveBeenCalled();
+    expect(createRequestPr).not.toHaveBeenCalled();
+
+    const bodies = postOnce.mock.calls.map((c) => String(c[2] ?? '')).join('\n');
+    expect(bodies).toContain('PR already open: #88');
   });
 });

--- a/test/request-orchestrator.labels-lock.test.ts
+++ b/test/request-orchestrator.labels-lock.test.ts
@@ -127,6 +127,7 @@ const loadTemplate = jest.fn() as unknown as jest.MockedFunction<LoadTemplateFn>
 const parseForm = jest.fn() as unknown as jest.MockedFunction<ParseFormFn>;
 
 // Not used directly in these tests, but request handler imports them
+const runApprovalHook = jest.fn(async () => false);
 const validateRequestIssue = jest.fn() as unknown as jest.MockedFunction<
   (
     context: unknown,
@@ -211,6 +212,7 @@ jest.unstable_mockModule('../src/handlers/request/template.js', () => ({
 
 jest.unstable_mockModule('../src/handlers/request/validation/run.js', () => ({
   validateRequestIssue,
+  runApprovalHook,
 }));
 
 jest.unstable_mockModule('../src/handlers/request/pr/snapshot.js', () => ({

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
 /* eslint-disable require-await */
-import { jest } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 const PREV_DEBUG_NS = process.env.DEBUG_NS;
 process.env.DEBUG_NS = '1';
@@ -10,7 +10,7 @@ afterAll(() => {
 });
 
 type IssueParams = { owner: string; repo: string; issue_number: number };
-const setStateLabel = jest.fn(async () => {});
+const setStateLabel = jest.fn(async (_ctx: any, _params: any, _options: any, _state: any) => {});
 const ensureAssigneesOnce = jest.fn(async () => {});
 type PostOnceFn = (ctx: any, params: any, body: string, options?: any) => Promise<void>;
 
@@ -37,8 +37,11 @@ type FindOpenIssuePrsFn = (
 
 const findOpenIssuePrs = jest.fn<FindOpenIssuePrsFn>(async () => []);
 
+type RunApprovalHookFn = (ctx: any, repo: { owner: string; repo: string }, opts: any) => Promise<boolean>;
+const runApprovalHook = jest.fn<RunApprovalHookFn>(async () => false);
+
 const createRequestPr = jest.fn(async () => ({ number: 10 }));
-const tryMergeIfGreen = jest.fn(async () => {});
+const tryMergeIfGreen = jest.fn(async (_ctx: any, _opts: any) => {});
 const loadStaticConfig = jest.fn(async () => ({}));
 const getDocLinksFromConfig = jest.fn(() => '');
 
@@ -47,6 +50,10 @@ const DEFAULT_CONFIG = {
 } as any;
 
 let requestHandler: any;
+
+function postedBodies(): string {
+  return postOnce.mock.calls.map((call) => call[2] ?? '').join('\n');
+}
 
 function httpErr(status: number): Error & { status: number } {
   const e = new Error(String(status)) as Error & { status: number };
@@ -81,6 +88,8 @@ type IssuesRemoveLabelFn = (args: unknown) => Promise<unknown>;
 
 type PullsListFn = (args: unknown) => Promise<{ data: unknown[] }>;
 type PullsUpdateFn = (args: unknown) => Promise<unknown>;
+type PullsCreateReviewFn = (args: unknown) => Promise<unknown>;
+type PullsListFilesFn = (args: unknown) => Promise<{ data: unknown[] }>;
 
 type ChecksListAnnotationsFn = (args: any) => Promise<{ data: any[] }>;
 type ChecksListForSuiteFn = (args: any) => Promise<{ data: { check_runs: any[] } }>;
@@ -133,6 +142,8 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
           })
         ),
         list: jest.fn<PullsListFn>(() => Promise.resolve({ data: [] })),
+        listFiles: jest.fn<PullsListFilesFn>(() => Promise.resolve({ data: [] })),
+        createReview: jest.fn<PullsCreateReviewFn>(() => Promise.resolve({})),
         update: jest.fn<PullsUpdateFn>(() => Promise.resolve({})),
       },
       git: {
@@ -278,6 +289,7 @@ beforeAll(async () => {
 
   await jest.unstable_mockModule('../src/handlers/request/validation/run.js', () => ({
     validateRequestIssue,
+    runApprovalHook,
   }));
 
   await jest.unstable_mockModule('../src/handlers/request/pr/snapshot.js', () => ({
@@ -343,6 +355,7 @@ beforeEach(() => {
     nsType: 'product',
   });
 
+  runApprovalHook.mockResolvedValue(false);
   calcSnapshotHash.mockReturnValue('h1');
   extractHashFromPrBody.mockReturnValue('h1');
   findOpenIssuePrs.mockResolvedValue([]);
@@ -1136,7 +1149,7 @@ describe('parent owner approval gating', () => {
     expect(issue.body).toContain(`"target":"${target}"`);
 
     // Bot asks the *immediate* parent owners (sap.css.bar), not sap.css.
-    const posted = (postOnce as jest.Mock).mock.calls.map((c) => String(c[2] || '')).join('\n');
+    const posted = postedBodies();
     expect(posted).toContain('@barOwner');
     expect(posted).not.toContain('@topOwner');
 
@@ -1190,7 +1203,7 @@ describe('parent owner approval gating', () => {
 
     await h['issues.opened'][0](ctx);
 
-    const posted = (postOnce as jest.Mock).mock.calls.map((c) => String(c[2] || '')).join('\n');
+    const posted = postedBodies();
     expect(posted).not.toContain('Parent owner approval required');
     expect(ensureAssigneesOnce).toHaveBeenCalled();
     expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'review');
@@ -1253,7 +1266,7 @@ describe('parent owner approval gating', () => {
 
     await h['issue_comment.created'][0](commentCtx);
 
-    const posted = (postOnce as jest.Mock).mock.calls.map((c) => String(c[2] || '')).join('\n');
+    const posted = postedBodies();
     expect(posted).toContain('Approval ignored');
     expect(posted).toContain('@barOwner');
     expect(ensureAssigneesOnce).not.toHaveBeenCalled();
@@ -1321,7 +1334,7 @@ describe('parent owner approval gating', () => {
     // Body marker should now be enriched with approvedBy
     expect(issue.body).toContain('"approvedBy":"barOwner"');
 
-    const posted = (postOnce as jest.Mock).mock.calls.map((c) => String(c[2] || '')).join('\n');
+    const posted = postedBodies();
     expect(posted).toContain('Parent namespace approved by @barOwner');
     expect(posted).toContain('Routing to an approver');
 
@@ -1568,5 +1581,851 @@ describe('parent owner approval gating', () => {
     expect(postOnce.mock.calls.some((c) => String(c[2] ?? '').includes('Approved by @alice. Opened PR: #123'))).toBe(
       true
     );
+  });
+  test('accepts Approved comments from parent owners and auto-approves via onApproval hook before review handover', async () => {
+    const { app, handlers: h } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 554,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { type: 'User', login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    } as any);
+
+    const openCtx = mkIssuesContext({ issue, action: 'opened' });
+    const topYaml = `contacts:\n  - "@topOwner"\n`;
+    const barYaml = `contacts:\n  - "@barOwner"\n`;
+
+    (openCtx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64(topYaml), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64(barYaml), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await h['issues.opened'][0](openCtx);
+
+    (postOnce as jest.Mock).mockClear();
+    (ensureAssigneesOnce as jest.Mock).mockClear();
+    (createRequestPr as jest.Mock).mockClear();
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    const commentCtx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { type: 'User', login: 'barOwner' } },
+    });
+
+    await h['issue_comment.created'][0](commentCtx);
+
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      commentCtx,
+      { owner: 'o', repo: 'r' },
+      expect.objectContaining({ requestType: 'subContextNamespace', namespace: target })
+    );
+    expect(createRequestPr).toHaveBeenCalled();
+    expect(ensureAssigneesOnce).not.toHaveBeenCalled();
+
+    const posted = postedBodies();
+    expect(posted).toContain('Opened PR: #10');
+    expect(posted).not.toContain('Routing to an approver');
+  });
+
+  test('check_suite.success: direct PR without snapshot hash uses approved onApproval result and merges', async () => {
+    const cfg = {
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha1',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({ data: [{ number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } }] })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.issues.get.mockResolvedValueOnce({
+      data: {
+        number: 1,
+        title: 'Request',
+        body: 'Body',
+        labels: [],
+        user: { login: 'author' },
+      },
+    });
+
+    extractHashFromPrBody.mockReturnValueOnce('');
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    await handler(ctx);
+
+    expect(runApprovalHook).toHaveBeenCalled();
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 5, mergeMethod: 'squash' })
+    );
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ['Approved'] }));
+  });
+
+  test('check_suite.success: standalone direct PR with changed registry yaml uses onApproval and merges', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 51,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/direct', sha: 'sha-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [
+        { filename: 'resources/product-one.yaml', status: 'modified' },
+        { filename: 'README.md', status: 'modified' },
+        { filename: 'resources/deleted.yaml', status: 'removed' },
+      ],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from(
+          'type: product\nname: product-one\ndescription: Example\ncontact: owner@example.com\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved from standalone hook' } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.listFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 51, per_page: 100, page: 1 })
+    );
+    expect(ctx.octokit.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', path: 'resources/product-one.yaml', ref: 'feature/direct' })
+    );
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({
+        requestType: 'product',
+        namespace: 'product-one',
+        resourceName: 'product-one',
+        formData: expect.objectContaining({
+          identifier: 'product-one',
+          namespace: 'product-one',
+          contact: 'owner@example.com',
+        }),
+      })
+    );
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        pull_number: 51,
+        event: 'APPROVE',
+        body: 'approved from standalone hook',
+      })
+    );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 51, mergeMethod: 'squash' })
+    );
+  });
+
+  test('check_suite.success: standalone direct PR rejected by onApproval closes PR and posts rejection', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-reject-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 52,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/reject', sha: 'sha-reject-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-two.yaml', status: 'added' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-two\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'rejected',
+      path: 'details',
+      reason: 'policy denied',
+      errors: [
+        { field: 'details', message: 'policy denied' },
+        { field: 'name', message: 'resource name requires additional review' },
+      ],
+    } as any);
+
+    await handler(ctx);
+
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 52, state: 'closed' })
+    );
+    const posted = postedBodies();
+    expect(posted).toContain('onApproval rejected this request');
+    expect(posted).toContain('resource name requires additional review');
+    expect(posted).toContain('policy denied');
+  });
+
+  test('check_suite.success: standalone direct PR unknown mix does not merge or post', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-unknown-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 53,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/unknown', sha: 'sha-unknown-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [
+        { filename: 'resources/bad.yaml', status: 'modified' },
+        { filename: 'resources/no-name.yaml', status: 'modified' },
+      ],
+    });
+
+    ctx.octokit.repos.getContent
+      .mockResolvedValueOnce({
+        data: {
+          content: Buffer.from('::: not yaml :::', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          content: Buffer.from('type: product\ndescription: missing name\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      });
+
+    await handler(ctx);
+
+    expect(runApprovalHook).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR approval review failure keeps PR open and does not merge', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-review-failure',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 54,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/review-fail', sha: 'sha-review-failure' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-review.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-review\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.createReview.mockRejectedValueOnce(new Error('review api failed'));
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approve please' } as any);
+
+    await handler(ctx);
+
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    const posted = postedBodies();
+    expect(posted).toContain('automatic PR approval failed');
+    expect(posted).toContain('approve please');
+  });
+
+  test('check_suite.success: direct PR without snapshot hash rejects and closes PR plus request', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const pr = { number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } };
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha1',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] }).mockResolvedValueOnce({ data: [] });
+    ctx.octokit.issues.get.mockResolvedValueOnce({
+      data: {
+        number: 1,
+        title: 'Request',
+        body: 'Body',
+        labels: [],
+        user: { login: 'author' },
+        state: 'open',
+      },
+    });
+
+    extractHashFromPrBody.mockReturnValueOnce('');
+    findOpenIssuePrs.mockResolvedValueOnce([pr]);
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'rejected',
+      path: 'namespace',
+      reason: 'policy denied',
+    } as any);
+
+    await handler(ctx);
+
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 5, state: 'closed' })
+    );
+    expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 1, state: 'closed' })
+    );
+
+    const posted = postedBodies();
+    expect(posted).toContain('onApproval rejected this request');
+    expect(posted).toContain('policy denied');
+  });
+
+  test('check_suite.success: direct PR without snapshot hash posts unknown feedback and does not merge', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha1',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({ data: [{ number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } }] })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.issues.get.mockResolvedValueOnce({
+      data: {
+        number: 1,
+        title: 'Request',
+        body: 'Body',
+        labels: [],
+        user: { login: 'author' },
+      },
+    });
+
+    extractHashFromPrBody.mockReturnValueOnce('');
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'unknown',
+      path: 'issue.author',
+      reason: 'manual review required',
+    } as any);
+
+    await handler(ctx);
+
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 5 }),
+      expect.stringContaining('## onApproval feedback'),
+      expect.anything()
+    );
+    expect(postedBodies()).toContain('manual review required');
+  });
+
+  test('check_suite.success: standalone direct PR resolves request type from doc type and uses default approval review body', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+        vendor: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-vendor-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 55,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/vendor', sha: 'sha-vendor-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/vendor-one.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from(
+          'type: vendor\nname: vendor-one\ncontact:\n  - owner1@example.com\n  - owner2@example.com\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    await handler(ctx);
+
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({
+        requestType: 'vendor',
+        namespace: 'vendor-one',
+        resourceName: 'vendor-one',
+        formData: expect.objectContaining({
+          name: 'vendor-one',
+          identifier: 'vendor-one',
+          namespace: 'vendor-one',
+          contact: 'owner1@example.com\nowner2@example.com',
+        }),
+      })
+    );
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Approved automatically by onApproval hook.' })
+    );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 55, mergeMethod: 'squash' })
+    );
+  });
+
+  test('check_suite.success: standalone direct PR skips merge when changed yaml cannot be read from repo ref', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-read-fail',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 56,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/read-fail', sha: 'sha-read-fail' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/unreadable.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockRejectedValueOnce(new Error('cannot load ref content'));
+
+    await handler(ctx);
+
+    expect(runApprovalHook).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR ignores malformed and scalar yaml candidates', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-bad-yaml',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 57,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/bad-yaml', sha: 'sha-bad-yaml' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [
+        { filename: 'resources/malformed.yaml', status: 'modified' },
+        { filename: 'resources/scalar.yaml', status: 'modified' },
+      ],
+    });
+
+    ctx.octokit.repos.getContent
+      .mockResolvedValueOnce({
+        data: {
+          content: Buffer.from('type: [broken\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          content: Buffer.from('plain scalar string', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      });
+
+    await handler(ctx);
+
+    expect(runApprovalHook).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR paginates changed files and skips multi-match resources without matching doc type', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+        vendor: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-paginated-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 58,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/paginated', sha: 'sha-paginated-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles
+      .mockResolvedValueOnce({
+        data: [
+          ...Array.from({ length: 99 }, (_, index) => ({ filename: `docs/file-${index}.md`, status: 'modified' })),
+          { filename: 'resources/shared.yaml', status: 'modified' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [{ filename: 'resources/shared.yaml', status: 'modified' }],
+      });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: unsupported\nname: shared-resource\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.listFiles).toHaveBeenCalledTimes(2);
+    expect(runApprovalHook).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR with approved and unknown changed resources does not merge', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-mixed-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 59,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/mixed', sha: 'sha-mixed-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [
+        { filename: 'resources/product-ok.yaml', status: 'modified' },
+        { filename: 'resources/product-missing.yaml', status: 'modified' },
+      ],
+    });
+
+    ctx.octokit.repos.getContent
+      .mockResolvedValueOnce({
+        data: {
+          content: Buffer.from('type: product\nname: product-ok\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      })
+      .mockRejectedValueOnce(new Error('file missing'));
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved product-ok' } as any);
+
+    await handler(ctx);
+
+    expect(runApprovalHook).toHaveBeenCalledTimes(1);
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
   });
 });

--- a/test/request-orchestrator.test.ts
+++ b/test/request-orchestrator.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
 /* eslint-disable require-await */
-import { jest } from '@jest/globals';
+import { beforeAll, beforeEach, expect, jest, test } from '@jest/globals';
 
 process.env.DEBUG_NS = '0';
 
@@ -11,14 +11,19 @@ type CollapseBotCommentsByPrefix = (
   opts: { perPage?: number; tagPrefix: string; keepTags?: string[]; collapseBody?: string; classifier?: string }
 ) => Promise<void>;
 
+type SetStateLabelFn = (ctx: unknown, params: IssueParams, issue: unknown, state: string) => Promise<void>;
+type EnsureAssigneesOnceFn = (ctx: unknown, params: IssueParams, issue: unknown, assignees: string[]) => Promise<void>;
+type PostOnceFn = (ctx: unknown, params: IssueParams, body: string, options?: unknown) => Promise<void>;
+
 const collapseBotCommentsByPrefix = jest.fn() as unknown as jest.MockedFunction<CollapseBotCommentsByPrefix>;
-const setStateLabel = jest.fn(async () => {});
-const ensureAssigneesOnce = jest.fn(async () => {});
-const postOnce = jest.fn(async (..._args: any[]) => {});
+const setStateLabel = jest.fn<SetStateLabelFn>(async () => {});
+const ensureAssigneesOnce = jest.fn<EnsureAssigneesOnceFn>(async () => {});
+const postOnce = jest.fn<PostOnceFn>(async (..._args: Parameters<PostOnceFn>) => {});
 
 const loadTemplate = jest.fn(async () => ({}));
 const parseForm = jest.fn(() => ({}));
 const validateRequestIssue = jest.fn(async () => ({}));
+const runApprovalHook = jest.fn(async () => false);
 const calcSnapshotHash = jest.fn(() => 'h1');
 const extractHashFromPrBody = jest.fn(() => 'h1');
 const findOpenIssuePrs = jest.fn(async () => []);
@@ -141,6 +146,7 @@ beforeAll(async () => {
 
   await jest.unstable_mockModule('../src/handlers/request/validation/run.js', () => ({
     validateRequestIssue,
+    runApprovalHook,
   }));
 
   await jest.unstable_mockModule('../src/handlers/request/pr/snapshot.js', () => ({
@@ -378,7 +384,7 @@ test('issues.opened: template load error -> posts config error and sets author s
   await handler(ctx);
 
   expect(postOnce).toHaveBeenCalled();
-  const body = postOnce.mock.calls[0][2] as string;
+  const body = postOnce.mock.calls[0][2];
   expect(body).toContain('Configuration error: unable to load request template');
 
   expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), expect.anything(), 'author');
@@ -446,7 +452,7 @@ test('issues.opened: validation errors -> posts and sets author state', async ()
   await handler(ctx);
 
   expect(postOnce).toHaveBeenCalled();
-  const body = postOnce.mock.calls[0][2] as string;
+  const body = postOnce.mock.calls[0][2];
   expect(body).toContain('## Detected issues');
 
   expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), expect.anything(), 'author');
@@ -503,7 +509,188 @@ test('issues.opened: success -> normalizes title and hands over with labels and 
   expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(expect.objectContaining({ name: 'approved-label' }));
 
   expect(postOnce).toHaveBeenCalled();
-  const body = postOnce.mock.calls[0][2] as string;
+  const body = postOnce.mock.calls[0][2];
   expect(body).toContain('### ✅ No issues detected');
   expect(body).toContain('<!-- nsreq:snapshot:h1 -->');
+});
+
+test('issues.opened: onApproval hook match auto-approves and skips review handover', async () => {
+  const cfg = {
+    workflow: {
+      approvers: ['cpa-user'],
+      labels: {
+        approvalRequested: ['needs-review'],
+        approvalSuccessful: ['Approved'],
+      },
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const issue = {
+    number: 16,
+    title: 'Request',
+    body: 'Body',
+    labels: [],
+    user: { login: 'author' },
+  };
+
+  const ctx = mkIssueContext({
+    action: 'opened',
+    issue,
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+  await handler(ctx);
+
+  expect(runApprovalHook).toHaveBeenCalled();
+  expect(createRequestPr).toHaveBeenCalled();
+  expect(ensureAssigneesOnce).not.toHaveBeenCalled();
+
+  const body = postOnce.mock.calls[0][2];
+  expect(body).toContain('Opened PR: #10');
+  expect(body).not.toContain('Routing to an approver for review');
+});
+
+test('issues.opened: onApproval false keeps normal review handover unchanged', async () => {
+  const cfg = {
+    workflow: {
+      approvers: ['cpa-user'],
+      labels: {
+        global: ['registry-bot'],
+        approvalRequested: ['needs-review'],
+      },
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const issue = {
+    number: 17,
+    title: 'Request',
+    body: 'Body',
+    labels: [],
+    user: { login: 'author' },
+  };
+
+  const ctx = mkIssueContext({
+    action: 'opened',
+    issue,
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  runApprovalHook.mockResolvedValueOnce({} as any);
+
+  await handler(ctx);
+
+  expect(createRequestPr).not.toHaveBeenCalled();
+  expect(ensureAssigneesOnce).toHaveBeenCalledWith(ctx, expect.anything(), expect.anything(), ['cpa-user']);
+
+  const body = postOnce.mock.calls[0][2];
+  expect(body).toContain('Routing to an approver for review');
+});
+
+test('issues.opened: onApproval rejected posts feedback and closes request', async () => {
+  const cfg = {
+    workflow: {
+      approvers: ['cpa-user'],
+      labels: {
+        approvalRequested: ['needs-review'],
+        approvalSuccessful: ['Approved'],
+      },
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const issue = {
+    number: 18,
+    title: 'Request',
+    body: 'Body',
+    labels: [],
+    user: { login: 'author' },
+  };
+
+  const ctx = mkIssueContext({
+    action: 'opened',
+    issue,
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  runApprovalHook.mockResolvedValueOnce({
+    status: 'rejected',
+    path: 'namespace',
+    reason: 'not eligible',
+  } as any);
+
+  await handler(ctx);
+
+  expect(createRequestPr).not.toHaveBeenCalled();
+  expect(ensureAssigneesOnce).not.toHaveBeenCalled();
+  expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+    expect.objectContaining({ issue_number: 18, state: 'closed' })
+  );
+
+  const posted = postOnce.mock.calls.map((c: any[]) => String(c[2] ?? '')).join('\n');
+  expect(posted).toContain('onApproval rejected this request');
+  expect(posted).toContain('not eligible');
+  expect(posted).not.toContain('Routing to an approver for review');
+});
+
+test('issues.opened: onApproval unknown posts feedback and keeps normal review handover', async () => {
+  const cfg = {
+    workflow: {
+      approvers: ['cpa-user'],
+      labels: {
+        global: ['registry-bot'],
+        approvalRequested: ['needs-review'],
+      },
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const issue = {
+    number: 19,
+    title: 'Request',
+    body: 'Body',
+    labels: [],
+    user: { login: 'author' },
+  };
+
+  const ctx = mkIssueContext({
+    action: 'opened',
+    issue,
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  runApprovalHook.mockResolvedValueOnce({
+    status: 'unknown',
+    path: 'issue.author',
+    reason: 'manual review required',
+  } as any);
+
+  await handler(ctx);
+
+  expect(createRequestPr).not.toHaveBeenCalled();
+  expect(ensureAssigneesOnce).toHaveBeenCalledWith(ctx, expect.anything(), expect.anything(), ['cpa-user']);
+
+  const bodies = postOnce.mock.calls.map((c: any[]) => String(c[2] ?? ''));
+  expect(bodies.some((b) => b.includes('## onApproval feedback'))).toBe(true);
+  expect(bodies.some((b) => b.includes('manual review required'))).toBe(true);
+  expect(bodies.some((b) => b.includes('Routing to an approver for review'))).toBe(true);
 });

--- a/test/time-utils.test.ts
+++ b/test/time-utils.test.ts
@@ -7,16 +7,22 @@ function ymd(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+function expectDate(value: Date | null): Date {
+  expect(value).not.toBeNull();
+  if (value === null) {
+    throw new Error('Expected a Date instance');
+  }
+  return value;
+}
+
 test('parseYmdUtc parses a valid YYYY-MM-DD as UTC date', () => {
   const dt = parseYmdUtc('2024-01-05');
-  expect(dt).not.toBeNull();
-  expect(ymd(dt!)).toBe('2024-01-05');
+  expect(ymd(expectDate(dt))).toBe('2024-01-05');
 });
 
 test('parseYmdUtc trims whitespace', () => {
   const dt = parseYmdUtc('  2024-01-05  ');
-  expect(dt).not.toBeNull();
-  expect(ymd(dt!)).toBe('2024-01-05');
+  expect(ymd(expectDate(dt))).toBe('2024-01-05');
 });
 
 test('parseYmdUtc returns null for invalid format', () => {
@@ -32,8 +38,7 @@ test('parseYmdUtc returns null for invalid calendar date', () => {
 
 test('parseYmdUtc accepts leap day', () => {
   const dt = parseYmdUtc('2024-02-29');
-  expect(dt).not.toBeNull();
-  expect(ymd(dt!)).toBe('2024-02-29');
+  expect(ymd(expectDate(dt))).toBe('2024-02-29');
 });
 
 test('addMonthsUtc adds months in UTC and preserves day when possible', () => {

--- a/test/validation-run.more.test.ts
+++ b/test/validation-run.more.test.ts
@@ -517,7 +517,10 @@ describe('validation/run.ts extra coverage', () => {
       { template, formData: {} }
     );
 
-    expect(res.errors).toEqual(['Cannot resolve primary identifier from template']);
+    expect(res.errors).toEqual([
+      'Required field is missing in form: Foo',
+      'Cannot resolve primary identifier from template',
+    ]);
     expect(res.namespace).toBe('');
     expect(res.nsType).toBe('');
 
@@ -1813,6 +1816,248 @@ describe('validation/run.ts extra coverage', () => {
     );
 
     expect(res.errors.join('\n')).toMatch(/No schema configured/i);
+
+    restore();
+  });
+  it('runApprovalHook: descriptor hooks forward worker logs and normalize approval result', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        hooks: { allowedHosts: ['api.sap.com'] },
+      },
+      source: 'repo:cfg',
+      hooks: {
+        __type: 'registry-bot-hooks:esm',
+        __path: '.github/registry-bot/config.js',
+        __hash: 'h',
+        __code: 'export default {}',
+      },
+      hooksSource: 'repo:.github/registry-bot/config.js#h',
+    } as any);
+
+    mocks.runHookInWorker.mockResolvedValueOnce({
+      found: true,
+      value: { approved: true },
+      logs: [{ level: 'info', obj: { ok: 1 }, msg: 'worker-info' }],
+    } as any);
+
+    const ctx: any = {
+      octokit: { repos: { getContent: jest.fn() }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const approved = await mod.runApprovalHook(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      {
+        requestType: 'systemNamespace',
+        namespace: 'sap.agt.foo',
+        formData: { namespace: 'sap.agt.foo' },
+        issue: {
+          number: 1,
+          title: 't',
+          body: 'b',
+          state: 'open',
+          labels: [{ name: 'needs-review' }],
+          user: { login: 'agent-fabric-serviceuser' },
+        },
+      }
+    );
+
+    expect(approved).toEqual({ status: 'approved' });
+    expect(mocks.runHookInWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fn: 'onApproval',
+        allowedHosts: ['api.sap.com'],
+        args: expect.objectContaining({
+          requestType: 'systemNamespace',
+          namespace: 'sap.agt.foo',
+          resourceName: 'sap.agt.foo',
+          issue: expect.objectContaining({
+            author: 'agent-fabric-serviceuser',
+            labels: ['needs-review'],
+          }),
+        }),
+      }),
+      expect.anything()
+    );
+    expect(ctx.log.info).toHaveBeenCalledWith({ ok: 1 }, 'worker-info');
+
+    restore();
+  });
+  it('runApprovalHook: legacy hook failures are swallowed and return false', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        hooks: { allowedHosts: ['api.sap.com'] },
+      },
+      source: 'repo:cfg',
+      hooks: {
+        onApproval: async () => {
+          throw new Error('boom');
+        },
+      },
+      hooksSource: 'mock-hooks.js',
+    } as any);
+
+    const ctx: any = {
+      octokit: { repos: { getContent: jest.fn() }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const approved = await mod.runApprovalHook(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      {
+        requestType: 'systemNamespace',
+        namespace: 'sap.agt.foo',
+        formData: { namespace: 'sap.agt.foo' },
+        issue: {
+          number: 1,
+          title: 't',
+          body: 'b',
+          state: 'open',
+          labels: [],
+          user: { login: 'agent-fabric-serviceuser' },
+        },
+      }
+    );
+
+    expect(approved).toEqual({});
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: 'boom' }),
+      'resource-bot hooks.onApproval failed'
+    );
+
+    restore();
+  });
+
+  it('runApprovalHook: legacy hook normalizes unknown and rejected decisions', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig
+      .mockResolvedValueOnce({
+        config: { hooks: { allowedHosts: ['api.sap.com'] } },
+        source: 'repo:cfg',
+        hooks: { onApproval: async () => 'unknown' },
+        hooksSource: 'mock-hooks.js',
+      } as any)
+      .mockResolvedValueOnce({
+        config: { hooks: { allowedHosts: ['api.sap.com'] } },
+        source: 'repo:cfg',
+        hooks: {
+          onApproval: async () => ({ status: 'rejected', path: 'namespace', reason: 'policy denied' }),
+        },
+        hooksSource: 'mock-hooks.js',
+      } as any);
+
+    const mkCtx = () => ({
+      octokit: { repos: { getContent: jest.fn() }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    });
+
+    const unknownDecision = await mod.runApprovalHook(
+      mkCtx() as any,
+      { owner: 'o', repo: 'r' },
+      {
+        requestType: 'systemNamespace',
+        namespace: 'sap.agt.foo',
+        formData: { namespace: 'sap.agt.foo' },
+        issue: { number: 1, title: 't', body: 'b', state: 'open', labels: [], user: { login: 'u' } },
+      }
+    );
+
+    const rejectedDecision = await mod.runApprovalHook(
+      mkCtx() as any,
+      { owner: 'o', repo: 'r' },
+      {
+        requestType: 'systemNamespace',
+        namespace: 'sap.agt.foo',
+        formData: { namespace: 'sap.agt.foo' },
+        issue: { number: 1, title: 't', body: 'b', state: 'open', labels: [], user: { login: 'u' } },
+      }
+    );
+
+    expect(unknownDecision).toEqual({ status: 'unknown' });
+    expect(rejectedDecision).toEqual({ status: 'rejected', path: 'namespace', reason: 'policy denied' });
+
+    restore();
+  });
+  it('validateRequestIssue: returns machine readable validation issues for hook and schema errors', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        requests: {
+          product: { folderName: 'data', schema: '/schema.json', issueTemplate: 'x' },
+        },
+      },
+      source: 'repo:cfg',
+      hooks: {
+        onValidate: async () => [{ field: 'vendorId', message: 'Vendor is incorrect because XYZ' }],
+      },
+      hooksSource: 'mock-hooks.js',
+    } as any);
+
+    const schemaObj = {
+      type: 'object',
+      required: ['type', 'name', 'identifier', 'title'],
+      properties: {
+        type: { const: 'product' },
+        name: { type: 'string' },
+        identifier: { type: 'string' },
+        title: { type: 'string' },
+      },
+    };
+
+    const getContent = jest.fn(async ({ path }: { path: string }) => {
+      if (path === 'schema.json') {
+        return {
+          data: {
+            content: Buffer.from(JSON.stringify(schemaObj), 'utf8').toString('base64'),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      const e: any = new Error('not found');
+      e.status = 404;
+      throw e;
+    });
+
+    const ctx: any = {
+      octokit: { repos: { getContent }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const template: any = {
+      body: [
+        { id: 'identifier', attributes: { label: 'Name' }, validations: { required: true } },
+        { id: 'title', attributes: { label: 'Title' }, validations: { required: true } },
+      ],
+      _meta: { requestType: 'product', schema: '/schema.json', root: 'data' },
+    };
+
+    const result = await mod.validateRequestIssue(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      { body: 'body' },
+      { template, formData: { identifier: 'PROD-1', title: 'Some Product' } }
+    );
+
+    expect(result.validationIssues).toEqual(
+      expect.arrayContaining([{ path: 'vendorId', message: 'Vendor is incorrect because XYZ' }])
+    );
 
     restore();
   });

--- a/test/validation-run.test.ts
+++ b/test/validation-run.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type */
 /* eslint-disable require-await */
-import { jest } from '@jest/globals';
+import { beforeAll, beforeEach, expect, jest, test } from '@jest/globals';
 
 process.env.DEBUG_NS = '1';
 
@@ -20,7 +20,6 @@ function httpErr(status: number): Error & { status: number } {
 }
 
 /* mocks wired into run.ts */
-
 type LoadStaticConfigFn = (...args: any[]) => Promise<{
   config: any;
   source: string;
@@ -279,7 +278,10 @@ test('adds required-field messages and returns "Cannot resolve primary identifie
     { template: tpl as any, formData: {} as any }
   );
 
-  expect(res.errors).toEqual(['Cannot resolve primary identifier from template']);
+  expect(res.errors).toEqual([
+    'Required field is missing in form: Identifier',
+    'Cannot resolve primary identifier from template',
+  ]);
   expect(res.errorsFormatted).toMatch(/Required field is missing/i);
 });
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["node", "jest"],
     "module": "ESNext",
+    "moduleResolution": "Bundler",
     "target": "ESNext",
     "noEmit": true
   },


### PR DESCRIPTION
Adds optional `onApproval` support to the bot core.

What changed:
- integrated `onApproval` into the request flow after validation and parent checks
- added support for direct and standalone PR approval handling
- enabled automatic PR approval review creation on approved direct PRs
- kept existing manual review flow as fallback when no approval decision is returned
- added structured machine-readable validation metadata for issue and PR comments
- aligned approval error output with hook-style `field` + `message` structure

Behavior:
- `approved` -> request/PR continues automatically
- `rejected` -> request or direct PR is closed with clear feedback
- no decision -> existing review flow stays unchanged

Notes:
- no policy-specific logic was hardcoded into the bot core
- target repo policy remains in `.github/registry-bot/config.js`
- existing flows remain backward compatible when `onApproval` is not used