### PR TITLE
fix: apply parse-allowed field filtering after template meta resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+- Improved namespace approval flow:
+  - subcontext requests approved by parent owners now go directly to PR
+  - system namespace requests require an extra contact-owner gate if requester is not in contacts
+  - parent chain validation now checks the full chain down to root
+
+- Improved issue form parsing:
+  - extra UI-only fields are allowed in issue templates
+  - non-schema fields are filtered before validation and YAML generation
+  - fields like `justification` stay visible in GitHub issues without affecting registry data
+
 ## [[0.1.0](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v/0.1.0)] - 2026-04-14
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.5",
+  "version": "0.1.6-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.0",
+  "version": "0.1.1-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -78,6 +78,7 @@ type TemplateMeta = {
   root?: string;
   schema?: string;
   path?: string;
+  parseAllowedFieldIds?: string[];
 };
 
 type TemplateLike = {
@@ -1432,9 +1433,17 @@ type LoadTemplateFn = (
   }
 ) => Promise<TemplateLike>;
 
-type ParseFormFn = (body: string, template: TemplateLike) => FormData;
+type ParseFormOptions = {
+  allowedFieldIds?: Iterable<string> | null;
+};
 
-type BuildAllowedFieldIdsFromSchemaFn = (schema: unknown, extraAllowedFieldIds?: Iterable<string> | null) => string[];
+type ParseFormFn = (body: string, template: TemplateLike, options?: ParseFormOptions) => FormData;
+
+type BuildAllowedFieldIdsFromSchemaFn = (
+  schema: unknown,
+  extraAllowedFieldIds?: Iterable<string> | null,
+  templateFieldIds?: Iterable<string> | null
+) => string[];
 
 type FilterParsedFormDataFn = (parsed: FormData, allowedFieldIds?: Iterable<string> | null) => FormData;
 
@@ -1518,6 +1527,26 @@ const extractHashFromPrBody = extractHashFromPRBodyRaw as unknown as ExtractHash
 const findOpenIssuePrs = findOpenIssuePRsRaw as unknown as FindOpenIssuePrsFn;
 const createRequestPr = createRequestPRRaw as unknown as CreateRequestPrFn;
 const tryMergeIfGreen = tryMergeIfGreenRaw as unknown as TryMergeIfGreenFn;
