### PR TITLE
fix: handle stale request branches in approval flow

### DIFF
--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1727,6 +1727,41 @@ function buildFormDataFromRegistryDoc(doc: Record<string, unknown>): FormData {
   return out;
 }
 
+function isChangedYamlCandidate(file: PullRequestFileLike): string {
+  const filename = normalizeRepoPath(file?.filename);
+  const status = toStringTrim(file?.status).toLowerCase();
+
+  if (!filename || !isYamlPath(filename) || status === 'removed') return '';
+  return filename;
+}
+
+async function listChangedYamlFilesPage(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number,
+  page: number
+): Promise<PullRequestFileLike[]> {
+  const res = await (
+    context.octokit.pulls as unknown as {
+      listFiles: (args: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        per_page?: number;
+        page?: number;
+      }) => Promise<{ data?: PullRequestFileLike[] }>;
+    }
+  ).listFiles({
+    owner: repoInfo.owner,
+    repo: repoInfo.repo,
+    pull_number: prNumber,
+    per_page: 100,
+    page,
+  });
+
+  return Array.isArray(res?.data) ? res.data : [];
+}
+
 async function listChangedYamlFilesForPr(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -1736,36 +1771,12 @@ async function listChangedYamlFilesForPr(
   let page = 1;
 
   while (true) {
-    const res = await (
-      context.octokit.pulls as unknown as {
-        listFiles: (args: {
-          owner: string;
-          repo: string;
-          pull_number: number;
-          per_page?: number;
-          page?: number;
-        }) => Promise<{ data?: PullRequestFileLike[] }>;
-      }
-    ).listFiles({
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      pull_number: prNumber,
-      per_page: 100,
-      page,
-    });
-
-    const files = Array.isArray(res?.data) ? res.data : [];
+    const files = await listChangedYamlFilesPage(context, repoInfo, prNumber, page);
     if (!files.length) break;
 
     for (const file of files) {
-      const filename = normalizeRepoPath(file?.filename);
-      const status = toStringTrim(file?.status).toLowerCase();
-
-      if (!filename) continue;
-      if (!isYamlPath(filename)) continue;
-      if (status === 'removed') continue;
-
-      out.push(filename);
+      const filename = isChangedYamlCandidate(file);
+      if (filename) out.push(filename);
     }
 
     if (files.length < 100) break;
@@ -1808,6 +1819,56 @@ async function readRepoFileTextAtRef(
   }
 }
 
+async function readRegistryDocForApproval(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  filePath: string,
+  ref: string
+): Promise<Record<string, unknown> | null> {
+  const raw = await readRepoFileTextAtRef(context, repoInfo, filePath, ref);
+  if (!raw) return null;
+
+  try {
+    const parsed = YAML.parse(raw) as unknown;
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function evaluateChangedResourceApproval(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  filePath: string
+): Promise<ApprovalDecision> {
+  const parsed = await readRegistryDocForApproval(context, repoInfo, filePath, pr.head.ref);
+  if (!parsed) return { status: 'unknown' };
+
+  const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
+  if (!requestType) return { status: 'unknown' };
+
+  const resourceName = toStringTrim(parsed['name']);
+  if (!resourceName) return { status: 'unknown' };
+
+  return normalizeApprovalDecision(
+    await runApprovalHook(context, repoInfo, {
+      requestType,
+      namespace: resourceName,
+      resourceName,
+      formData: buildFormDataFromRegistryDoc(parsed),
+      issue: {
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        state: pr.state,
+        user: pr.user,
+        labels: [],
+      },
+    })
+  );
+}
+
 async function evaluateDirectPrOnApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -1821,55 +1882,7 @@ async function evaluateDirectPrOnApproval(
   let approvedComment = '';
 
   for (const filePath of changedFiles) {
-    const raw = await readRepoFileTextAtRef(context, repoInfo, filePath, pr.head.ref);
-    if (!raw) {
-      sawUnknown = true;
-      continue;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = YAML.parse(raw);
-    } catch {
-      sawUnknown = true;
-      continue;
-    }
-
-    if (!isPlainObject(parsed)) {
-      sawUnknown = true;
-      continue;
-    }
-
-    const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
-    if (!requestType) {
-      sawUnknown = true;
-      continue;
-    }
-
-    const resourceName = toStringTrim(parsed['name']);
-    if (!resourceName) {
-      sawUnknown = true;
-      continue;
-    }
-
-    const formData = buildFormDataFromRegistryDoc(parsed);
-
-    const decision = normalizeApprovalDecision(
-      await runApprovalHook(context, repoInfo, {
-        requestType,
-        namespace: resourceName,
-        resourceName,
-        formData,
-        issue: {
-          number: pr.number,
-          title: pr.title,
-          body: pr.body,
-          state: pr.state,
-          user: pr.user,
-          labels: [],
-        },
-      })
-    );
+    const decision = await evaluateChangedResourceApproval(context, repoInfo, pr, filePath);
 
     if (decision.status === 'rejected') {
       return decision;
@@ -2026,9 +2039,7 @@ async function finalizeApprovedRequest(
   }
 
   try {
-    const pr = await createRequestPr(context, { owner: params.owner, repo: params.repo }, issue, parsedFormData, {
-      template,
-    });
+    const pr = await createRequestPrWithRecovery(context, params, issue, parsedFormData, template, resourceName);
 
     await applyApprovedRequestState(context, params, eff);
 
@@ -2147,6 +2158,244 @@ async function maybeHandleDirectPrApprovalForMerge(
   }
 
   return 'continue';
+}
+
+function buildSafeResourceSlug(resourceName: unknown): string {
+  return toStringTrim(resourceName)
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function resolveStructuredRootForTemplate(template: TemplateLike): string {
+  return toStringTrim(template?._meta?.root).replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function renderConfiguredRequestBranchName(
+  context: BotContext<RequestEvents>,
+  issue: IssueLike,
+  resourceName: string
+): string {
+  const cfg = (context.resourceBotConfig ?? DEFAULT_CONFIG) as unknown as {
+    pr?: { branchNameTemplate?: unknown } | null;
+  };
+
+  const branchTemplate = toStringTrim(cfg?.pr?.branchNameTemplate) || 'feat/resource-{resource}-issue-{issue}';
+
+  return String(branchTemplate)
+    .replace('{resource}', buildSafeResourceSlug(resourceName))
+    .replace('{issue}', String(issue.number || ''));
+}
+
+function extractCreatePrFailureMessage(error: unknown): string {
+  const raw = (error instanceof Error ? error.message : String(error)).trim();
+  const withoutUrl = raw.replace(/\s*-\s*https?:\/\/\S+$/i, '').trim();
+
+  const marker = 'Validation Failed:';
+  const idx = withoutUrl.indexOf(marker);
+
+  if (idx >= 0) {
+    const tail = withoutUrl.slice(idx + marker.length).trim();
+
+    try {
+      const parsed = JSON.parse(tail) as Record<string, unknown>;
+      const msg = toStringTrim(parsed['message']);
+      if (msg) return msg;
+    } catch {
+      // ignore
+    }
+
+    return tail || withoutUrl;
+  }
+
+  return withoutUrl;
+}
+
+function parseNoCommitsHeadBranchFromCreatePrError(error: unknown): string {
+  const raw = extractCreatePrFailureMessage(error);
+  const m = /No commits between [^ ]+ and ([^"\s]+)/i.exec(raw);
+  return m?.[1] ? toStringTrim(m[1]).replace(/^refs\/heads\//, '') : '';
+}
+
+function isResourceAlreadyExistsDuringPrCreation(error: unknown): boolean {
+  const msg = extractCreatePrFailureMessage(error);
+  return /Resource ['"`][^'"`]+['"`] already exists at /i.test(msg);
+}
+
+async function registryResourceExistsOnDefaultBranch(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  template: TemplateLike,
+  resourceName: string
+): Promise<boolean> {
+  const structRoot = resolveStructuredRootForTemplate(template);
+  if (!structRoot || !resourceName) return false;
+
+  for (const ext of ['yaml', 'yml']) {
+    try {
+      await context.octokit.repos.getContent({
+        owner: params.owner,
+        repo: params.repo,
+        path: `${structRoot}/${resourceName}.${ext}`,
+      });
+      return true;
+    } catch (e: unknown) {
+      if (getHttpStatus(e) === 404) continue;
+      throw e;
+    }
+  }
+
+  return false;
+}
+
+async function deleteBranchRefIfPresent(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  branchName: string
+): Promise<void> {
+  const branch = toStringTrim(branchName).replace(/^refs\/heads\//, '');
+  if (!branch) return;
+
+  try {
+    await context.octokit.git.deleteRef({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      ref: `heads/${branch}`,
+    });
+  } catch (e: unknown) {
+    if (getHttpStatus(e) !== 404) throw e;
+  }
+}
+
+function formatCreateRequestFailureForUser(error: unknown, branchName = '', resourceName = ''): string {
+  const msg = extractCreatePrFailureMessage(error);
+  const parsedBranch = parseNoCommitsHeadBranchFromCreatePrError(error) || toStringTrim(branchName);
+
+  if (/^No commits between\b/i.test(msg)) {
+    const suffix = parsedBranch ? ` '${parsedBranch}'` : '';
+    return `Failed to create PR automatically: stale request branch${suffix} blocked PR creation. Please retry approval.`;
+  }
+
+  if (isResourceAlreadyExistsDuringPrCreation(error)) {
+    const suffix = resourceName ? ` '${resourceName}'` : '';
+    return `Failed to create PR automatically: a stale request branch already contains${suffix}. Please retry approval.`;
+  }
+
+  return `Failed to create PR automatically: ${msg}`;
+}
+
+async function runCreateRequestPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  issue: IssueLike,
+  parsedFormData: FormData,
+  template: TemplateLike
+): Promise<{ number: number }> {
+  return await createRequestPr(context, repoInfo, issue, parsedFormData, { template });
+}
+
+async function retryCreatePrAfterBranchCleanup(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  branchName: string,
+  issue: IssueLike,
+  parsedFormData: FormData,
+  template: TemplateLike
+): Promise<{ number: number }> {
+  await deleteBranchRefIfPresent(context, repoInfo, branchName);
+  return await runCreateRequestPr(context, repoInfo, issue, parsedFormData, template);
+}
+
+async function handleNoCommitsCreatePrFailure(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  branchName: string,
+  issue: IssueLike,
+  parsedFormData: FormData,
+  template: TemplateLike,
+  resourceName: string
+): Promise<{ number: number }> {
+  try {
+    return await retryCreatePrAfterBranchCleanup(context, repoInfo, branchName, issue, parsedFormData, template);
+  } catch (retryError: unknown) {
+    throw new Error(formatCreateRequestFailureForUser(retryError, branchName, resourceName));
+  }
+}
+
+async function handleAlreadyExistsCreatePrFailure(
+  context: BotContext<RequestEvents>,
+  args: {
+    params: IssueParams;
+    repoInfo: RepoInfo;
+    issue: IssueLike;
+    parsedFormData: FormData;
+    template: TemplateLike;
+    resourceName: string;
+    branchName: string;
+  }
+): Promise<{ number: number }> {
+  const { params, repoInfo, issue, parsedFormData, template, resourceName, branchName } = args;
+
+  try {
+    const existsOnDefaultBranch = await registryResourceExistsOnDefaultBranch(context, params, template, resourceName);
+
+    if (existsOnDefaultBranch) {
+      throw new Error(`Failed to create PR automatically: Resource '${resourceName}' already exists in the registry.`);
+    }
+
+    return await retryCreatePrAfterBranchCleanup(context, repoInfo, branchName, issue, parsedFormData, template);
+  } catch (retryError: unknown) {
+    if (retryError instanceof Error && retryError.message.startsWith('Failed to create PR automatically:')) {
+      throw retryError;
+    }
+
+    throw new Error(formatCreateRequestFailureForUser(retryError, branchName, resourceName));
+  }
+}
+
+async function createRequestPrWithRecovery(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  issue: IssueLike,
+  parsedFormData: FormData,
+  template: TemplateLike,
+  resourceName: string
+): Promise<{ number: number }> {
+  const repoInfo: RepoInfo = { owner: params.owner, repo: params.repo };
+  const fallbackBranchName = renderConfiguredRequestBranchName(context, issue, resourceName);
+
+  try {
+    return await runCreateRequestPr(context, repoInfo, issue, parsedFormData, template);
+  } catch (error: unknown) {
+    const staleNoCommitsBranch = parseNoCommitsHeadBranchFromCreatePrError(error) || fallbackBranchName;
+    const failureMessage = extractCreatePrFailureMessage(error);
+
+    if (/^No commits between\b/i.test(failureMessage)) {
+      return await handleNoCommitsCreatePrFailure(
+        context,
+        repoInfo,
+        staleNoCommitsBranch,
+        issue,
+        parsedFormData,
+        template,
+        resourceName
+      );
+    }
+
+    if (isResourceAlreadyExistsDuringPrCreation(error)) {
+      return await handleAlreadyExistsCreatePrFailure(context, {
+        params,
+        repoInfo,
+        issue,
+        parsedFormData,
+        template,
+        resourceName,
+        branchName: fallbackBranchName,
+      });
+    }
+
+    throw new Error(formatCreateRequestFailureForUser(error, staleNoCommitsBranch, resourceName));
+  }
 }
 
 function isConfiguredApprover(login: string | undefined | null, allowedApprovers: string[]): boolean {

--- a/src/handlers/request/template.ts
+++ b/src/handlers/request/template.ts
@@ -373,11 +373,11 @@ export async function loadTemplate(
   if (!context?.octokit) {
     throw new Error('Configuration error: octokit is not available in context.');
   }
+
+  const octokit = context.octokit;
   if (!owner || !repo) {
     throw new Error('Configuration error: owner/repo are required to load templates.');
   }
-
-  const octokit = context.octokit;
 
   const labels = toLabelStrings(issueLabels);
 

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -1507,6 +1507,466 @@ describe('parent owner approval gating', () => {
     expect(postOnce.mock.calls.some((c) => String(c[2] ?? '').includes('Detected issues'))).toBe(true);
     expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
   });
+  test('issue_comment: approval recovers from stale request branch when PR creation fails with no commits between', async () => {
+    const cfg = {
+      workflow: {
+        labels: {
+          approvalRequested: ['needs-review'],
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: ['alice'],
+      },
+      pr: {
+        branchNameTemplate: 'feat/resource-{resource}-issue-{issue}',
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['issue_comment.created'][0];
+
+    const issue = {
+      number: 176,
+      title: 'System Namespace: sap.aiadm',
+      body: `### Namespace
+
+  sap.aiadm
+
+  ### System Description
+
+  \`\`\`text
+  Example description
+  \`\`\`
+
+  ### Contacts
+
+  \`\`\`text
+  owner@sap.com
+  \`\`\`
+
+  ### Visibility
+
+  public
+
+  <!-- nsreq:routing-lock = {"v":1,"expected":"System Namespace"} -->`,
+      labels: ['needs-review'],
+      user: { login: 'requester' },
+    };
+
+    loadTemplate.mockResolvedValueOnce({
+      title: 'System Namespace',
+      name: 'System Namespace',
+      body: [],
+      labels: ['System Namespace'],
+      _meta: {
+        requestType: 'systemNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        path: '.github/ISSUE_TEMPLATE/1-system-namespace-request.yaml',
+      },
+    });
+
+    parseForm.mockReturnValueOnce({
+      namespace: 'sap.aiadm',
+      description: 'Example description',
+      contact: 'owner@sap.com',
+      visibility: 'public',
+    });
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: [],
+      errorsGrouped: null,
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.aiadm',
+      nsType: 'system',
+      template: {
+        _meta: {
+          requestType: 'systemNamespace',
+          root: '/data/namespaces',
+          schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        },
+      },
+    });
+
+    createRequestPr
+      .mockRejectedValueOnce(
+        new Error(
+          'Validation Failed: {"resource":"PullRequest","code":"custom","message":"No commits between main and feat/resource-sap.aiadm-issue-176"} - https://docs.github.com/enterprise-server@3.17/rest/pulls/pulls#create-a-pull-request'
+        )
+      )
+      .mockResolvedValueOnce({ number: 999 });
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'alice' } },
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    await handler(ctx);
+
+    expect(ctx.octokit.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      ref: 'heads/feat/resource-sap.aiadm-issue-176',
+    });
+
+    expect(createRequestPr).toHaveBeenCalledTimes(2);
+    expect(postOnce.mock.calls.some((c) => String(c[2] ?? '').includes('Approved by @alice. Opened PR: #999'))).toBe(
+      true
+    );
+    expect(
+      postOnce.mock.calls.some((c) =>
+        String(c[2] ?? '').includes('No commits between main and feat/resource-sap.aiadm-issue-176')
+      )
+    ).toBe(false);
+  });
+
+  test('issue_comment: approval recovers from stale branch when PR creation reports resource already exists only on request branch', async () => {
+    const cfg = {
+      workflow: {
+        labels: {
+          approvalRequested: ['needs-review'],
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: ['alice'],
+      },
+      pr: {
+        branchNameTemplate: 'feat/resource-{resource}-issue-{issue}',
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['issue_comment.created'][0];
+
+    const issue = {
+      number: 176,
+      title: 'System Namespace: sap.aiadm',
+      body: `### Namespace
+
+sap.aiadm
+
+### System Description
+
+\`\`\`text
+Example description
+\`\`\`
+
+### Contacts
+
+\`\`\`text
+owner@sap.com
+\`\`\`
+
+### Visibility
+
+public
+
+<!-- nsreq:routing-lock = {"v":1,"expected":"System Namespace"} -->`,
+      labels: ['needs-review'],
+      user: { login: 'requester' },
+    };
+
+    loadTemplate.mockResolvedValueOnce({
+      title: 'System Namespace',
+      name: 'System Namespace',
+      body: [],
+      labels: ['System Namespace'],
+      _meta: {
+        requestType: 'systemNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        path: '.github/ISSUE_TEMPLATE/1-system-namespace-request.yaml',
+      },
+    });
+
+    parseForm.mockReturnValueOnce({
+      namespace: 'sap.aiadm',
+      description: 'Example description',
+      contact: 'owner@sap.com',
+      visibility: 'public',
+    });
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: [],
+      errorsGrouped: null,
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.aiadm',
+      nsType: 'system',
+      template: {
+        _meta: {
+          requestType: 'systemNamespace',
+          root: '/data/namespaces',
+          schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        },
+      },
+    });
+
+    createRequestPr
+      .mockRejectedValueOnce(new Error("Resource 'sap.aiadm' already exists at data/namespaces"))
+      .mockResolvedValueOnce({ number: 1001 });
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'alice' } },
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (String(path) === 'data/namespaces/sap.aiadm.yaml') {
+        const err: any = new Error('Not Found');
+        err.status = 404;
+        throw err;
+      }
+      const err: any = new Error('Not Found');
+      err.status = 404;
+      throw err;
+    });
+
+    await handler(ctx);
+
+    expect(ctx.octokit.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      ref: 'heads/feat/resource-sap.aiadm-issue-176',
+    });
+
+    expect(createRequestPr).toHaveBeenCalledTimes(2);
+    expect(postOnce.mock.calls.some((c) => String(c[2] ?? '').includes('Approved by @alice. Opened PR: #1001'))).toBe(
+      true
+    );
+  });
+
+  test('issue_comment: approval shows human-readable exists message when resource already exists on default branch', async () => {
+    const cfg = {
+      workflow: {
+        labels: {
+          approvalRequested: ['needs-review'],
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: ['alice'],
+      },
+      pr: {
+        branchNameTemplate: 'feat/resource-{resource}-issue-{issue}',
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['issue_comment.created'][0];
+
+    const issue = {
+      number: 176,
+      title: 'System Namespace: sap.aiadm',
+      body: `### Namespace
+
+sap.aiadm
+
+### System Description
+
+\`\`\`text
+Example description
+\`\`\`
+
+### Contacts
+
+\`\`\`text
+owner@sap.com
+\`\`\`
+
+### Visibility
+
+public
+
+<!-- nsreq:routing-lock = {"v":1,"expected":"System Namespace"} -->`,
+      labels: ['needs-review'],
+      user: { login: 'requester' },
+    };
+
+    loadTemplate.mockResolvedValueOnce({
+      title: 'System Namespace',
+      name: 'System Namespace',
+      body: [],
+      labels: ['System Namespace'],
+      _meta: {
+        requestType: 'systemNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        path: '.github/ISSUE_TEMPLATE/1-system-namespace-request.yaml',
+      },
+    });
+
+    parseForm.mockReturnValueOnce({
+      namespace: 'sap.aiadm',
+      description: 'Example description',
+      contact: 'owner@sap.com',
+      visibility: 'public',
+    });
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: [],
+      errorsGrouped: null,
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.aiadm',
+      nsType: 'system',
+      template: {
+        _meta: {
+          requestType: 'systemNamespace',
+          root: '/data/namespaces',
+          schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        },
+      },
+    });
+
+    createRequestPr.mockRejectedValueOnce(new Error("Resource 'sap.aiadm' already exists at data/namespaces"));
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'alice' } },
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({ data: { content: 'x', encoding: 'base64' } });
+
+    await handler(ctx);
+
+    expect(createRequestPr).toHaveBeenCalledTimes(1);
+    expect(ctx.octokit.git.deleteRef).not.toHaveBeenCalled();
+
+    const bodies = postOnce.mock.calls.map((c) => String(c[2] ?? '')).join('\n');
+    expect(bodies).toContain("Failed to create PR automatically: Resource 'sap.aiadm' already exists in the registry.");
+  });
+
+  test('issue_comment: approval shows human-readable stale branch message when retry after no-commits also fails', async () => {
+    const cfg = {
+      workflow: {
+        labels: {
+          approvalRequested: ['needs-review'],
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: ['alice'],
+      },
+      pr: {
+        branchNameTemplate: 'feat/resource-{resource}-issue-{issue}',
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['issue_comment.created'][0];
+
+    const issue = {
+      number: 176,
+      title: 'System Namespace: sap.aiadm',
+      body: `### Namespace
+
+sap.aiadm
+
+### System Description
+
+\`\`\`text
+Example description
+\`\`\`
+
+### Contacts
+
+\`\`\`text
+owner@sap.com
+\`\`\`
+
+### Visibility
+
+public
+
+<!-- nsreq:routing-lock = {"v":1,"expected":"System Namespace"} -->`,
+      labels: ['needs-review'],
+      user: { login: 'requester' },
+    };
+
+    loadTemplate.mockResolvedValueOnce({
+      title: 'System Namespace',
+      name: 'System Namespace',
+      body: [],
+      labels: ['System Namespace'],
+      _meta: {
+        requestType: 'systemNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        path: '.github/ISSUE_TEMPLATE/1-system-namespace-request.yaml',
+      },
+    });
+
+    parseForm.mockReturnValueOnce({
+      namespace: 'sap.aiadm',
+      description: 'Example description',
+      contact: 'owner@sap.com',
+      visibility: 'public',
+    });
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: [],
+      errorsGrouped: null,
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.aiadm',
+      nsType: 'system',
+      template: {
+        _meta: {
+          requestType: 'systemNamespace',
+          root: '/data/namespaces',
+          schema: '.github/registry-bot/request-schemas/system-namespace.schema.json',
+        },
+      },
+    });
+
+    createRequestPr
+      .mockRejectedValueOnce(
+        new Error(
+          'Validation Failed: {"resource":"PullRequest","code":"custom","message":"No commits between main and feat/resource-sap.aiadm-issue-176"} - https://docs.github.com/enterprise-server@3.17/rest/pulls/pulls#create-a-pull-request'
+        )
+      )
+      .mockRejectedValueOnce(
+        new Error(
+          'Validation Failed: {"resource":"PullRequest","code":"custom","message":"No commits between main and feat/resource-sap.aiadm-issue-176"} - https://docs.github.com/enterprise-server@3.17/rest/pulls/pulls#create-a-pull-request'
+        )
+      );
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'alice' } },
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    await handler(ctx);
+
+    expect(ctx.octokit.git.deleteRef).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      ref: 'heads/feat/resource-sap.aiadm-issue-176',
+    });
+
+    const bodies = postOnce.mock.calls.map((c) => String(c[2] ?? '')).join('\n');
+    expect(bodies).toContain(
+      "Failed to create PR automatically: stale request branch 'feat/resource-sap.aiadm-issue-176' blocked PR creation. Please retry approval."
+    );
+    expect(bodies).not.toContain('Validation Failed: {"resource":"PullRequest"');
+    expect(bodies).not.toContain('https://docs.github.com/');
+  });
 
   test('issue_comment: explicit approved creates PR only after request is valid', async () => {
     const cfg = {


### PR DESCRIPTION
## Summary

Make the approval flow more robust when PR creation fails after the request branch was already created.

## Changes

- recover from stale request branches automatically
- retry PR creation after stale branch cleanup
- avoid false "resource already exists" errors when the file exists only on the stale branch
- replace raw GitHub API errors with human-readable messages
- add tests for stale branch recovery and retry behavior

## Result

- no raw GitHub validation errors shown to users
- cleaner recovery after failed PR creation
- existing approval and validation logic stays unchanged