### PR TITLE
Extend approval hook logic and improve PR validation handling

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Create GitHub Release
         uses: open-resource-discovery/github-release@8c4d8e4db8921195691f8a150e3f744db03ce2dc # main
         with:
-          tag-template: 'rel/<version>'
+          tag-template: 'v/<version>'
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ## Added
+
 - Direct PR auto-approval via `onApproval` hook
 - Use last commit author as `requestAuthorId`
 - Merge `approvers` and `approversPool` for approval logic
@@ -16,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Machine-readable validation output
 
 ## Improved
+
 - Consistent validation feedback between CI and bot comments
 - Safer approval logic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Added
+- Direct PR auto-approval via `onApproval` hook
+- Use last commit author as `requestAuthorId`
+- Merge `approvers` and `approversPool` for approval logic
+- Auto-add `Approved` label on successful auto-approval
+- Multi-file validation support with aggregated PR comment
+- Machine-readable validation output
+
+## Improved
+- Consistent validation feedback between CI and bot comments
+- Safer approval logic
+
 ## [[0.0.5](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/rel/0.0.5)] - 2026-04-10
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.0.5",
+  "version": "0.1.0-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.0-dev.1",
+  "version": "0.1.0",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -106,6 +106,11 @@ type PullRequestFileLike = {
   status?: string | null;
 };
 