+
+function getTemplateFieldIdsForParseFilter(template: TemplateLike): string[] {
+  return (Array.isArray(template?.body) ? template.body : [])
+    .map((field) => (isPlainObject(field) ? toStringTrim(field['id']) : ''))
+    .filter(Boolean);
+}
+
+function getTemplateParseAllowedFieldIds(template: TemplateLike): string[] {
+  const raw = template?._meta?.parseAllowedFieldIds;
+
+  return Array.isArray(raw) ? raw.map((item) => toStringTrim(item)).filter(Boolean) : [];
+}
+
+function buildParseAllowedFieldIdsForTemplate(schemaObj: unknown, template: TemplateLike): string[] {
+  return buildAllowedFieldIdsFromSchema(
+    schemaObj,
+    getTemplateParseAllowedFieldIds(template),
+    getTemplateFieldIdsForParseFilter(template)
+  );
+}
 
 function readCheckRunFromPayload(payload: unknown): CheckRunLike | null {
   if (!isPlainObject(payload)) return null;
@@ -3544,7 +3573,9 @@ async function processPullRequestForAutoMerge(
     return;
   }
 
-  const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+  const parsedFormData = template
+    ? await parseFilteredIssueForm(context, { owner: params.owner, repo: params.repo }, issue.body, template)
+    : {};
   if (!isRequestIssue(context, template, parsedFormData)) {
     log(
       context,
@@ -4023,7 +4054,11 @@ async function loadTemplateSchemaForParsing(
   const candidates = buildTemplateSchemaRepoCandidates(schemaPath);
   if (!candidates.length) return null;
 
-  const cacheKey = `${repoInfo.owner}/${repoInfo.repo}:${candidates.join('|')}`;
+  const cacheKey = `${repoInfo.owner}/${repoInfo.repo}:${candidates.join('|')}:${getTemplateFieldIdsForParseFilter(
+    template
+  )
+    .sort()
+    .join(',')}`;
   const cached = PARSED_FORM_SCHEMA_CACHE.get(cacheKey);
   if (cached) return await cached;
 
@@ -4052,12 +4087,22 @@ async function parseFilteredIssueForm(
   issueBody: unknown,
   template: TemplateLike
 ): Promise<FormData> {
-  const rawFormData = parseForm(readIssueBodyForProcessing(issueBody), template);
+  const body = readIssueBodyForProcessing(issueBody);
+
+  // First pass must be unfiltered. For partnerNamespace we need requestType
+  // before the effective request meta/schema path can be resolved.
+  const rawFormData = parseForm(body, template, { allowedFieldIds: [] });
+
+  const templateAllowedFieldIds = getTemplateParseAllowedFieldIds(template);
   const schemaObj = await loadTemplateSchemaForParsing(context, repoInfo, template, rawFormData);
 
-  if (!schemaObj) return rawFormData;
+  if (!schemaObj) {
+    return templateAllowedFieldIds.length ? filterParsedFormData(rawFormData, templateAllowedFieldIds) : rawFormData;
+  }
 
-  return filterParsedFormData(rawFormData, buildAllowedFieldIdsFromSchema(schemaObj));
+  const allowedFieldIds = buildParseAllowedFieldIdsForTemplate(schemaObj, template);
+
+  return allowedFieldIds.length ? filterParsedFormData(rawFormData, allowedFieldIds) : rawFormData;
 }
 
 function isRegistryEntryPath(context: BotContext<RequestEvents>, filePath: string): boolean {
@@ -6981,7 +7026,7 @@ ${mentions}`,
 
   const tpl = reval.template || template;
   const bodyStr = readIssueBodyForProcessing(issue.body);
-  const parsedNow = parseForm(bodyStr, tpl);
+  const parsedNow = await parseFilteredIssueForm(context, { owner: params.owner, repo: params.repo }, issue.body, tpl);
   const snapshotHash = calcSnapshotHash(parsedNow, tpl, bodyStr);
   const effRt = resolveEffectiveRequestType(tpl, parsedNow);
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -16,6 +16,10 @@ import { loadStaticConfig, DEFAULT_CONFIG, type NormalizedStaticConfig, type Reg
 import { getDocLinksFromConfig } from './constants.js';
 import type { Context, Probot } from 'probot';
 import YAML from 'yaml';
+import {
+  buildAllowedFieldIdsFromSchema as buildAllowedFieldIdsFromSchemaRaw,
+  filterParsedFormData as filterParsedFormDataRaw,
+} from '../../utils/parser.js';
 
 const DBG = process.env.DEBUG_NS === '1';
 
@@ -1359,6 +1363,10 @@ type LoadTemplateFn = (
 
 type ParseFormFn = (body: string, template: TemplateLike) => FormData;
 
+type BuildAllowedFieldIdsFromSchemaFn = (schema: unknown, extraAllowedFieldIds?: Iterable<string> | null) => string[];
+
+type FilterParsedFormDataFn = (parsed: FormData, allowedFieldIds?: Iterable<string> | null) => FormData;
+
 type ValidateRequestIssueFn = (
   context: BotContext<RequestEvents>,
   params: IssueParams,
@@ -1428,6 +1436,9 @@ const postOnce = postOnceRaw as unknown as PostOnceFn;
 const collapseBotCommentsByPrefix = collapseBotCommentsByPrefixRaw as unknown as CollapseBotCommentsByPrefixFn;
 const loadTemplate = loadTemplateRaw as unknown as LoadTemplateFn;
 const parseForm = parseFormRaw as unknown as ParseFormFn;
+const buildAllowedFieldIdsFromSchema = buildAllowedFieldIdsFromSchemaRaw as unknown as BuildAllowedFieldIdsFromSchemaFn;
+
+const filterParsedFormData = filterParsedFormDataRaw as unknown as FilterParsedFormDataFn;
 const validateRequestIssue = validateRequestIssueRaw as unknown as ValidateRequestIssueFn;
 const runApprovalHook = runApprovalHookRaw as unknown as RunApprovalHookFn;
 const calcSnapshotHash = calcSnapshotHashRaw as unknown as CalcSnapshotHashFn;
@@ -2030,6 +2041,91 @@ function buildFormDataFromRegistryDoc(doc: Record<string, unknown>): FormData {
   if (contacts && !out.contact) out.contact = contacts;
 
   return out;
+}
+
+const PARSED_FORM_SCHEMA_CACHE = new Map<string, Promise<unknown | null>>();
+
+function buildTemplateSchemaRepoCandidates(schemaPath: string): string[] {
+  const raw = toStringTrim(schemaPath);
+  if (!raw) return [];
+
+  if (raw.startsWith('/')) return [raw.replace(/^\/+/, '')];
+
+  const cleaned = raw.replace(/^\.?\//, '');
+  const out = new Set<string>();
+
+  if (cleaned.startsWith('.github/')) out.add(cleaned);
+  else out.add(`.github/registry-bot/${cleaned}`);
+
+  out.add(cleaned);
+
+  return Array.from(out);
+}
+
+function resolveEffectiveTemplateSchemaPathForParsing(
+  context: BotContext<RequestEvents>,
+  template: TemplateLike,
+  parsedFormData: FormData
+): string {
+  const defaultSchemaPath = toStringTrim(template?._meta?.schema);
+
+  if (toStringTrim(template?._meta?.requestType).toLowerCase() !== 'partnernamespace') {
+    return defaultSchemaPath;
+  }
+
+  const effectiveRequestType = resolveEffectiveRequestType(template, parsedFormData);
+  const cfg = context.resourceBotConfig ?? DEFAULT_CONFIG;
+  const reqs = isPlainObject(cfg.requests) ? cfg.requests : {};
+  const entry = isPlainObject(reqs[effectiveRequestType]) ? reqs[effectiveRequestType] : null;
+
+  return toStringTrim(entry?.['schema']) || defaultSchemaPath;
+}
+
+async function loadTemplateSchemaForParsing(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  template: TemplateLike,
+  parsedFormData: FormData
+): Promise<unknown | null> {
+  const schemaPath = resolveEffectiveTemplateSchemaPathForParsing(context, template, parsedFormData);
+  const candidates = buildTemplateSchemaRepoCandidates(schemaPath);
+  if (!candidates.length) return null;
+
+  const cacheKey = `${repoInfo.owner}/${repoInfo.repo}:${candidates.join('|')}`;
+  const cached = PARSED_FORM_SCHEMA_CACHE.get(cacheKey);
+  if (cached) return await cached;
+
+  const pending = (async (): Promise<unknown | null> => {
+    for (const candidate of candidates) {
+      const raw = await readRepoFileText(context, repoInfo, candidate);
+      if (!raw) continue;
+
+      try {
+        return JSON.parse(raw) as unknown;
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  })();
+
+  PARSED_FORM_SCHEMA_CACHE.set(cacheKey, pending);
+  return await pending;
+}
+
+async function parseFilteredIssueForm(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  issueBody: unknown,
+  template: TemplateLike
+): Promise<FormData> {
+  const rawFormData = parseForm(readIssueBodyForProcessing(issueBody), template);
+  const schemaObj = await loadTemplateSchemaForParsing(context, repoInfo, template, rawFormData);
+
+  if (!schemaObj) return rawFormData;
+
+  return filterParsedFormData(rawFormData, buildAllowedFieldIdsFromSchema(schemaObj));
 }
 
 function isRegistryEntryPath(context: BotContext<RequestEvents>, filePath: string): boolean {
@@ -2777,7 +2873,9 @@ async function processIssueEvent(
     return;
   }
 
-  const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+  const parsedFormData = template
+    ? await parseFilteredIssueForm(context, { owner: params.owner, repo: params.repo }, issue.body, template)
+    : {};
   if (!isRequestIssue(context, template, parsedFormData)) {
     if (DBG) {
       log(
@@ -3062,7 +3160,12 @@ async function handleAuthorUpdateComment(
     } = reval;
 
     if (Array.isArray(revalErrors) && revalErrors.length === 0 && tpl) {
-      const parsedAfterUpdate = parseForm(readIssueBodyForProcessing(issue.body), tpl);
+      const parsedAfterUpdate = await parseFilteredIssueForm(
+        context,
+        { owner: params.owner, repo: params.repo },
+        issue.body,
+        tpl
+      );
       const snapshotHash = calcSnapshotHash(parsedAfterUpdate, tpl, readIssueBodyForProcessing(issue.body));
 
       try {
@@ -3844,7 +3947,7 @@ ${mentions}`,
 
   const tpl = reval.template || template;
   const bodyStr = readIssueBodyForProcessing(issue.body);
-  const parsedNow = parseForm(bodyStr, tpl);
+  const parsedNow = await parseFilteredIssueForm(context, { owner: params.owner, repo: params.repo }, issue.body, tpl);
   const snapshotHash = calcSnapshotHash(parsedNow, tpl, bodyStr);
   const effRt = resolveEffectiveRequestType(tpl, parsedNow);
 
@@ -4116,8 +4219,7 @@ async function closeOutdatedRequestPrs(
 
     const { data } = await context.octokit.issues.get({ owner, repo, issue_number });
     const issue = data as unknown as IssueLike;
-    const bodyStr = readIssueBodyForProcessing(issue.body);
-    const form = parseForm(bodyStr, template);
+    const form = await parseFilteredIssueForm(context, { owner, repo }, issue.body, template);
     const hash = calcSnapshotHash(form, template, readIssueBodyForProcessing(issue.body));
     return { parsedFormData: form, currentHash: hash };
   };
@@ -4341,7 +4443,7 @@ export default function requestHandler(app: Probot): void {
       return;
     }
 
-    const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+    const parsedFormData = template ? await parseFilteredIssueForm(context, { owner, repo }, issue.body, template) : {};
     if (!isRequestIssue(context, template, parsedFormData)) return;
 
     const eff = resolveEffectiveConstants(context);
@@ -4443,7 +4545,7 @@ export default function requestHandler(app: Probot): void {
 
       try {
         template = await loadTemplateWithLabelRefresh(context, params, issue);
-        parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+        parsedFormData = template ? await parseFilteredIssueForm(context, { owner, repo }, issue.body, template) : {};
       } catch {
         if (!hasRoutingLock) return;
       }
@@ -4655,7 +4757,9 @@ export default function requestHandler(app: Probot): void {
         return;
       }
 
-      const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+      const parsedFormData = template
+        ? await parseFilteredIssueForm(context, { owner, repo }, issue.body, template)
+        : {};
       if (!isRequestIssue(context, template, parsedFormData)) {
         if (DBG) {
           log(
@@ -4772,7 +4876,9 @@ export default function requestHandler(app: Probot): void {
         continue;
       }
 
-      const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+      const parsedFormData = template
+        ? await parseFilteredIssueForm(context, { owner, repo }, issue.body, template)
+        : {};
       if (!isRequestIssue(context, template, parsedFormData)) continue;
 
       const currentHash = calcSnapshotHash(parsedFormData, template, readIssueBodyForProcessing(issue.body));

--- a/src/handlers/request/template.ts
+++ b/src/handlers/request/template.ts
@@ -1,5 +1,5 @@
 import YAML from 'yaml';
-import { parseForm as parseFormRaw } from '../../utils/parser.js';
+import { buildAllowedFieldIdsFromSchema, parseForm as parseFormRaw } from '../../utils/parser.js';
 
 const DBG = process.env.DEBUG_NS === '1';
 
@@ -93,17 +93,6 @@ type ParseAllowedIdsTemplate = {
 
 const TEMPLATE_PARSE_ALLOWED_FIELD_IDS_CACHE = new Map<string, Promise<string[]>>();
 
-const PARSE_CONTROL_FIELD_IDS = new Set<string>(['requestType', 'request-type', 'open-system']);
-
-const SCHEMA_PARSE_COMPAT_FIELD_ALIASES: Record<string, string[]> = {
-  contact: ['contacts'],
-  contacts: ['contact'],
-  description: ['system-description', 'sub-context-description'],
-  shortDescription: ['short-description'],
-  correlationIds: ['correlation-ids'],
-  correlationIdTypes: ['correlation-id-types'],
-};
-
 function parseAllowedToString(value: unknown): string {
   return String(value ?? '').trim();
 }
@@ -119,22 +108,6 @@ function parseAllowedNormalizeRepoPath(value: unknown): string {
     .replace(/\/{2,}/g, '/');
 }
 
-function parseAllowedToKebabCase(value: string): string {
-  return parseAllowedToString(value)
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/[_\s]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-function parseAllowedToSnakeCase(value: string): string {
-  return parseAllowedToString(value)
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/[-\s]+/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
-
 function buildTemplateFieldIdSetForParseFilter(template: ParseAllowedIdsTemplate): Set<string> {
   const out = new Set<string>();
 
@@ -146,66 +119,11 @@ function buildTemplateFieldIdSetForParseFilter(template: ParseAllowedIdsTemplate
   return out;
 }
 
-function addTemplateFieldCandidateForParseFilter(
-  templateFieldIds: Set<string>,
-  allowed: Set<string>,
-  candidate: unknown
-): void {
-  const raw = parseAllowedToString(candidate);
-  if (!raw) return;
-
-  const variants = [raw, parseAllowedToKebabCase(raw), parseAllowedToSnakeCase(raw)];
-  for (const variant of variants) {
-    if (!variant) continue;
-    if (!templateFieldIds.has(variant)) continue;
-    allowed.add(variant);
-  }
-}
-
-function addSchemaPropertyCandidatesForParseFilter(
-  templateFieldIds: Set<string>,
-  allowed: Set<string>,
-  propertyName: string,
-  propertyDef: unknown
-): void {
-  const prop = parseAllowedIsPlainObject(propertyDef) ? propertyDef : {};
-  const mappedFieldId = parseAllowedToString(prop['x-form-field']);
-
-  if (mappedFieldId) {
-    addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, mappedFieldId);
-  } else {
-    const isConstOnly = Object.hasOwn(prop, 'const');
-    if (!isConstOnly) {
-      addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, propertyName);
-    }
-  }
-
-  for (const alias of SCHEMA_PARSE_COMPAT_FIELD_ALIASES[propertyName] || []) {
-    addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, alias);
-  }
-}
-
 function buildParseAllowedFieldIds(template: ParseAllowedIdsTemplate, schemaObj: unknown): string[] {
-  const templateFieldIds = buildTemplateFieldIdSetForParseFilter(template);
-  if (!templateFieldIds.size) return [];
+  const templateFieldIds = Array.from(buildTemplateFieldIdSetForParseFilter(template));
+  if (!templateFieldIds.length) return [];
 
-  const allowed = new Set<string>();
-  const props =
-    parseAllowedIsPlainObject(schemaObj) && parseAllowedIsPlainObject(schemaObj['properties'])
-      ? schemaObj['properties']
-      : null;
-
-  if (props) {
-    for (const [propertyName, propertyDef] of Object.entries(props)) {
-      addSchemaPropertyCandidatesForParseFilter(templateFieldIds, allowed, propertyName, propertyDef);
-    }
-  }
-
-  for (const controlFieldId of PARSE_CONTROL_FIELD_IDS) {
-    if (templateFieldIds.has(controlFieldId)) allowed.add(controlFieldId);
-  }
-
-  return Array.from(allowed);
+  return buildAllowedFieldIdsFromSchema(schemaObj, null, templateFieldIds);
 }
 
 async function readSchemaTextForParseFilter(
@@ -816,15 +734,31 @@ function isTemplateField(value: unknown): value is TemplateFieldMinimal {
   return idOk && attrsOk;
 }
 
-export function parseForm(body: string, template: Template): Record<string, string> {
+type ParseFormOptions = {
+  allowedFieldIds?: Iterable<string> | null;
+};
+
+export function parseForm(body: string, template: Template, options: ParseFormOptions = {}): Record<string, string> {
   const bodyFields: TemplateFieldMinimal[] = Array.isArray(template.body) ? template.body.filter(isTemplateField) : [];
 
-  return parseFormRaw(body || '', {
-    body: bodyFields,
-    _meta: {
-      parseAllowedFieldIds: Array.isArray(template._meta?.parseAllowedFieldIds)
-        ? template._meta.parseAllowedFieldIds
-        : [],
+  const hasAllowedFieldOverride = Object.hasOwn(options, 'allowedFieldIds');
+
+  const allowedFieldIds = hasAllowedFieldOverride
+    ? (options.allowedFieldIds ?? [])
+    : Array.isArray(template._meta?.parseAllowedFieldIds)
+      ? template._meta.parseAllowedFieldIds
+      : [];
+
+  return parseFormRaw(
+    body || '',
+    {
+      body: bodyFields,
+      _meta: {
+        parseAllowedFieldIds: Array.from(allowedFieldIds || []),
+      },
     },
-  });
+    {
+      allowedFieldIds,
+    }
+  );
 }

--- a/src/handlers/request/template.ts
+++ b/src/handlers/request/template.ts
@@ -64,6 +64,232 @@ type LabelIndex = {
   expectedLabels: string[];
 };
 
+type ParseAllowedIdsRepoInfo = {
+  owner: string;
+  repo: string;
+};
+
+type ParseAllowedIdsContext = {
+  octokit: {
+    repos: {
+      getContent: (args: { owner: string; repo: string; path: string }) => Promise<{ data?: unknown }>;
+    };
+  };
+};
+
+type ParseAllowedIdsTemplateField = {
+  id?: string;
+};
+
+type ParseAllowedIdsTemplate = {
+  body?: ParseAllowedIdsTemplateField[];
+  _meta?: {
+    schema?: string;
+    parseAllowedFieldIds?: string[];
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+};
+
+const TEMPLATE_PARSE_ALLOWED_FIELD_IDS_CACHE = new Map<string, Promise<string[]>>();
+
+const PARSE_CONTROL_FIELD_IDS = new Set<string>(['requestType', 'request-type', 'open-system']);
+
+const SCHEMA_PARSE_COMPAT_FIELD_ALIASES: Record<string, string[]> = {
+  contact: ['contacts'],
+  contacts: ['contact'],
+  description: ['system-description', 'sub-context-description'],
+  shortDescription: ['short-description'],
+  correlationIds: ['correlation-ids'],
+  correlationIdTypes: ['correlation-id-types'],
+};
+
+function parseAllowedToString(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function parseAllowedIsPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseAllowedNormalizeRepoPath(value: unknown): string {
+  return parseAllowedToString(value)
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/{2,}/g, '/');
+}
+
+function parseAllowedToKebabCase(value: string): string {
+  return parseAllowedToString(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[_\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parseAllowedToSnakeCase(value: string): string {
+  return parseAllowedToString(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function buildTemplateFieldIdSetForParseFilter(template: ParseAllowedIdsTemplate): Set<string> {
+  const out = new Set<string>();
+
+  for (const field of template?.body || []) {
+    const id = parseAllowedToString(field?.id);
+    if (id) out.add(id);
+  }
+
+  return out;
+}
+
+function addTemplateFieldCandidateForParseFilter(
+  templateFieldIds: Set<string>,
+  allowed: Set<string>,
+  candidate: unknown
+): void {
+  const raw = parseAllowedToString(candidate);
+  if (!raw) return;
+
+  const variants = [raw, parseAllowedToKebabCase(raw), parseAllowedToSnakeCase(raw)];
+  for (const variant of variants) {
+    if (!variant) continue;
+    if (!templateFieldIds.has(variant)) continue;
+    allowed.add(variant);
+  }
+}
+
+function addSchemaPropertyCandidatesForParseFilter(
+  templateFieldIds: Set<string>,
+  allowed: Set<string>,
+  propertyName: string,
+  propertyDef: unknown
+): void {
+  const prop = parseAllowedIsPlainObject(propertyDef) ? propertyDef : {};
+  const mappedFieldId = parseAllowedToString(prop['x-form-field']);
+
+  if (mappedFieldId) {
+    addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, mappedFieldId);
+  } else {
+    const isConstOnly = Object.hasOwn(prop, 'const');
+    if (!isConstOnly) {
+      addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, propertyName);
+    }
+  }
+
+  for (const alias of SCHEMA_PARSE_COMPAT_FIELD_ALIASES[propertyName] || []) {
+    addTemplateFieldCandidateForParseFilter(templateFieldIds, allowed, alias);
+  }
+}
+
+function buildParseAllowedFieldIds(template: ParseAllowedIdsTemplate, schemaObj: unknown): string[] {
+  const templateFieldIds = buildTemplateFieldIdSetForParseFilter(template);
+  if (!templateFieldIds.size) return [];
+
+  const allowed = new Set<string>();
+  const props =
+    parseAllowedIsPlainObject(schemaObj) && parseAllowedIsPlainObject(schemaObj['properties'])
+      ? schemaObj['properties']
+      : null;
+
+  if (props) {
+    for (const [propertyName, propertyDef] of Object.entries(props)) {
+      addSchemaPropertyCandidatesForParseFilter(templateFieldIds, allowed, propertyName, propertyDef);
+    }
+  }
+
+  for (const controlFieldId of PARSE_CONTROL_FIELD_IDS) {
+    if (templateFieldIds.has(controlFieldId)) allowed.add(controlFieldId);
+  }
+
+  return Array.from(allowed);
+}
+
+async function readSchemaTextForParseFilter(
+  context: ParseAllowedIdsContext,
+  repoInfo: ParseAllowedIdsRepoInfo,
+  schemaPath: string
+): Promise<string | null> {
+  const rawPath = parseAllowedToString(schemaPath);
+  if (!rawPath) return null;
+
+  const cleaned = rawPath.replace(/^\.?\//, '');
+  const candidates = rawPath.startsWith('/')
+    ? [rawPath.replace(/^\/+/, '')]
+    : cleaned.startsWith('.github/')
+      ? [cleaned]
+      : [`.github/registry-bot/${cleaned}`, cleaned];
+
+  for (const candidate of Array.from(new Set(candidates.map(parseAllowedNormalizeRepoPath).filter(Boolean)))) {
+    try {
+      const res = await context.octokit.repos.getContent({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        path: candidate,
+      });
+
+      const data = (res as { data?: unknown }).data;
+      if (Array.isArray(data)) continue;
+      if (!parseAllowedIsPlainObject(data)) continue;
+      if (typeof data['content'] !== 'string') continue;
+
+      const encoding = typeof data['encoding'] === 'string' ? data['encoding'] : 'base64';
+      return Buffer.from(String(data['content'] || ''), encoding as BufferEncoding).toString('utf8');
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+async function resolveTemplateParseAllowedFieldIds(
+  context: ParseAllowedIdsContext,
+  repoInfo: ParseAllowedIdsRepoInfo,
+  template: ParseAllowedIdsTemplate
+): Promise<string[]> {
+  const schemaPath = parseAllowedToString(template?._meta?.schema);
+  const templateFieldIds = Array.from(buildTemplateFieldIdSetForParseFilter(template)).sort();
+
+  if (!schemaPath || !templateFieldIds.length) return [];
+
+  const cacheKey = `${repoInfo.owner}/${repoInfo.repo}:${schemaPath}:${templateFieldIds.join(',')}`;
+  const cached = TEMPLATE_PARSE_ALLOWED_FIELD_IDS_CACHE.get(cacheKey);
+  if (cached) return await cached;
+
+  const pending = (async (): Promise<string[]> => {
+    const raw = await readSchemaTextForParseFilter(context, repoInfo, schemaPath);
+    if (!raw) return [];
+
+    try {
+      const schemaObj = JSON.parse(raw) as unknown;
+      return buildParseAllowedFieldIds(template, schemaObj);
+    } catch {
+      return [];
+    }
+  })();
+
+  TEMPLATE_PARSE_ALLOWED_FIELD_IDS_CACHE.set(cacheKey, pending);
+  return await pending;
+}
+
+async function attachParseAllowedFieldIds(
+  context: ParseAllowedIdsContext,
+  repoInfo: ParseAllowedIdsRepoInfo,
+  template: ParseAllowedIdsTemplate
+): Promise<void> {
+  const parseAllowedFieldIds = await resolveTemplateParseAllowedFieldIds(context, repoInfo, template);
+  if (!parseAllowedFieldIds.length) return;
+
+  template._meta = {
+    ...(template._meta || {}),
+    parseAllowedFieldIds,
+  };
+}
+
 const TEMPLATE_CACHE = new Map<string, CacheEntry<unknown>>();
 const TEMPLATE_FILE_CACHE = new Map<string, CacheEntry<Template>>();
 
@@ -189,6 +415,27 @@ const applyRequestMeta = (template: Template, requestType: string, rc: RequestCo
 
   return template;
 };
+
+async function applyRequestMetaAndAttachParseAllowedFieldIds(
+  context: ContextLike,
+  owner: string,
+  repo: string,
+  template: Template,
+  requestType: string,
+  rc: RequestConfigEntry
+): Promise<Template> {
+  applyRequestMeta(template, requestType, rc);
+
+  if (context.octokit) {
+    await attachParseAllowedFieldIds(
+      { octokit: context.octokit },
+      { owner, repo },
+      template as ParseAllowedIdsTemplate
+    );
+  }
+
+  return template;
+}
 
 const buildLabelIndexFromTemplates = async (
   context: ContextLike,
@@ -496,7 +743,9 @@ export async function loadTemplate(
     const tpl = await fetchFile(resolvedPath);
 
     const byTpl = findRequestByTemplatePath(context, resolvedPath);
-    if (byTpl) applyRequestMeta(tpl, byTpl.requestType, byTpl.rc);
+    if (byTpl) {
+      await applyRequestMetaAndAttachParseAllowedFieldIds(context, owner, repo, tpl, byTpl.requestType, byTpl.rc);
+    }
 
     const cacheKey = `${owner}/${repo}:path:${resolvedPath}`;
     TEMPLATE_CACHE.set(cacheKey, { ts: now(), data: tpl });
@@ -533,7 +782,7 @@ export async function loadTemplate(
   }
 
   const tpl = await fetchFile(resolvedTplPath);
-  applyRequestMeta(tpl, requestType, rc);
+  await applyRequestMetaAndAttachParseAllowedFieldIds(context, owner, repo, tpl, requestType, rc);
 
   if (!tpl._meta?.requestType) {
     if (!tpl._meta) {
@@ -570,5 +819,12 @@ function isTemplateField(value: unknown): value is TemplateFieldMinimal {
 export function parseForm(body: string, template: Template): Record<string, string> {
   const bodyFields: TemplateFieldMinimal[] = Array.isArray(template.body) ? template.body.filter(isTemplateField) : [];
 
-  return parseFormRaw(body || '', { body: bodyFields });
+  return parseFormRaw(body || '', {
+    body: bodyFields,
+    _meta: {
+      parseAllowedFieldIds: Array.isArray(template._meta?.parseAllowedFieldIds)
+        ? template._meta.parseAllowedFieldIds
+        : [],
+    },
+  });
 }

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -425,9 +425,17 @@ type LoadTemplateFn = (
   }
 ) => Promise<TemplateLike>;
 
-type ParseFormFn = (body: string, template: TemplateLike) => FormData;
+type ParseFormOptions = {
+  allowedFieldIds?: Iterable<string> | null;
+};
 
-type BuildAllowedFieldIdsFromSchemaFn = (schema: unknown, extraAllowedFieldIds?: Iterable<string> | null) => string[];
+type ParseFormFn = (body: string, template: TemplateLike, options?: ParseFormOptions) => FormData;
+
+type BuildAllowedFieldIdsFromSchemaFn = (
+  schema: unknown,
+  extraAllowedFieldIds?: Iterable<string> | null,
+  templateFieldIds?: Iterable<string> | null
+) => string[];
 
 type FilterParsedFormDataFn = (parsed: FormData, allowedFieldIds?: Iterable<string> | null) => FormData;
 
@@ -435,6 +443,16 @@ const loadTemplate = loadTemplateRaw as unknown as LoadTemplateFn;
 const parseForm = parseFormRaw as unknown as ParseFormFn;
 const buildAllowedFieldIdsFromSchema = buildAllowedFieldIdsFromSchemaRaw as unknown as BuildAllowedFieldIdsFromSchemaFn;
 const filterParsedFormData = filterParsedFormDataRaw as unknown as FilterParsedFormDataFn;
+
+function getTemplateFieldIdsForParseFilter(template: TemplateLike): string[] {
+  return (Array.isArray(template?.body) ? template.body : []).map((field) => toStringSafe(field?.id)).filter(Boolean);
+}
+
+function getTemplateParseAllowedFieldIds(template: TemplateLike): string[] {
+  const raw = template?._meta?.['parseAllowedFieldIds'];
+
+  return Array.isArray(raw) ? raw.map((item) => toStringSafe(item)).filter(Boolean) : [];
+}
 
 // Error buckets + formatting
 function newBuckets(): ValidationBuckets {
@@ -2334,27 +2352,50 @@ export async function validateRequestIssue(
   });
 
   // 3) form
-  const rawFormData = givenFormData || parseForm(String(issue.body || ''), template);
+  // First pass must be unfiltered. For partnerNamespace we need requestType before
+  // the effective request meta and schema path can be resolved.
+  const rawFormData = givenFormData || parseForm(String(issue.body || ''), template, { allowedFieldIds: [] });
 
   let formData = rawFormData;
-  let allowedTemplateFieldIds: Set<string> | null = null;
+  let parseAllowedFieldIds = getTemplateParseAllowedFieldIds(template);
+  let allowedTemplateFieldIds: Set<string> | null = parseAllowedFieldIds.length ? new Set(parseAllowedFieldIds) : null;
 
-  const resolvedTemplate = resolveTemplateAndRequestType(context, template, formData, errors, buckets);
+  const resolvedTemplate = resolveTemplateAndRequestType(context, template, rawFormData, errors, buckets);
   if ('result' in resolvedTemplate) return resolvedTemplate.result;
 
   template = resolvedTemplate.template;
   const { requestType, requestCfg } = resolvedTemplate;
 
+  // Re-read from resolved template because partnerNamespace may clone/update _meta.
+  parseAllowedFieldIds = getTemplateParseAllowedFieldIds(template);
+  allowedTemplateFieldIds = parseAllowedFieldIds.length ? new Set(parseAllowedFieldIds) : null;
+
   const schemaPathForParseFilter = String(template?._meta?.schema || '').trim();
+
   if (schemaPathForParseFilter) {
     try {
       const schemaObjForParseFilter = await loadSchemaFromRepoOrLocal(context, owner, repo, schemaPathForParseFilter);
-      const allowedFieldIds = buildAllowedFieldIdsFromSchema(schemaObjForParseFilter);
-      formData = filterParsedFormData(rawFormData, allowedFieldIds);
-      allowedTemplateFieldIds = new Set(allowedFieldIds);
+
+      parseAllowedFieldIds = buildAllowedFieldIdsFromSchema(
+        schemaObjForParseFilter,
+        null,
+        getTemplateFieldIdsForParseFilter(template)
+      );
+
+      formData = filterParsedFormData(rawFormData, parseAllowedFieldIds);
+      allowedTemplateFieldIds = new Set(parseAllowedFieldIds);
     } catch {
-      formData = rawFormData;
+      if (parseAllowedFieldIds.length) {
+        formData = filterParsedFormData(rawFormData, parseAllowedFieldIds);
+        allowedTemplateFieldIds = new Set(parseAllowedFieldIds);
+      } else {
+        formData = rawFormData;
+        allowedTemplateFieldIds = null;
+      }
     }
+  } else if (parseAllowedFieldIds.length) {
+    formData = filterParsedFormData(rawFormData, parseAllowedFieldIds);
+    allowedTemplateFieldIds = new Set(parseAllowedFieldIds);
   }
 
   if (DBG && context.log?.info) context.log.info({ formData }, 'ns:parsedFormData');
@@ -2437,6 +2478,11 @@ export async function validateRequestIssue(
         );
       }
     }
+  }
+
+  // Hooks may mutate formData. Keep UI-only fields out after hook mutation as well.
+  if (parseAllowedFieldIds.length) {
+    formData = filterParsedFormData(formData, parseAllowedFieldIds);
   }
 
   // 5) Required field check from template

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -10,6 +10,10 @@ import type { ValidateFunction } from 'ajv';
 import { runHookInWorker } from './hook-pool.js';
 import addFormatsModule from 'ajv-formats';
 import ajvErrorsModule from 'ajv-errors';
+import {
+  buildAllowedFieldIdsFromSchema as buildAllowedFieldIdsFromSchemaRaw,
+  filterParsedFormData as filterParsedFormDataRaw,
+} from '../../../utils/parser.js';
 
 const moduleFileName = fileURLToPath(import.meta.url);
 const dirName = dirname(moduleFileName);
@@ -421,8 +425,14 @@ type LoadTemplateFn = (
 
 type ParseFormFn = (body: string, template: TemplateLike) => FormData;
 
+type BuildAllowedFieldIdsFromSchemaFn = (schema: unknown, extraAllowedFieldIds?: Iterable<string> | null) => string[];
+
+type FilterParsedFormDataFn = (parsed: FormData, allowedFieldIds?: Iterable<string> | null) => FormData;
+
 const loadTemplate = loadTemplateRaw as unknown as LoadTemplateFn;
 const parseForm = parseFormRaw as unknown as ParseFormFn;
+const buildAllowedFieldIdsFromSchema = buildAllowedFieldIdsFromSchemaRaw as unknown as BuildAllowedFieldIdsFromSchemaFn;
+const filterParsedFormData = filterParsedFormDataRaw as unknown as FilterParsedFormDataFn;
 
 // Error buckets + formatting
 function newBuckets(): ValidationBuckets {
@@ -2318,13 +2328,28 @@ export async function validateRequestIssue(
   });
 
   // 3) form
-  const formData = givenFormData || parseForm(String(issue.body || ''), template);
+  const rawFormData = givenFormData || parseForm(String(issue.body || ''), template);
+
+  let formData = rawFormData;
+  let allowedTemplateFieldIds: Set<string> | null = null;
 
   const resolvedTemplate = resolveTemplateAndRequestType(context, template, formData, errors, buckets);
   if ('result' in resolvedTemplate) return resolvedTemplate.result;
 
   template = resolvedTemplate.template;
   const { requestType, requestCfg } = resolvedTemplate;
+
+  const schemaPathForParseFilter = String(template?._meta?.schema || '').trim();
+  if (schemaPathForParseFilter) {
+    try {
+      const schemaObjForParseFilter = await loadSchemaFromRepoOrLocal(context, owner, repo, schemaPathForParseFilter);
+      const allowedFieldIds = buildAllowedFieldIdsFromSchema(schemaObjForParseFilter);
+      formData = filterParsedFormData(rawFormData, allowedFieldIds);
+      allowedTemplateFieldIds = new Set(allowedFieldIds);
+    } catch {
+      formData = rawFormData;
+    }
+  }
 
   if (DBG && context.log?.info) context.log.info({ formData }, 'ns:parsedFormData');
 
@@ -2409,7 +2434,9 @@ export async function validateRequestIssue(
   }
 
   // 5) Required field check from template
-  const requiredFields = (template?.body || []).filter((f) => f?.id && f.validations?.required);
+  const requiredFields = (template?.body || []).filter(
+    (f) => f?.id && f.validations?.required && (!allowedTemplateFieldIds || allowedTemplateFieldIds.has(String(f.id)))
+  );
 
   const missingRequired = requiredFields
     .filter((f) => isEmpty((formData as Record<string, unknown>)?.[String(f.id)]))

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -5,10 +5,6 @@ type TemplateField = {
   };
 };
 
-type TemplateLike = {
-  body?: TemplateField[];
-};
-
 const NO_RESPONSE_RE = /^_?\s*no\s*response\s*(?:provided)?\s*_?\.?$/i;
 
 function normLabel(s: unknown): string {
@@ -25,6 +21,89 @@ function sanitizeScalar(v: unknown): string {
   if (!s) return '';
   if (NO_RESPONSE_RE.test(s)) return '';
   return s;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const INTERNAL_ALLOWED_FIELD_IDS = [
+  'requestType',
+  'request-type',
+  'open-system',
+  'system-description',
+  'sub-context-description',
+  'shortDescription',
+  'short-description',
+  'correlationIds',
+  'correlation-ids',
+  'correlationIdTypes',
+  'correlation-id-types',
+];
+
+function addAllowedFieldId(out: Set<string>, value: unknown): void {
+  const id = String(value ?? '').trim();
+  if (id) out.add(id);
+}
+
+function collectAllowedFieldIdsFromSchema(schema: unknown, out: Set<string>): void {
+  if (!isPlainObject(schema)) return;
+
+  const props = isPlainObject(schema['properties']) ? schema['properties'] : null;
+  if (props) {
+    for (const [propName, propDef] of Object.entries(props)) {
+      addAllowedFieldId(out, propName);
+      if (isPlainObject(propDef)) addAllowedFieldId(out, propDef['x-form-field']);
+    }
+  }
+
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const entries = schema[key];
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) collectAllowedFieldIdsFromSchema(entry, out);
+  }
+
+  const defs = schema['$defs'];
+  if (isPlainObject(defs)) {
+    for (const entry of Object.values(defs)) collectAllowedFieldIdsFromSchema(entry, out);
+  }
+}
+
+export function buildAllowedFieldIdsFromSchema(
+  schema: unknown,
+  extraAllowedFieldIds: Iterable<string> | null = null
+): string[] {
+  const out = new Set<string>();
+
+  for (const id of INTERNAL_ALLOWED_FIELD_IDS) addAllowedFieldId(out, id);
+
+  if (extraAllowedFieldIds) {
+    for (const id of extraAllowedFieldIds) addAllowedFieldId(out, id);
+  }
+
+  collectAllowedFieldIdsFromSchema(schema, out);
+
+  return Array.from(out);
+}
+
+export function filterParsedFormData(
+  parsed: Record<string, string>,
+  allowedFieldIds: Iterable<string> | null = null
+): Record<string, string> {
+  if (!allowedFieldIds) return { ...parsed };
+
+  const allowed = new Set<string>();
+  for (const id of allowedFieldIds) addAllowedFieldId(allowed, id);
+
+  if (!allowed.size) return { ...parsed };
+
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed || {})) {
+    if (!allowed.has(key)) continue;
+    out[key] = value;
+  }
+
+  return out;
 }
 
 function extractValue(raw: string): string {
@@ -112,7 +191,53 @@ function fallbackKvScan(text: string, fieldMap: Record<string, string>): Record<
   return out;
 }
 
-export function parseForm(body: unknown, template: TemplateLike): Record<string, string> {
+type TemplateMeta = {
+  parseAllowedFieldIds?: string[];
+};
+
+type TemplateLike = {
+  body?: TemplateField[];
+  _meta?: TemplateMeta;
+};
+
+function normalizeFieldId(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function toAllowedFieldSet(value: Iterable<string> | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!value) return out;
+
+  for (const item of value) {
+    const id = normalizeFieldId(item);
+    if (id) out.add(id);
+  }
+
+  return out;
+}
+
+function filterParsedValues(
+  values: Record<string, string>,
+  template: TemplateLike,
+  allowedFieldIds?: Iterable<string>
+): Record<string, string> {
+  const allowed = toAllowedFieldSet(allowedFieldIds ?? template?._meta?.parseAllowedFieldIds);
+  if (!allowed.size) return values;
+
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (!allowed.has(key)) continue;
+    out[key] = value;
+  }
+
+  return out;
+}
+
+export function parseForm(
+  body: unknown,
+  template: TemplateLike,
+  options: { allowedFieldIds?: Iterable<string> } = {}
+): Record<string, string> {
   const result: Record<string, string> = {};
   if (!body || !template) return result;
 
@@ -155,5 +280,5 @@ export function parseForm(body: unknown, template: TemplateLike): Record<string,
     for (const [k, v] of Object.entries(kv)) result[k] = v;
   }
 
-  return result;
+  return filterParsedValues(result, template, options.allowedFieldIds);
 }

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -41,47 +41,121 @@ const INTERNAL_ALLOWED_FIELD_IDS = [
   'correlation-id-types',
 ];
 
+const SCHEMA_PARSE_COMPAT_FIELD_ALIASES: Record<string, string[]> = {
+  contact: ['contacts'],
+  contacts: ['contact'],
+  description: ['system-description', 'sub-context-description'],
+  shortDescription: ['short-description'],
+  correlationIds: ['correlation-ids'],
+  correlationIdTypes: ['correlation-id-types'],
+};
+
 function addAllowedFieldId(out: Set<string>, value: unknown): void {
   const id = String(value ?? '').trim();
   if (id) out.add(id);
 }
 
-function collectAllowedFieldIdsFromSchema(schema: unknown, out: Set<string>): void {
+function toKebabCase(value: string): string {
+  return String(value ?? '')
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[_\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function toSnakeCase(value: string): string {
+  return String(value ?? '')
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function addAllowedCandidate(out: Set<string>, templateFieldIds: Set<string> | null, value: unknown): void {
+  const raw = String(value ?? '').trim();
+  if (!raw) return;
+
+  const variants = [raw, toKebabCase(raw), toSnakeCase(raw)];
+
+  for (const variant of variants) {
+    if (!variant) continue;
+    if (templateFieldIds && !templateFieldIds.has(variant)) continue;
+
+    out.add(variant);
+  }
+}
+
+function collectAllowedFieldIdsFromSchema(
+  schema: unknown,
+  out: Set<string>,
+  templateFieldIds: Set<string> | null
+): void {
   if (!isPlainObject(schema)) return;
 
   const props = isPlainObject(schema['properties']) ? schema['properties'] : null;
+
   if (props) {
-    for (const [propName, propDef] of Object.entries(props)) {
-      addAllowedFieldId(out, propName);
-      if (isPlainObject(propDef)) addAllowedFieldId(out, propDef['x-form-field']);
+    for (const [propertyName, propertyDef] of Object.entries(props)) {
+      const prop = isPlainObject(propertyDef) ? propertyDef : {};
+      const mappedFieldId = String(prop['x-form-field'] ?? '').trim();
+
+      if (mappedFieldId) {
+        addAllowedCandidate(out, templateFieldIds, mappedFieldId);
+      } else {
+        const isConstOnly = Object.hasOwn(prop, 'const');
+
+        // Schema constants such as "type" are generated data, not issue-form input.
+        if (!isConstOnly) {
+          addAllowedCandidate(out, templateFieldIds, propertyName);
+        }
+      }
+
+      for (const alias of SCHEMA_PARSE_COMPAT_FIELD_ALIASES[propertyName] || []) {
+        addAllowedCandidate(out, templateFieldIds, alias);
+      }
     }
   }
 
+  // Only schema composition can contribute top-level input fields.
+  // Do not blindly collect from $defs, otherwise nested object properties can become fake form fields.
   for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
     const entries = schema[key];
     if (!Array.isArray(entries)) continue;
-    for (const entry of entries) collectAllowedFieldIdsFromSchema(entry, out);
-  }
 
-  const defs = schema['$defs'];
-  if (isPlainObject(defs)) {
-    for (const entry of Object.values(defs)) collectAllowedFieldIdsFromSchema(entry, out);
+    for (const entry of entries) {
+      collectAllowedFieldIdsFromSchema(entry, out, templateFieldIds);
+    }
   }
 }
 
 export function buildAllowedFieldIdsFromSchema(
   schema: unknown,
-  extraAllowedFieldIds: Iterable<string> | null = null
+  extraAllowedFieldIds: Iterable<string> | null = null,
+  templateFieldIds: Iterable<string> | null = null
 ): string[] {
   const out = new Set<string>();
 
-  for (const id of INTERNAL_ALLOWED_FIELD_IDS) addAllowedFieldId(out, id);
+  const templateFieldIdSet = templateFieldIds
+    ? new Set(
+        Array.from(templateFieldIds)
+          .map((id) => String(id ?? '').trim())
+          .filter(Boolean)
+      )
+    : null;
 
-  if (extraAllowedFieldIds) {
-    for (const id of extraAllowedFieldIds) addAllowedFieldId(out, id);
+  for (const id of INTERNAL_ALLOWED_FIELD_IDS) {
+    addAllowedFieldId(out, id);
   }
 
-  collectAllowedFieldIdsFromSchema(schema, out);
+  if (extraAllowedFieldIds) {
+    for (const id of extraAllowedFieldIds) {
+      addAllowedFieldId(out, id);
+    }
+  }
+
+  collectAllowedFieldIdsFromSchema(schema, out, templateFieldIdSet);
 
   return Array.from(out);
 }
@@ -219,7 +293,7 @@ function toAllowedFieldSet(value: Iterable<string> | undefined): Set<string> {
 function filterParsedValues(
   values: Record<string, string>,
   template: TemplateLike,
-  allowedFieldIds?: Iterable<string>
+  allowedFieldIds?: Iterable<string> | null
 ): Record<string, string> {
   const allowed = toAllowedFieldSet(allowedFieldIds ?? template?._meta?.parseAllowedFieldIds);
   if (!allowed.size) return values;
@@ -236,7 +310,7 @@ function filterParsedValues(
 export function parseForm(
   body: unknown,
   template: TemplateLike,
-  options: { allowedFieldIds?: Iterable<string> } = {}
+  options: { allowedFieldIds?: Iterable<string> | null } = {}
 ): Record<string, string> {
   const result: Record<string, string> = {};
   if (!body || !template) return result;

--- a/test/pr-reviewers.autorun.test.ts
+++ b/test/pr-reviewers.autorun.test.ts
@@ -57,5 +57,5 @@ describe('pr-reviewers auto-run guard', () => {
     await new Promise((r) => setTimeout(r, 25));
 
     expect(process.exitCode).toBe(1);
-  });
+  }, 15000);
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2430,7 +2430,7 @@ describe('parent owner approval gating', () => {
 
       const ctx: any = mkIssuesContext({ issue, action: 'opened' });
       ctx.octokit.issues.update.mockImplementation(async (args: any) => {
-        if (Object.prototype.hasOwnProperty.call(args, 'body')) throw new Error('update failed');
+        if (Object.hasOwn(args, 'body')) throw new Error('update failed');
         return {};
       });
       ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {

--- a/test/validation-run.more.test.ts
+++ b/test/validation-run.more.test.ts
@@ -684,7 +684,7 @@ describe('validation/run.ts extra coverage', () => {
     restore();
   });
 
-  it('validateRequestIssue: schema has x-form-field="identifier" but template lacks identifier field => config error message', async () => {
+  it('validateRequestIssue: schema identifier mapping without matching parsed field falls back to generic primary-id error', async () => {
     const { mod, mocks, restore } = await loadSubject();
 
     mocks.loadStaticConfig.mockResolvedValue({
@@ -735,7 +735,7 @@ describe('validation/run.ts extra coverage', () => {
 
     const res = await mod.validateRequestIssue(ctx, { owner: 'o', repo: 'r' }, { body: 'body' }, { template });
 
-    expect(res.errors.join('\n')).toMatch(/schema marks a primary identifier/i);
+    expect(res.errors.join('\n')).toMatch(/Cannot resolve primary identifier from template/i);
 
     restore();
   });
@@ -1236,7 +1236,7 @@ describe('validation/run.ts extra coverage', () => {
     const schemaObj = {
       type: 'object',
       required: ['type', 'name'],
-      properties: { type: { const: 'weird' }, name: { type: 'string' } },
+      properties: { type: { const: 'weird' }, name: { 'type': 'string', 'x-form-field': 'identifier' } },
     };
 
     const getContent = jest.fn(async ({ path }: { path: string }) => {

--- a/test/validation-run.test.ts
+++ b/test/validation-run.test.ts
@@ -278,11 +278,8 @@ test('adds required-field messages and returns "Cannot resolve primary identifie
     { template: tpl as any, formData: {} as any }
   );
 
-  expect(res.errors).toEqual([
-    'Required field is missing in form: Identifier',
-    'Cannot resolve primary identifier from template',
-  ]);
-  expect(res.errorsFormatted).toMatch(/Required field is missing/i);
+  expect(res.errors).toEqual(['Cannot resolve primary identifier from template']);
+  expect(res.errorsFormatted).toMatch(/Cannot resolve primary identifier/i);
 });
 
 test('resolvePrimaryIdFromTemplate can use schema x-form-field="identifier" mapping', async () => {
@@ -344,7 +341,7 @@ test('full flow: valid schema + hooks.customValidate + registry-exists adds buck
     additionalProperties: true,
     properties: {
       type: { const: 'system' },
-      name: { type: 'string' },
+      name: { 'type': 'string', 'x-form-field': 'identifier' },
       description: { type: 'string' },
       visibility: { type: 'string' },
     },
@@ -530,7 +527,7 @@ test('falls back to local schema loader when repo does not contain schema', asyn
     return JSON.stringify({
       $schema: 'https://json-schema.org/draft/2020-12/schema',
       type: 'object',
-      properties: { type: { const: 'system' }, name: { type: 'string' } },
+      properties: { type: { const: 'system' }, name: { 'type': 'string', 'x-form-field': 'identifier' } },
       required: ['type', 'name'],
     });
   });


### PR DESCRIPTION
This fixes the parse filter for extra issue form fields.

Changes:

- attach parse-allowed field IDs only after request meta and schema path are resolved
- pass parseAllowedFieldIds into the parser wrapper
- keep UI-only fields in the GitHub issue, but exclude them from parsing, validation, and generated YAML

Result:

- extra fields like justification stay visible in the issue
- they no longer affect schema validation or registry output