+type PullRequestCommitLike = {
+  author?: UserLike | null;
+  committer?: UserLike | null;
+};
+
 type CheckRunPullRequestRef = { number?: number | null };
 
 type CheckRunLike = {
@@ -786,12 +791,7 @@ function extractFieldFromMsg(m: string): string {
   return '';
 }
 
-function buildRegistryValidationPrCommentBody(filePath: string, messages: string[]): string {
-  const lines: string[] = [];
-
-  lines.push(`## Detected issues: ${filePath}`);
-  lines.push('');
-
+function groupRegistryValidationMessages(messages: string[]): Map<string, string[]> {
   const grouped = new Map<string, string[]>();
 
   for (const raw of messages) {
@@ -804,24 +804,70 @@ function buildRegistryValidationPrCommentBody(filePath: string, messages: string
     grouped.set(field, arr);
   }
 
-  const keys = Array.from(grouped.keys()).sort((a, b) => {
+  return grouped;
+}
+
+function sortRegistryValidationGroupKeys(grouped: Map<string, string[]>): string[] {
+  return Array.from(grouped.keys()).sort((a, b) => {
     if (a === 'details') return 1;
     if (b === 'details') return -1;
     return a.localeCompare(b);
   });
+}
 
-  for (const k of keys) {
-    lines.push(`### ${toSectionTitle(k)}`);
-    for (const msg of grouped.get(k) ?? []) {
+function appendRegistryValidationSections(lines: string[], grouped: Map<string, string[]>, headingLevel: string): void {
+  for (const key of sortRegistryValidationGroupKeys(grouped)) {
+    lines.push(`${headingLevel} ${toSectionTitle(key)}`);
+    for (const msg of grouped.get(key) ?? []) {
       lines.push(`- ${msg}`);
     }
     lines.push('');
   }
+}
+
+function appendRegistryValidationFileSection(
+  lines: string[],
+  machineReadable: MachineReadableIssue[],
+  filePath: string,
+  messages: string[]
+): void {
+  lines.push(`### ${filePath}`, '');
+  appendRegistryValidationSections(lines, groupRegistryValidationMessages(messages), '####');
+  machineReadable.push(...buildRegistryValidationMachineReadableIssues(filePath, messages));
+}
+
+function buildRegistryValidationPrCommentBody(filePath: string, messages: string[]): string {
+  const lines: string[] = [`## Detected issues: ${filePath}`, ''];
+
+  appendRegistryValidationSections(lines, groupRegistryValidationMessages(messages), '###');
 
   const body = lines.join('\n').trimEnd();
   const machineReadable = buildRegistryValidationMachineReadableIssues(filePath, messages);
 
   return `${body}
+
+${buildMachineReadableMetadataBlock(machineReadable)}`;
+}
+
+function buildRegistryValidationAggregatePrCommentBody(byFile: Map<string, string[]>): string {
+  const entries = Array.from(byFile.entries())
+    .filter(([, messages]) => Array.isArray(messages) && messages.length > 0)
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  if (!entries.length) return '';
+  if (entries.length === 1) {
+    const [filePath, messages] = entries[0];
+    return buildRegistryValidationPrCommentBody(filePath, messages);
+  }
+
+  const lines: string[] = ['## Detected issues', ''];
+  const machineReadable: MachineReadableIssue[] = [];
+
+  for (const [filePath, messages] of entries) {
+    appendRegistryValidationFileSection(lines, machineReadable, filePath, messages);
+  }
+
+  return `${lines.join('\n').trimEnd()}
 
 ${buildMachineReadableMetadataBlock(machineReadable)}`;
 }
@@ -1188,6 +1234,7 @@ type RunApprovalHookFn = (
     resourceName?: string | null;
     formData: FormData;
     issue: IssueLike;
+    requestAuthorId?: string | null;
   }
 ) => Promise<ApprovalDecision | boolean>;
 
@@ -1631,6 +1678,68 @@ The PR could not be approved automatically, so merge remains blocked until a rev
   }
 }
 
+async function resolvePullRequestRequestAuthorId(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<string> {
+  let page = 1;
+  let lastCommitter = '';
+
+  while (true) {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        listCommits: (args: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          per_page?: number;
+          page?: number;
+        }) => Promise<{ data?: PullRequestCommitLike[] }>;
+      }
+    ).listCommits({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: pr.number,
+      per_page: 100,
+      page,
+    });
+
+    const commits = Array.isArray(res?.data) ? res.data : [];
+    if (!commits.length) break;
+
+    const last = commits.at(-1);
+    lastCommitter = normalizeLogin(last?.committer?.login) || normalizeLogin(last?.author?.login) || lastCommitter;
+
+    if (commits.length < 100) break;
+    page += 1;
+    if (page > 20) break;
+  }
+
+  return lastCommitter || normalizeLogin(pr.user?.login);
+}
+
+async function addApprovedLabelToPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+  if (!approvedLabel) return;
+
+  try {
+    await context.octokit.issues.addLabels({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      issue_number: prNumber,
+      labels: [approvedLabel],
+    });
+  } catch {
+    // ignore
+  }
+}
+
 function normalizeRepoPath(path: unknown): string {
   return toStringTrim(path)
     .replace(/\\/g, '/')
@@ -1696,37 +1805,77 @@ function pickRequestTypeForChangedResource(
   return '';
 }
 
+function resolveRegistryDocResourceName(doc: Record<string, unknown>): string {
+  const directKeys = ['identifier', 'namespace', 'product-id', 'productId', 'id', 'name', 'vendor'];
+
+  for (const key of directKeys) {
+    const value = toStringTrim(doc[key]).replaceAll('\u00a0', ' ').trim();
+    if (value) return value;
+  }
+
+  return '';
+}
+
+function stringifyRegistryDocFormValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+
+  if (Array.isArray(value)) {
+    const scalarItems = value
+      .map((item) =>
+        typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean' ? String(item) : ''
+      )
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (scalarItems.length === value.length) return scalarItems.join('\n');
+  }
+
+  return YAML.stringify(value).trim();
+}
+
 function buildFormDataFromRegistryDoc(doc: Record<string, unknown>): FormData {
   const out: FormData = {};
 
-  const name = toStringTrim(doc['name']);
-  if (name) {
-    out.name = name;
-    out.identifier = name;
-    out.namespace = name;
+  for (const [key, value] of Object.entries(doc)) {
+    const serialized = stringifyRegistryDocFormValue(value);
+    if (serialized) out[key] = serialized;
   }
 
+  const resourceName = resolveRegistryDocResourceName(doc);
+  if (resourceName) {
+    out.identifier = out.identifier || resourceName;
+    out.namespace = out.namespace || resourceName;
+  }
+
+  const name = toStringTrim(doc['name']);
+  if (name && !out.name) out.name = name;
+
   const description = toStringTrim(doc['description']);
-  if (description) out.description = description;
+  if (description && !out.description) out.description = description;
 
   const title = toStringTrim(doc['title']);
-  if (title) out.title = title;
+  if (title && !out.title) out.title = title;
 
   const vendor = toStringTrim(doc['vendor']);
-  if (vendor) out.vendor = vendor;
+  if (vendor && !out.vendor) out.vendor = vendor;
 
   const contacts = Array.isArray(doc['contact'])
     ? doc['contact']
-        .map((v) => toStringTrim(v))
+        .map((v: unknown) => toStringTrim(v))
         .filter(Boolean)
         .join('\n')
     : toStringTrim(doc['contact']);
 
-  if (contacts) out.contact = contacts;
+  if (contacts && !out.contact) out.contact = contacts;
 
   return out;
 }
 
+function isRegistryEntryPath(context: BotContext<RequestEvents>, filePath: string): boolean {
+  return matchRequestTypesForFile(context, filePath).length > 0;
+}
 function isChangedYamlCandidate(file: PullRequestFileLike): string {
   const filename = normalizeRepoPath(file?.filename);
   const status = toStringTrim(file?.status).toLowerCase();
@@ -1776,7 +1925,7 @@ async function listChangedYamlFilesForPr(
 
     for (const file of files) {
       const filename = isChangedYamlCandidate(file);
-      if (filename) out.push(filename);
+      if (filename && isRegistryEntryPath(context, filename)) out.push(filename);
     }
 
     if (files.length < 100) break;
@@ -1840,7 +1989,8 @@ async function evaluateChangedResourceApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   pr: PullRequestLike,
-  filePath: string
+  filePath: string,
+  requestAuthorId?: string
 ): Promise<ApprovalDecision> {
   const parsed = await readRegistryDocForApproval(context, repoInfo, filePath, pr.head.ref);
   if (!parsed) return { status: 'unknown' };
@@ -1848,7 +1998,7 @@ async function evaluateChangedResourceApproval(
   const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
   if (!requestType) return { status: 'unknown' };
 
-  const resourceName = toStringTrim(parsed['name']);
+  const resourceName = resolveRegistryDocResourceName(parsed);
   if (!resourceName) return { status: 'unknown' };
 
   return normalizeApprovalDecision(
@@ -1857,6 +2007,7 @@ async function evaluateChangedResourceApproval(
       namespace: resourceName,
       resourceName,
       formData: buildFormDataFromRegistryDoc(parsed),
+      requestAuthorId,
       issue: {
         number: pr.number,
         title: pr.title,
@@ -1877,12 +2028,14 @@ async function evaluateDirectPrOnApproval(
   const changedFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
   if (!changedFiles.length) return {};
 
+  const requestAuthorId = await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
+
   let sawApproved = false;
   let sawUnknown = false;
   let approvedComment = '';
 
   for (const filePath of changedFiles) {
-    const decision = await evaluateChangedResourceApproval(context, repoInfo, pr, filePath);
+    const decision = await evaluateChangedResourceApproval(context, repoInfo, pr, filePath, requestAuthorId);
 
     if (decision.status === 'rejected') {
       return decision;
@@ -1916,7 +2069,10 @@ async function maybeHandleStandaloneDirectPrApproval(
 
   if (decision.status === 'approved') {
     const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
-    return approved ? 'approved' : 'continue';
+    if (!approved) return 'continue';
+
+    await addApprovedLabelToPr(context, repoInfo, pr.number);
+    return 'approved';
   }
 
   if (decision.status === 'rejected') {
@@ -1987,9 +2143,8 @@ async function rejectRequestFromApprovalHook(
     }
   }
 
-  const closedPrSection = closedPrs.length
-    ? `\n\nClosed linked PR(s): ${closedPrs.map((n) => `#${n}`).join(', ')}.`
-    : '';
+  const closedPrRefs = closedPrs.map((n) => `#${n}`).join(', ');
+  const closedPrSection = closedPrs.length ? `\n\nClosed linked PR(s): ${closedPrRefs}.` : '';
 
   await postOnce(context, params, `${buildApprovalRejectedBody(decision)}${closedPrSection}`, {
     minimizeTag: options.minimizeTag || 'nsreq:on-approval:rejected',
@@ -2009,10 +2164,16 @@ async function finalizeApprovedRequest(
   issue: IssueLike,
   template: TemplateLike,
   parsedFormData: FormData,
-  approvalPrefix: string,
-  approvalComment = ''
+  options: {
+    approvalPrefix: string;
+    approvalComment?: string;
+    autoApproved?: boolean;
+  }
 ): Promise<void> {
   const eff = resolveEffectiveConstants(context);
+  const approvalPrefix = toStringTrim(options.approvalPrefix);
+  const approvalComment = toStringTrim(options.approvalComment);
+  const autoApproved = options.autoApproved === true;
 
   const resourceName = extractResourceNameFromForm(parsedFormData, template).replaceAll('\u00a0', ' ').trim();
   if (!resourceName) {
@@ -2028,6 +2189,9 @@ async function finalizeApprovedRequest(
   const existing = await findOpenIssuePrs(context, { owner: params.owner, repo: params.repo }, issue.number);
   if (existing.length) {
     await applyApprovedRequestState(context, params, eff);
+    if (autoApproved) {
+      await addApprovedLabelToPr(context, { owner: params.owner, repo: params.repo }, existing[0].number);
+    }
 
     const lead = [toStringTrim(approvalPrefix), toStringTrim(approvalComment)].filter(Boolean).join('. ');
     const body = lead ? `${lead}. PR already open: #${existing[0].number}` : `PR already open: #${existing[0].number}`;
@@ -2042,6 +2206,10 @@ async function finalizeApprovedRequest(
     const pr = await createRequestPrWithRecovery(context, params, issue, parsedFormData, template, resourceName);
 
     await applyApprovedRequestState(context, params, eff);
+
+    if (autoApproved) {
+      await addApprovedLabelToPr(context, { owner: params.owner, repo: params.repo }, pr.number);
+    }
 
     const lead = [toStringTrim(approvalPrefix), toStringTrim(approvalComment)].filter(Boolean).join('. ');
     const body = lead ? `${lead}. Opened PR: #${pr.number}` : `Opened PR: #${pr.number}`;
@@ -2085,7 +2253,11 @@ async function maybeHandleApprovalDecision(
   );
 
   if (decision.status === 'approved') {
-    await finalizeApprovedRequest(context, params, issue, template, parsedFormData, '', toStringTrim(decision.comment));
+    await finalizeApprovedRequest(context, params, issue, template, parsedFormData, {
+      approvalPrefix: '',
+      approvalComment: decision.comment,
+      autoApproved: true,
+    });
     return 'approved';
   }
 
@@ -2114,12 +2286,14 @@ async function maybeHandleDirectPrApprovalForMerge(
   parsedFormData: FormData,
   pr: PullRequestLike
 ): Promise<ApprovalHandlingResult> {
+  const requestAuthorId = await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
   const decision = normalizeApprovalDecision(
     await runApprovalHook(context, repoInfo, {
       requestType: resolveEffectiveRequestType(template, parsedFormData),
       namespace: toStringTrim(parsedFormData['namespace'] || parsedFormData['identifier']),
       resourceName: extractResourceNameFromForm(parsedFormData, template),
       formData: parsedFormData,
+      requestAuthorId,
       issue,
     })
   );
@@ -2128,6 +2302,7 @@ async function maybeHandleDirectPrApprovalForMerge(
     const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
     if (!approved) return 'continue';
 
+    await addApprovedLabelToPr(context, repoInfo, pr.number);
     await applyApprovedRequestState(context, issueParams, resolveEffectiveConstants(context));
     return 'approved';
   }
@@ -2435,7 +2610,6 @@ async function processIssueEvent(
       }
       return;
     }
-
     log(context, 'error', { err: msg }, 'Error loading template in issues handler');
 
     const userMsg = buildTemplateLoadErrorMessage(msg);
@@ -2671,7 +2845,9 @@ async function handleApprovalComment(
     );
   }
 
-  await finalizeApprovedRequest(context, params, issue, template, parsedFormData, `Approved by @${commenter}`);
+  await finalizeApprovedRequest(context, params, issue, template, parsedFormData, {
+    approvalPrefix: `Approved by @${commenter}`,
+  });
 }
 
 async function handleAuthorUpdateComment(
@@ -4148,7 +4324,7 @@ export default function requestHandler(app: Probot): void {
             context,
             { owner: ownerLogin, repo: repoName, issue_number: prNumber },
             {
-              tagPrefix: 'nsreq:ci-validation:',
+              tagPrefix: 'nsreq:ci-validation',
               collapseBody: 'Validation issues resolved.',
               classifier: 'RESOLVED',
             }
@@ -4242,14 +4418,14 @@ export default function requestHandler(app: Probot): void {
           byFile.set(file, arr);
         }
 
-        const currentCiTags = Array.from(byFile.keys()).map((file) => `nsreq:ci-validation:${normalizeKey(file)}`);
+        const currentCiTags = ['nsreq:ci-validation'];
 
         for (const prNumber of prNumbers) {
           await collapseBotCommentsByPrefix(
             context,
             { owner: ownerLogin, repo: repoName, issue_number: prNumber },
             {
-              tagPrefix: 'nsreq:ci-validation:',
+              tagPrefix: 'nsreq:ci-validation',
               keepTags: currentCiTags,
               collapseBody: 'Validation issues resolved.',
               classifier: 'RESOLVED',
@@ -4257,20 +4433,22 @@ export default function requestHandler(app: Probot): void {
           );
         }
 
-        for (const [file, msgs] of byFile.entries()) {
-          for (const prNumber of prNumbers) {
-            const body = buildRegistryValidationPrCommentBody(file, msgs);
-            if (!body) continue;
+        const body = buildRegistryValidationAggregatePrCommentBody(byFile);
+        if (!body) break;
 
-            if (DBG) {
-              log(context, 'debug', { prNumber, file, bodyLen: body.length }, 'dbg:checks:posting PR comment');
-            }
-
-            // Use per-file tag to avoid overwriting when multiple files fail.
-            await postOnce(context, { owner: ownerLogin, repo: repoName, issue_number: prNumber }, body, {
-              minimizeTag: `nsreq:ci-validation:${normalizeKey(file)}`,
-            });
+        for (const prNumber of prNumbers) {
+          if (DBG) {
+            log(
+              context,
+              'debug',
+              { prNumber, files: Array.from(byFile.keys()), bodyLen: body.length },
+              'dbg:checks:posting PR comment'
+            );
           }
+
+          await postOnce(context, { owner: ownerLogin, repo: repoName, issue_number: prNumber }, body, {
+            minimizeTag: 'nsreq:ci-validation',
+          });
         }
 
         break; // avoid spamming multiple runs/suite events

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -157,6 +157,14 @@ type MachineReadableIssue = Readonly<{
   filePath?: string;
 }>;
 
+type RegistryValidationMachineReadableSource = Readonly<{
+  filePath: string;
+  message: string;
+  schemaPath?: string;
+}>;
+
+type SchemaFieldAliasLookup = Map<string, string>;
+
 function normalizeMachineReadableIssues(value: unknown): MachineReadableIssue[] {
   const items = Array.isArray(value) ? value : [];
   const out: MachineReadableIssue[] = [];
@@ -222,15 +230,140 @@ function singleMachineReadableIssue(field: string, message: string, filePath = '
     : [];
 }
 
-function buildRegistryValidationMachineReadableIssues(filePath: string, messages: string[]): MachineReadableIssue[] {
-  const out: MachineReadableIssue[] = [];
-  const normalizedFilePath = toStringTrim(filePath);
+const SCHEMA_FIELD_ALIAS_CACHE = new Map<string, Promise<SchemaFieldAliasLookup>>();
 
-  for (const raw of messages || []) {
-    const message = normalizeMsg(raw);
+function normalizeSchemaFieldAlias(value: unknown): string {
+  const raw = toStringTrim(value);
+  if (!raw) return '';
+
+  return raw
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function addSchemaFieldAlias(lookup: SchemaFieldAliasLookup, aliasValue: unknown, propertyName: string): void {
+  const alias = normalizeSchemaFieldAlias(aliasValue);
+  if (!alias || lookup.has(alias)) return;
+
+  lookup.set(alias, propertyName);
+
+  if (alias.endsWith('s') && alias.length > 1) {
+    const singular = alias.slice(0, -1);
+    if (singular && !lookup.has(singular)) lookup.set(singular, propertyName);
+  } else {
+    const plural = `${alias}s`;
+    if (!lookup.has(plural)) lookup.set(plural, propertyName);
+  }
+}
+
+function collectSchemaFieldAliasesForProperty(
+  propertyName: string,
+  propertyDef: unknown,
+  lookup: SchemaFieldAliasLookup
+): void {
+  addSchemaFieldAlias(lookup, propertyName, propertyName);
+  if (!isPlainObject(propertyDef)) return;
+
+  addSchemaFieldAlias(lookup, propertyDef['title'], propertyName);
+  addSchemaFieldAlias(lookup, propertyDef['x-form-field'], propertyName);
+  collectSchemaFieldAliases(propertyDef, lookup);
+}
+
+function collectSchemaFieldAliasesFromProperties(props: Record<string, unknown>, lookup: SchemaFieldAliasLookup): void {
+  for (const [propertyName, propertyDef] of Object.entries(props)) {
+    collectSchemaFieldAliasesForProperty(propertyName, propertyDef, lookup);
+  }
+}
+
+function collectSchemaFieldAliasesFromArray(items: unknown[], lookup: SchemaFieldAliasLookup): void {
+  for (const item of items) {
+    collectSchemaFieldAliases(item, lookup);
+  }
+}
+
+function collectSchemaFieldAliases(schemaObj: unknown, lookup: SchemaFieldAliasLookup): void {
+  if (!isPlainObject(schemaObj)) return;
+
+  const props = isPlainObject(schemaObj['properties']) ? schemaObj['properties'] : null;
+  if (props) collectSchemaFieldAliasesFromProperties(props, lookup);
+
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const items = schemaObj[key];
+    if (!Array.isArray(items)) continue;
+
+    collectSchemaFieldAliasesFromArray(items, lookup);
+  }
+
+  const defs = isPlainObject(schemaObj['$defs']) ? schemaObj['$defs'] : null;
+  if (defs) {
+    for (const value of Object.values(defs)) {
+      collectSchemaFieldAliases(value, lookup);
+    }
+  }
+}
+
+async function loadSchemaFieldAliasLookup(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  schemaPath: string
+): Promise<SchemaFieldAliasLookup> {
+  const normalizedPath = toStringTrim(schemaPath).replace(/^\.\//, '');
+  if (!normalizedPath) return new Map<string, string>();
+
+  const cached = SCHEMA_FIELD_ALIAS_CACHE.get(normalizedPath);
+  if (cached) return await cached;
+
+  const pending = (async (): Promise<SchemaFieldAliasLookup> => {
+    const raw = await readRepoFileText(context, repoInfo, normalizedPath);
+    if (!raw) return new Map<string, string>();
+
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      const lookup = new Map<string, string>();
+      collectSchemaFieldAliases(parsed, lookup);
+      return lookup;
+    } catch {
+      return new Map<string, string>();
+    }
+  })();
+
+  SCHEMA_FIELD_ALIAS_CACHE.set(normalizedPath, pending);
+  return await pending;
+}
+
+async function resolveMachineReadableRegistryField(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  fieldHint: string,
+  schemaPath?: string
+): Promise<string> {
+  const fallback = toStringTrim(fieldHint) || 'details';
+  const normalizedSchemaPath = toStringTrim(schemaPath);
+
+  if (!normalizedSchemaPath || fallback === 'details') return fallback;
+
+  const lookup = await loadSchemaFieldAliasLookup(context, repoInfo, normalizedSchemaPath);
+  if (!lookup.size) return fallback;
+
+  return lookup.get(normalizeSchemaFieldAlias(fallback)) || fallback;
+}
+
+async function buildRegistryValidationMachineReadableIssues(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  items: RegistryValidationMachineReadableSource[]
+): Promise<MachineReadableIssue[]> {
+  const out: MachineReadableIssue[] = [];
+
+  for (const item of items || []) {
+    const message = normalizeMsg(item.message);
     if (!message) continue;
 
-    const field = extractFieldFromMsg(raw) || 'details';
+    const fieldHint = extractFieldFromMsg(item.message) || 'details';
+    const field = await resolveMachineReadableRegistryField(context, repoInfo, fieldHint, item.schemaPath);
+    const normalizedFilePath = toStringTrim(item.filePath);
+
     out.push({
       field,
       message,
@@ -825,31 +958,36 @@ function appendRegistryValidationSections(lines: string[], grouped: Map<string, 
   }
 }
 
-function appendRegistryValidationFileSection(
-  lines: string[],
-  machineReadable: MachineReadableIssue[],
-  filePath: string,
-  messages: string[]
-): void {
-  lines.push(`### ${filePath}`, '');
+function appendRegistryValidationFileSection(lines: string[], filePath: string, messages: string[]): void {
+  lines.push(`### File: \`${filePath}\``, '');
   appendRegistryValidationSections(lines, groupRegistryValidationMessages(messages), '####');
-  machineReadable.push(...buildRegistryValidationMachineReadableIssues(filePath, messages));
 }
 
-function buildRegistryValidationPrCommentBody(filePath: string, messages: string[]): string {
-  const lines: string[] = [`## Detected issues: ${filePath}`, ''];
+async function buildRegistryValidationPrCommentBody(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  filePath: string,
+  messages: string[],
+  machineReadableSources: RegistryValidationMachineReadableSource[]
+): Promise<string> {
+  const lines: string[] = ['## Detected issues', '', `### File: \`${filePath}\``, ''];
 
   appendRegistryValidationSections(lines, groupRegistryValidationMessages(messages), '###');
 
   const body = lines.join('\n').trimEnd();
-  const machineReadable = buildRegistryValidationMachineReadableIssues(filePath, messages);
+  const machineReadable = await buildRegistryValidationMachineReadableIssues(context, repoInfo, machineReadableSources);
 
   return `${body}
 
 ${buildMachineReadableMetadataBlock(machineReadable)}`;
 }
 
-function buildRegistryValidationAggregatePrCommentBody(byFile: Map<string, string[]>): string {
+async function buildRegistryValidationAggregatePrCommentBody(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  byFile: Map<string, string[]>,
+  machineReadableSources: RegistryValidationMachineReadableSource[]
+): Promise<string> {
   const entries = Array.from(byFile.entries())
     .filter(([, messages]) => Array.isArray(messages) && messages.length > 0)
     .sort(([a], [b]) => a.localeCompare(b));
@@ -857,15 +995,22 @@ function buildRegistryValidationAggregatePrCommentBody(byFile: Map<string, strin
   if (!entries.length) return '';
   if (entries.length === 1) {
     const [filePath, messages] = entries[0];
-    return buildRegistryValidationPrCommentBody(filePath, messages);
+    return await buildRegistryValidationPrCommentBody(
+      context,
+      repoInfo,
+      filePath,
+      messages,
+      machineReadableSources.filter((item) => toStringTrim(item.filePath) === toStringTrim(filePath))
+    );
   }
 
   const lines: string[] = ['## Detected issues', ''];
-  const machineReadable: MachineReadableIssue[] = [];
 
   for (const [filePath, messages] of entries) {
-    appendRegistryValidationFileSection(lines, machineReadable, filePath, messages);
+    appendRegistryValidationFileSection(lines, filePath, messages);
   }
+
+  const machineReadable = await buildRegistryValidationMachineReadableIssues(context, repoInfo, machineReadableSources);
 
   return `${lines.join('\n').trimEnd()}
 
@@ -4409,14 +4554,22 @@ export default function requestHandler(app: Probot): void {
         if (!relevant.length) continue;
 
         const byFile = new Map<string, string[]>();
+        const machineReadableSources: RegistryValidationMachineReadableSource[] = [];
         for (const a of relevant) {
           const file = toStringTrim(a.path) || 'unknown file';
           const rawMsg = toStringTrim(a.message) || toStringTrim(a.raw_details);
           const msg = stripRegistrySuffix(rawMsg);
           if (!msg) continue;
+          const schemaMeta = /\bschema=([^\s\]]+)/.exec(rawMsg);
           const arr = byFile.get(file) ?? [];
           arr.push(msg);
           byFile.set(file, arr);
+
+          machineReadableSources.push({
+            filePath: file,
+            message: msg,
+            schemaPath: schemaMeta?.[1] ? toStringTrim(schemaMeta[1]) : '',
+          });
         }
 
         const currentCiTags = ['nsreq:ci-validation'];
@@ -4434,7 +4587,12 @@ export default function requestHandler(app: Probot): void {
           );
         }
 
-        const body = buildRegistryValidationAggregatePrCommentBody(byFile);
+        const body = await buildRegistryValidationAggregatePrCommentBody(
+          context,
+          { owner: ownerLogin, repo: repoName },
+          byFile,
+          machineReadableSources
+        );
         if (!body) break;
 
         for (const prNumber of prNumbers) {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -190,7 +190,7 @@ function buildMachineReadableMetadataBlock(issues: MachineReadableIssue[]): stri
   if (!normalized.length) return '';
 
   return `
-
+##
 <details>
 <summary>Show as JSON (Robots Friendly)</summary>
 
@@ -2800,7 +2800,6 @@ async function handleApprovalComment(
     const normalizedIssues = (reval.validationIssues || []).map((issue) => ({
       field: toStringTrim(issue.path) || 'details',
       message: toStringTrim(issue.message),
-      ...(issue.path ? { filePath: toStringTrim(issue.path) } : {}),
     }));
 
     await postOnce(
@@ -2955,7 +2954,6 @@ async function handleAuthorUpdateComment(
           (reval.validationIssues || []).map((validationIssue) => ({
             field: toStringTrim(validationIssue.path) || 'details',
             message: toStringTrim(validationIssue.message),
-            ...(validationIssue.path ? { filePath: toStringTrim(validationIssue.path) } : {}),
           }))
         )
       ),
@@ -3297,7 +3295,6 @@ ${mentions}`,
           (reval.validationIssues || []).map((validationIssue) => ({
             field: toStringTrim(validationIssue.path) || 'details',
             message: toStringTrim(validationIssue.message),
-            ...(validationIssue.path ? { filePath: toStringTrim(validationIssue.path) } : {}),
           }))
         )
       ),

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1686,34 +1686,38 @@ async function resolvePullRequestRequestAuthorId(
   let page = 1;
   let lastCommitter = '';
 
-  while (true) {
-    const res = await (
-      context.octokit.pulls as unknown as {
-        listCommits: (args: {
-          owner: string;
-          repo: string;
-          pull_number: number;
-          per_page?: number;
-          page?: number;
-        }) => Promise<{ data?: PullRequestCommitLike[] }>;
-      }
-    ).listCommits({
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      pull_number: pr.number,
-      per_page: 100,
-      page,
-    });
+  try {
+    while (true) {
+      const res = await (
+        context.octokit.pulls as unknown as {
+          listCommits: (args: {
+            owner: string;
+            repo: string;
+            pull_number: number;
+            per_page?: number;
+            page?: number;
+          }) => Promise<{ data?: PullRequestCommitLike[] }>;
+        }
+      ).listCommits({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        pull_number: pr.number,
+        per_page: 100,
+        page,
+      });
 
-    const commits = Array.isArray(res?.data) ? res.data : [];
-    if (!commits.length) break;
+      const commits = Array.isArray(res?.data) ? res.data : [];
+      if (!commits.length) break;
 
-    const last = commits.at(-1);
-    lastCommitter = normalizeLogin(last?.committer?.login) || normalizeLogin(last?.author?.login) || lastCommitter;
+      const last = commits.at(-1);
+      lastCommitter = normalizeLogin(last?.committer?.login) || normalizeLogin(last?.author?.login) || lastCommitter;
 
-    if (commits.length < 100) break;
-    page += 1;
-    if (page > 20) break;
+      if (commits.length < 100) break;
+      page += 1;
+      if (page > 20) break;
+    }
+  } catch {
+    return lastCommitter || normalizeLogin(pr.user?.login);
   }
 
   return lastCommitter || normalizeLogin(pr.user?.login);

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -544,19 +544,51 @@ function normalizeApprovalHookErrors(value: unknown): readonly {
   return out;
 }
 
+function normalizeLoginValue(value: unknown): string {
+  return toStringSafe(value).replace(/^@+/, '').trim();
+}
+
+function uniqLogins(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values || []) {
+    const login = normalizeLoginValue(value);
+    if (!login) continue;
+
+    const key = login.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(login);
+  }
+
+  return out;
+}
+
+function toLoginArray(value: unknown): string[] {
+  return Array.isArray(value) ? uniqLogins(value.map((item) => normalizeLoginValue(item)).filter(Boolean)) : [];
+}
+
 function getApprovalHookApprovers(context: ValidationContext, requestType: string): string[] {
   const cfg = context.resourceBotConfig ?? {};
+  const workflow = isPlainObject(cfg['workflow']) ? cfg['workflow'] : {};
+
+  const fallbackApprovers = uniqLogins([
+    ...toLoginArray(workflow['approvers']),
+    ...toLoginArray(workflow['approversPool']),
+  ]);
+
   const reqs = isPlainObject(cfg.requests) ? cfg.requests : {};
-  const entry = isPlainObject(reqs[requestType]) ? (reqs[requestType] as Record<string, unknown>) : null;
+  const entry = isPlainObject(reqs[requestType]) ? reqs[requestType] : null;
 
-  const localApprovers = Array.isArray(entry?.['approvers'])
-    ? entry['approvers'].map((v) => toStringSafe(v)).filter(Boolean)
-    : [];
+  if (!entry) return fallbackApprovers;
 
-  if (localApprovers.length) return localApprovers;
+  const hasOwnApprovers = Array.isArray(entry['approvers']);
+  const hasOwnApproversPool = Array.isArray(entry['approversPool']);
 
-  const workflow = isPlainObject(cfg.workflow) ? cfg.workflow : {};
-  return Array.isArray(workflow['approvers']) ? workflow['approvers'].map((v) => toStringSafe(v)).filter(Boolean) : [];
+  if (!hasOwnApprovers && !hasOwnApproversPool) return fallbackApprovers;
+
+  return uniqLogins([...toLoginArray(entry['approvers']), ...toLoginArray(entry['approversPool'])]);
 }
 
 function buildApprovalHookData(
@@ -2615,11 +2647,12 @@ function buildApprovalHookArgs(
     resourceName?: string | null;
     formData: FormData;
     issue: IssueLike;
+    requestAuthorId?: string | null;
   }
 ): OnApprovalArgs {
   const namespace = resolveApprovalNamespace(args);
   const resourceName = resolveApprovalResourceName(args, namespace);
-  const requesterId = toStringSafe(args.issue?.user?.login);
+  const requesterId = toStringSafe(args.requestAuthorId) || toStringSafe(args.issue?.user?.login);
 
   return {
     requestType: toStringSafe(args.requestType),
@@ -2715,6 +2748,7 @@ export async function runApprovalHook(
     resourceName?: string | null;
     formData: FormData;
     issue: IssueLike;
+    requestAuthorId?: string | null;
   }
 ): Promise<ApprovalHookDecision> {
   await ensureStaticConfigLoaded(context);

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -655,6 +655,75 @@ function buildLabelToFieldIdMap(template: TemplateLike): Map<string, string> {
   return out;
 }
 
+function getTemplateFieldLabel(template: TemplateLike, fieldId: unknown): string {
+  const id = toStringSafe(fieldId);
+  if (!id) return '';
+
+  const fields = Array.isArray(template?.body) ? template.body : [];
+  for (const field of fields) {
+    if (toStringSafe(field?.id) !== id) continue;
+
+    const label = toStringSafe(field?.attributes?.label);
+    return label;
+  }
+
+  return '';
+}
+
+function getSchemaMappedFieldName(schemaObj: unknown, fieldId: unknown): string {
+  const id = toStringSafe(fieldId);
+  if (!id) return '';
+
+  const schemaProps = getObjectProp(schemaObj, 'properties');
+  if (!schemaProps) return '';
+
+  if (Object.hasOwn(schemaProps, id)) {
+    const propDef = schemaProps[id];
+    if (isPlainObject(propDef)) {
+      const mappedFormFieldId = toStringSafe(propDef['x-form-field']);
+      if (mappedFormFieldId) return mappedFormFieldId;
+    }
+
+    return id;
+  }
+
+  for (const [propName, propDef] of Object.entries(schemaProps)) {
+    if (!isPlainObject(propDef)) continue;
+    if (toStringSafe(propDef['x-form-field']) !== id) continue;
+    return propName;
+  }
+
+  return '';
+}
+
+function resolveMachineReadableFieldName(
+  template: TemplateLike,
+  schemaObj: unknown,
+  fieldId: unknown,
+  fallback = 'details'
+): string {
+  const id = toStringSafe(fieldId);
+  if (!id) return fallback;
+
+  const templateLabel = getTemplateFieldLabel(template, id);
+  if (templateLabel) return templateLabel;
+
+  const schemaFieldName = getSchemaMappedFieldName(schemaObj, id);
+  if (schemaFieldName) {
+    const mappedTemplateLabel = getTemplateFieldLabel(template, schemaFieldName);
+    if (mappedTemplateLabel) return mappedTemplateLabel;
+
+    const reverseMappedSchemaFieldName = getSchemaMappedFieldName(schemaObj, schemaFieldName);
+    if (reverseMappedSchemaFieldName && reverseMappedSchemaFieldName !== schemaFieldName) {
+      return reverseMappedSchemaFieldName;
+    }
+
+    return schemaFieldName;
+  }
+
+  return id || fallback;
+}
+
 function parseRuleValidationIssue(raw: string): ValidationIssue | null {
   const m = /^([A-Za-z0-9_.-]+)\s*:\s*(.+)$/.exec(raw);
   if (!m?.[1] || !m?.[2]) return null;
@@ -665,13 +734,14 @@ function parseRuleValidationIssue(raw: string): ValidationIssue | null {
 function buildMachineReadableValidationIssues(
   buckets: ValidationBuckets,
   template: TemplateLike,
+  schemaObj: unknown,
   ajvErrors: AjvErrorLike[] = []
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const labelToFieldId = buildLabelToFieldIdMap(template);
   const { idToLabel } = buildTemplateLabelMaps(template);
   const primaryFieldId = guessPrimaryFieldId(template) || 'identifier';
-  const primaryLabel = idToLabel.get(primaryFieldId) || humanizeKey(primaryFieldId);
+  const primaryLabel = resolveMachineReadableFieldName(template, schemaObj, primaryFieldId, 'details');
   const ajvMessages = new Set<string>();
 
   for (const err of Array.isArray(ajvErrors) ? ajvErrors : []) {
@@ -683,14 +753,23 @@ function buildMachineReadableValidationIssues(
     const fieldIds = fieldIdsFromAjvError(err);
     if (fieldIds.length) {
       for (const fieldId of fieldIds) {
-        const issue = makeValidationIssue(fieldId, msg, 'schema');
+        const issue = makeValidationIssue(
+          resolveMachineReadableFieldName(template, schemaObj, fieldId, 'details'),
+          msg,
+          'details'
+        );
         if (issue) issues.push(issue);
       }
       continue;
     }
 
     const instancePath = toStringSafe(err?.instancePath).replace(/^\/+/, '');
-    const issue = makeValidationIssue(instancePath || 'schema', msg, 'schema');
+    const instanceField = instancePath.split('/').find(Boolean) || '';
+    const issue = makeValidationIssue(
+      resolveMachineReadableFieldName(template, schemaObj, instanceField, 'details'),
+      msg,
+      'details'
+    );
     if (issue) issues.push(issue);
   }
 
@@ -698,31 +777,39 @@ function buildMachineReadableValidationIssues(
     const requiredMatch = /^Required field is missing in form:\s*(.+)$/i.exec(raw);
     if (requiredMatch?.[1]) {
       const label = toStringSafe(requiredMatch[1]).toLowerCase();
-      const fieldId = labelToFieldId.get(label) || primaryFieldId;
-      const issue = makeValidationIssue(fieldId, 'Required field is missing.', 'form');
+      const fieldName = resolveMachineReadableFieldName(
+        template,
+        schemaObj,
+        labelToFieldId.get(label) || '',
+        requiredMatch[1]
+      );
+      const issue = makeValidationIssue(fieldName, 'Required field is missing.', requiredMatch[1]);
       if (issue) issues.push(issue);
       continue;
     }
 
-    const issue = makeValidationIssue('form', raw, 'form');
+    const issue = makeValidationIssue('details', raw, 'details');
     if (issue) issues.push(issue);
   }
 
   for (const raw of dedupe(buckets.rules || [])) {
     const structured = parseRuleValidationIssue(raw);
     if (structured) {
-      issues.push(structured);
+      issues.push({
+        ...structured,
+        path: resolveMachineReadableFieldName(template, schemaObj, structured.path, structured.path || 'details'),
+      });
       continue;
     }
 
     const inferredLabel = inferFieldLabelFromRuleMsg(raw, primaryLabel, idToLabel);
-    const inferredFieldId = inferredLabel ? labelToFieldId.get(inferredLabel.toLowerCase()) || 'rules' : 'rules';
-    const issue = makeValidationIssue(inferredFieldId, raw, 'rules');
+    const inferredFieldName = inferredLabel || 'details';
+    const issue = makeValidationIssue(inferredFieldName, raw, inferredFieldName);
     if (issue) issues.push(issue);
   }
 
   for (const raw of dedupe(buckets.registry || [])) {
-    const issue = makeValidationIssue(primaryFieldId, raw, primaryFieldId);
+    const issue = makeValidationIssue(primaryLabel, raw, primaryLabel);
     if (issue) issues.push(issue);
   }
 
@@ -730,7 +817,7 @@ function buildMachineReadableValidationIssues(
     const normalized = normalizeAjvMessage(raw);
     if (ajvMessages.has(normalized)) continue;
 
-    const issue = makeValidationIssue('schema', raw, 'schema');
+    const issue = makeValidationIssue('details', raw, 'details');
     if (issue) issues.push(issue);
   }
 
@@ -1091,8 +1178,6 @@ function formatUnifiedIssues(
     if (ajvMsgSet.has(msg)) continue;
     addGrouped(grouped, 'General', `[schema] ${msg}`);
   }
-
-  if (!grouped.size) return '';
   const ordered = orderGroupedKeys(labelOrder, grouped);
   return ordered
     .map((k) => {
@@ -1135,7 +1220,6 @@ function pickIdentifierFromFields(template: TemplateLike, formData: FormData): s
   const fields = Array.isArray(template.body) ? template.body : [];
 
   for (const field of fields) {
-    if (!field?.id) continue;
     const id = String(field.id).trim();
     const required = field?.validations?.required === true;
     const label = toStringSafe(field?.attributes?.label).toLowerCase();
@@ -1407,13 +1491,21 @@ function buildValidateRequestIssueResult(
   errors: string[],
   buckets: ValidationBuckets,
   template: TemplateLike,
-  ajvErrorsForUnifiedFormat: AjvErrorLike[],
-  formData: FormData,
-  namespace: string,
-  nsType: string
+  options: {
+    schemaObj: unknown;
+    ajvErrorsForUnifiedFormat: AjvErrorLike[];
+    formData: FormData;
+    namespace: string;
+    nsType: string;
+  }
 ): ValidateRequestIssueResult {
-  const unified = formatUnifiedIssues(buckets, template, ajvErrorsForUnifiedFormat);
-  const validationIssues = buildMachineReadableValidationIssues(buckets, template, ajvErrorsForUnifiedFormat);
+  const unified = formatUnifiedIssues(buckets, template, options.ajvErrorsForUnifiedFormat);
+  const validationIssues = buildMachineReadableValidationIssues(
+    buckets,
+    template,
+    options.schemaObj,
+    options.ajvErrorsForUnifiedFormat
+  );
 
   return {
     errors,
@@ -1421,10 +1513,10 @@ function buildValidateRequestIssueResult(
     errorsFormatted: unified || formatBuckets(buckets),
     errorsFormattedSingle: unified || formatFirstBucket(buckets),
     validationIssues,
-    formData,
+    formData: options.formData,
     template,
-    namespace,
-    nsType,
+    namespace: options.namespace,
+    nsType: options.nsType,
   };
 }
 
@@ -1432,13 +1524,20 @@ function buildValidateRequestIssueErrorResult(
   errors: string[],
   buckets: ValidationBuckets,
   template: TemplateLike,
+  schemaObj: unknown,
   message: string,
   targetBucket: string[]
 ): ValidateRequestIssueResult {
   targetBucket.push(message);
   errors.push(message);
 
-  return buildValidateRequestIssueResult(errors, buckets, template, [], {}, '', '');
+  return buildValidateRequestIssueResult(errors, buckets, template, {
+    schemaObj,
+    ajvErrorsForUnifiedFormat: [],
+    formData: {},
+    namespace: '',
+    nsType: '',
+  });
 }
 
 function resolveTemplateAndRequestType(
@@ -1463,6 +1562,7 @@ function resolveTemplateAndRequestType(
           errors,
           buckets,
           template,
+          null,
           `Invalid Partner Namespace 'Request Type' selection '${toStringSafe(selected) || ''}'. Expected one of: authority, system, subContext.`,
           buckets.form
         ),
@@ -1476,6 +1576,7 @@ function resolveTemplateAndRequestType(
           errors,
           buckets,
           template,
+          null,
           `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests has no such entry.`,
           buckets.schema
         ),
@@ -1489,6 +1590,7 @@ function resolveTemplateAndRequestType(
           errors,
           buckets,
           template,
+          null,
           `Configuration error: Partner Namespace selection maps to '${mapped}', but cfg.requests['${mapped}'].schema is empty.`,
           buckets.schema
         ),
@@ -1520,6 +1622,7 @@ function resolveTemplateAndRequestType(
         errors,
         buckets,
         template,
+        null,
         'Configuration error: template missing _meta.requestType (expected cfg.requests mapping via loadTemplate).',
         buckets.schema
       ),
@@ -1533,6 +1636,7 @@ function resolveTemplateAndRequestType(
         errors,
         buckets,
         template,
+        null,
         `Configuration error: unknown requestType '${requestType}' (missing cfg.requests entry).`,
         buckets.schema
       ),
@@ -2329,6 +2433,7 @@ export async function validateRequestIssue(
   // 6) Resolve primary identifier
   const schemaPathForId = String(template?._meta?.schema || '').trim();
   const schemaObjForId = await loadSchemaFromRepoOrLocal(context, owner, repo, schemaPathForId);
+  let schemaObjForValidation: unknown = schemaObjForId;
 
   const rawResolved = resolvePrimaryIdFromTemplate(template, formData, schemaObjForId) || '';
   const rawIdOrNs = rawResolved.replaceAll('\u00a0', ' ').trim();
@@ -2338,7 +2443,13 @@ export async function validateRequestIssue(
     buckets.form.push(msg);
     errors.push(msg);
 
-    return buildValidateRequestIssueResult(errors, buckets, template, [], {}, '', '');
+    return buildValidateRequestIssueResult(errors, buckets, template, {
+      schemaObj: schemaObjForValidation,
+      ajvErrorsForUnifiedFormat: [],
+      formData: {},
+      namespace: '',
+      nsType: '',
+    });
   }
 
   // 7) Normalize formData
@@ -2390,6 +2501,7 @@ export async function validateRequestIssue(
 
       const schemaObj = await loadSchemaFromRepoOrLocal(context, owner, repo, schemaPath);
       if (!schemaObj) throw new Error(`Schema not found for path: ${schemaPath}`);
+      schemaObjForValidation = schemaObj;
 
       // enforce identifier mapping consistency
       const schemaProps = getObjectProp(schemaObj, 'properties') || {};
@@ -2578,15 +2690,13 @@ export async function validateRequestIssue(
 
   const nsType = inferNsType(requestType);
 
-  return buildValidateRequestIssueResult(
-    errors,
-    buckets,
-    template,
+  return buildValidateRequestIssueResult(errors, buckets, template, {
+    schemaObj: schemaObjForValidation,
     ajvErrorsForUnifiedFormat,
-    normalizedFormData,
+    formData: normalizedFormData,
     namespace,
-    nsType
-  );
+    nsType,
+  });
 }
 
 function logApprovalHookMessages(

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -90,6 +90,7 @@ type PullsListFn = (args: unknown) => Promise<{ data: unknown[] }>;
 type PullsUpdateFn = (args: unknown) => Promise<unknown>;
 type PullsCreateReviewFn = (args: unknown) => Promise<unknown>;
 type PullsListFilesFn = (args: unknown) => Promise<{ data: unknown[] }>;
+type PullsListCommitsFn = (args: unknown) => Promise<{ data: unknown[] }>;
 
 type ChecksListAnnotationsFn = (args: any) => Promise<{ data: any[] }>;
 type ChecksListForSuiteFn = (args: any) => Promise<{ data: { check_runs: any[] } }>;
@@ -143,6 +144,7 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
         ),
         list: jest.fn<PullsListFn>(() => Promise.resolve({ data: [] })),
         listFiles: jest.fn<PullsListFilesFn>(() => Promise.resolve({ data: [] })),
+        listCommits: jest.fn<PullsListCommitsFn>(() => Promise.resolve({ data: [] })),
         createReview: jest.fn<PullsCreateReviewFn>(() => Promise.resolve({})),
         update: jest.fn<PullsUpdateFn>(() => Promise.resolve({})),
       },
@@ -903,6 +905,67 @@ test('check_suite.completed failure posts PR comment when registry-validate anno
   expect(String(body)).toContain("Property 'contact' is required for System.");
 
   expect(tryMergeIfGreen).not.toHaveBeenCalled();
+});
+
+test('check_suite.completed failure aggregates multi-file registry issues into one machine-readable PR comment', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['check_suite.completed'][0];
+
+  const ctx = mkCheckSuiteContext({
+    event: 'check_suite.completed',
+    conclusion: 'failure',
+    sha: 'sha-aggregate',
+    ownerLogin: 'o1',
+    repoName: 'r1',
+    withCachedConfig: true,
+  });
+
+  ctx.payload.check_suite.id = 501;
+  ctx.payload.check_suite.pull_requests = [{ number: 77 }];
+
+  ctx.octokit.checks.listForSuite.mockResolvedValueOnce({
+    data: { check_runs: [{ id: 9002, html_url: 'https://example/check/9002' }] },
+  });
+
+  ctx.octokit.checks.listAnnotations.mockResolvedValueOnce({
+    data: [
+      {
+        path: 'data/namespaces/sap.css.yaml',
+        title: 'registry-validate systemNamespace',
+        message:
+          "Property 'contact' is required for System. [file=data/namespaces/sap.css.yaml schema=.github/registry-bot/request-schemas/system-namespace.schema.json requestType=systemNamespace]",
+        annotation_level: 'failure',
+      },
+      {
+        path: 'data/products/product-one.yaml',
+        title: 'registry-validate product',
+        message:
+          '/identifier MUST match pattern. [file=data/products/product-one.yaml schema=.github/registry-bot/request-schemas/product.schema.json requestType=product]',
+        annotation_level: 'failure',
+      },
+    ],
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValueOnce({
+    data: { html_url: 'https://github.tools.sap/o1/r1/pull/77' },
+  });
+
+  await handler(ctx);
+
+  expect(postOnce).toHaveBeenCalledTimes(1);
+  const [, params, body, options] = (postOnce as jest.Mock).mock.calls[0];
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
+
+  expect(params).toEqual({ owner: 'o1', repo: 'r1', issue_number: 77 });
+  expect(options).toEqual(expect.objectContaining({ minimizeTag: 'nsreq:ci-validation' }));
+  expect(bodyText).toContain('## Detected issues');
+  expect(bodyText).toContain('### data/namespaces/sap.css.yaml');
+  expect(bodyText).toContain('### data/products/product-one.yaml');
+  expect(bodyText).toContain('Show as JSON (Robots Friendly)');
+  expect(bodyText).toContain('"filePath": "data/namespaces/sap.css.yaml"');
+  expect(bodyText).toContain('"filePath": "data/products/product-one.yaml"');
 });
 
 test('check_suite.completed failure does nothing if there are no registry-validate annotations', async () => {
@@ -2155,6 +2218,9 @@ public
     });
 
     extractHashFromPrBody.mockReturnValueOnce('');
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'ignored-author' }, committer: { login: 'last-committer' } }],
+    });
     runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
 
     await handler(ctx);
@@ -2163,6 +2229,11 @@ public
     expect(tryMergeIfGreen).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 5, mergeMethod: 'squash' })
+    );
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({ requestAuthorId: 'last-committer' })
     );
     expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ['Approved'] }));
   });
@@ -2208,6 +2279,7 @@ public
     ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
       data: [
         { filename: 'resources/product-one.yaml', status: 'modified' },
+        { filename: '.github/workflows/review.yaml', status: 'modified' },
         { filename: 'README.md', status: 'modified' },
         { filename: 'resources/deleted.yaml', status: 'removed' },
       ],
@@ -2221,6 +2293,10 @@ public
         ).toString('base64'),
         encoding: 'base64',
       },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'ignored-author' }, committer: { login: 'direct-last-committer' } }],
     });
 
     runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved from standalone hook' } as any);
@@ -2240,6 +2316,7 @@ public
         requestType: 'product',
         namespace: 'product-one',
         resourceName: 'product-one',
+        requestAuthorId: 'direct-last-committer',
         formData: expect.objectContaining({
           identifier: 'product-one',
           namespace: 'product-one',
@@ -2887,5 +2964,95 @@ public
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
     expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR ignores non-registry yaml files during onApproval evaluation', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-non-registry-yaml',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 60,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/non-registry-yaml', sha: 'sha-non-registry-yaml' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [
+        { filename: 'resources/product-ok.yaml', status: 'modified' },
+        { filename: '.github/release.yml', status: 'modified' },
+      ],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from(
+          'type: product\nidentifier: product-ok\ntitle: Product OK\nvisibility: public\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ committer: { login: 'registry-committer' } }],
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.repos.getContent).toHaveBeenCalledTimes(1);
+    expect(ctx.octokit.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        path: 'resources/product-ok.yaml',
+        ref: 'feature/non-registry-yaml',
+      })
+    );
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({
+        requestAuthorId: 'registry-committer',
+        formData: expect.objectContaining({
+          identifier: 'product-ok',
+          title: 'Product OK',
+          visibility: 'public',
+        }),
+      })
+    );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 60, mergeMethod: 'squash' })
+    );
   });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -890,6 +890,27 @@ test('check_suite.completed failure posts PR comment when registry-validate anno
     ],
   });
 
+  ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+    if (path === '.github/registry-bot/request-schemas/system-namespace.schema.json') {
+      return {
+        data: {
+          content: Buffer.from(
+            JSON.stringify({
+              properties: {
+                contacts: {
+                  title: 'Contacts',
+                },
+              },
+            })
+          ).toString('base64'),
+          encoding: 'base64',
+        },
+      };
+    }
+
+    throw httpErr(404);
+  });
+
   ctx.octokit.pulls.get.mockResolvedValueOnce({
     data: { html_url: 'https://github.tools.sap/o1/r1/pull/42' },
   });
@@ -898,11 +919,13 @@ test('check_suite.completed failure posts PR comment when registry-validate anno
 
   expect(postOnce).toHaveBeenCalledTimes(1);
   const [, params, body] = (postOnce as jest.Mock).mock.calls[0];
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
 
   expect(params).toEqual({ owner: 'o1', repo: 'r1', issue_number: 42 });
-  expect(String(body)).toContain('## Detected issues: data/namespaces/sap.css.yaml');
-  expect(String(body)).toContain('### Contacts');
-  expect(String(body)).toContain("Property 'contact' is required for System.");
+  expect(bodyText).toContain('## Detected issues: data/namespaces/sap.css.yaml');
+  expect(bodyText).toContain('### Contacts');
+  expect(bodyText).toContain("Property 'contact' is required for System.");
+  expect(bodyText).toContain('"field": "contacts"');
 
   expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
@@ -942,10 +965,60 @@ test('check_suite.completed failure aggregates multi-file registry issues into o
         path: 'data/products/product-one.yaml',
         title: 'registry-validate product',
         message:
+          'Product Name is required. [file=data/products/product-one.yaml schema=.github/registry-bot/request-schemas/product.schema.json requestType=product]',
+        annotation_level: 'failure',
+      },
+      {
+        path: 'data/products/product-one.yaml',
+        title: 'registry-validate product',
+        message:
           '/identifier MUST match pattern. [file=data/products/product-one.yaml schema=.github/registry-bot/request-schemas/product.schema.json requestType=product]',
         annotation_level: 'failure',
       },
     ],
+  });
+
+  ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+    if (path === '.github/registry-bot/request-schemas/system-namespace.schema.json') {
+      return {
+        data: {
+          content: Buffer.from(
+            JSON.stringify({
+              properties: {
+                contacts: {
+                  title: 'Contacts',
+                },
+              },
+            })
+          ).toString('base64'),
+          encoding: 'base64',
+        },
+      };
+    }
+
+    if (path === '.github/registry-bot/request-schemas/product.schema.json') {
+      return {
+        data: {
+          content: Buffer.from(
+            JSON.stringify({
+              properties: {
+                title: {
+                  'title': 'Product Name',
+                  'x-form-field': 'title',
+                },
+                identifier: {
+                  'title': 'Product ID',
+                  'x-form-field': 'identifier',
+                },
+              },
+            })
+          ).toString('base64'),
+          encoding: 'base64',
+        },
+      };
+    }
+
+    throw httpErr(404);
   });
 
   ctx.octokit.pulls.get.mockResolvedValueOnce({
@@ -966,6 +1039,10 @@ test('check_suite.completed failure aggregates multi-file registry issues into o
   expect(bodyText).toContain('Show as JSON (Robots Friendly)');
   expect(bodyText).toContain('"filePath": "data/namespaces/sap.css.yaml"');
   expect(bodyText).toContain('"filePath": "data/products/product-one.yaml"');
+  expect(bodyText).toContain('"field": "contacts"');
+  expect(bodyText).toContain('"field": "title"');
+  expect(bodyText).toContain('"field": "identifier"');
+  expect(bodyText).toContain('#### Product name');
 });
 
 test('check_suite.completed failure does nothing if there are no registry-validate annotations', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -922,7 +922,7 @@ test('check_suite.completed failure posts PR comment when registry-validate anno
   const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
 
   expect(params).toEqual({ owner: 'o1', repo: 'r1', issue_number: 42 });
-  expect(bodyText).toContain('## Detected issues: data/namespaces/sap.css.yaml');
+  expect(bodyText).toContain('### File: `data/namespaces/sap.css.yaml`');
   expect(bodyText).toContain('### Contacts');
   expect(bodyText).toContain("Property 'contact' is required for System.");
   expect(bodyText).toContain('"field": "contacts"');
@@ -1034,8 +1034,8 @@ test('check_suite.completed failure aggregates multi-file registry issues into o
   expect(params).toEqual({ owner: 'o1', repo: 'r1', issue_number: 77 });
   expect(options).toEqual(expect.objectContaining({ minimizeTag: 'nsreq:ci-validation' }));
   expect(bodyText).toContain('## Detected issues');
-  expect(bodyText).toContain('### data/namespaces/sap.css.yaml');
-  expect(bodyText).toContain('### data/products/product-one.yaml');
+  expect(bodyText).toContain('### File: `data/namespaces/sap.css.yaml`');
+  expect(bodyText).toContain('### File: `data/products/product-one.yaml`');
   expect(bodyText).toContain('Show as JSON (Robots Friendly)');
   expect(bodyText).toContain('"filePath": "data/namespaces/sap.css.yaml"');
   expect(bodyText).toContain('"filePath": "data/products/product-one.yaml"');

--- a/test/validation-run.more.test.ts
+++ b/test/validation-run.more.test.ts
@@ -2165,6 +2165,150 @@ describe('validation/run.ts extra coverage', () => {
 
     restore();
   });
+
+  it('maps machine-readable validation issue fields to issue template field names', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        requests: {
+          product: { folderName: 'data/products', schema: '/schema.json', issueTemplate: 'product.yml' },
+        },
+      },
+      source: 'repo:cfg',
+      hooks: null,
+      hooksSource: null,
+    } as any);
+
+    const schemaObj = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['type', 'name', 'title'],
+      properties: {
+        type: { const: 'product' },
+        name: { 'type': 'string', 'minLength': 5, 'x-form-field': 'identifier' },
+        title: { type: 'string', minLength: 3 },
+      },
+    };
+
+    const getContent = jest.fn(async ({ path }: { path: string }) => {
+      if (path === '/schema.json' || path === 'schema.json') {
+        return {
+          data: {
+            content: Buffer.from(JSON.stringify(schemaObj), 'utf8').toString('base64'),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      const e: any = new Error('not found');
+      e.status = 404;
+      throw e;
+    });
+
+    const ctx: any = {
+      octokit: { repos: { getContent }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const template: any = {
+      body: [
+        { id: 'identifier', attributes: { label: 'Name' }, validations: { required: true } },
+        { id: 'title', attributes: { label: 'Title' }, validations: { required: true } },
+      ],
+      _meta: { requestType: 'product', schema: '/schema.json', root: 'data' },
+    };
+
+    const result = await mod.validateRequestIssue(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      { body: 'body' },
+      { template, formData: { identifier: 'abc', title: 'ok' } }
+    );
+
+    expect(result.validationIssues).toEqual(
+      expect.arrayContaining([{ path: 'Name', message: 'MUST NOT have fewer than 5 characters' }])
+    );
+    expect(result.validationIssues).not.toEqual(
+      expect.arrayContaining([{ path: 'identifier', message: 'MUST NOT have fewer than 5 characters' }])
+    );
+
+    restore();
+  });
+
+  it('falls back to schema field names when the issue template has no field label mapping', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        requests: {
+          product: { folderName: 'data/products', schema: '/schema.json', issueTemplate: 'product.yml' },
+        },
+      },
+      source: 'repo:cfg',
+      hooks: null,
+      hooksSource: null,
+    } as any);
+
+    const schemaObj = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['type', 'name', 'title'],
+      properties: {
+        type: { const: 'product' },
+        name: { 'type': 'string', 'minLength': 5, 'x-form-field': 'identifier' },
+        title: { type: 'string', minLength: 3 },
+      },
+    };
+
+    const getContent = jest.fn(async ({ path }: { path: string }) => {
+      if (path === '/schema.json' || path === 'schema.json') {
+        return {
+          data: {
+            content: Buffer.from(JSON.stringify(schemaObj), 'utf8').toString('base64'),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      const e: any = new Error('not found');
+      e.status = 404;
+      throw e;
+    });
+
+    const ctx: any = {
+      octokit: { repos: { getContent }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const template: any = {
+      body: [
+        { id: 'identifier', validations: { required: true } },
+        { id: 'title', validations: { required: true } },
+      ],
+      _meta: { requestType: 'product', schema: '/schema.json', root: 'data' },
+    };
+
+    const result = await mod.validateRequestIssue(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      { body: 'body' },
+      { template, formData: { identifier: 'abc', title: 'ok' } }
+    );
+
+    expect(result.validationIssues).toEqual(
+      expect.arrayContaining([{ path: 'name', message: 'MUST NOT have fewer than 5 characters' }])
+    );
+    expect(result.validationIssues).not.toEqual(
+      expect.arrayContaining([{ path: 'identifier', message: 'MUST NOT have fewer than 5 characters' }])
+    );
+
+    restore();
+  });
 });
 
 describe('vendor governance', () => {

--- a/test/validation-run.more.test.ts
+++ b/test/validation-run.more.test.ts
@@ -1933,6 +1933,65 @@ describe('validation/run.ts extra coverage', () => {
 
     restore();
   });
+  it('runApprovalHook: merges approversPool into config.approvers and prefers explicit requestAuthorId', async () => {
+    const { mod, mocks, restore } = await loadSubject();
+
+    mocks.loadStaticConfig.mockResolvedValueOnce({
+      config: {
+        requests: {
+          systemNamespace: {
+            approvers: ['REQ-APPROVER'],
+            approversPool: ['REQ-POOL'],
+          },
+        },
+        workflow: {
+          approvers: ['WF-APPROVER'],
+          approversPool: ['WF-POOL'],
+        },
+        hooks: { allowedHosts: ['api.sap.com'] },
+      },
+      source: 'repo:cfg',
+      hooks: {
+        onApproval: async (args: any) => {
+          expect(args.requestAuthor.id).toBe('last-commit-user');
+          expect(args.issue.author).toBe('last-commit-user');
+          expect(args.config.approvers).toEqual(['REQ-APPROVER', 'REQ-POOL']);
+          return true;
+        },
+      },
+      hooksSource: 'mock-hooks.js',
+    } as any);
+
+    const ctx: any = {
+      octokit: { repos: { getContent: jest.fn() }, issues: mkIssuesStub() },
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      repo: () => ({ owner: 'o', repo: 'r' }),
+      issue: () => ({ owner: 'o', repo: 'r', issue_number: 1 }),
+    };
+
+    const approved = await mod.runApprovalHook(
+      ctx,
+      { owner: 'o', repo: 'r' },
+      {
+        requestType: 'systemNamespace',
+        namespace: 'sap.agt.foo',
+        formData: { namespace: 'sap.agt.foo' },
+        requestAuthorId: 'last-commit-user',
+        issue: {
+          number: 1,
+          title: 't',
+          body: 'b',
+          state: 'open',
+          labels: [],
+          user: { login: 'issue-author' },
+        },
+      }
+    );
+
+    expect(approved).toEqual({ status: 'approved' });
+
+    restore();
+  });
   it('runApprovalHook: legacy hook failures are swallowed and return false', async () => {
     const { mod, mocks, restore } = await loadSubject();
 


### PR DESCRIPTION
This PR improves the approval flow and PR validation handling.

Changes:
- Merge approvers and approversPool for onApproval hook
- Use last commit author as requestAuthorId in PR flows
- Add support for direct PR approval via onApproval hook
- Add Approved label on auto-approved PRs
- Aggregate multi-file validation results into a single PR comment
- Provide machine-readable validation output for automation

Notes:
- Keeps existing issue-based workflow intact
- Adds conservative handling for multi-file PR approvals
- Improves consistency between CI validation and bot comments