### PR TITLE
Re-evaluate direct PR approvals after approval config updates

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Create GitHub Release
         uses: open-resource-discovery/github-release@8c4d8e4db8921195691f8a150e3f744db03ce2dc # main
         with:
-          tag-template: 'v/<version>'
+          tag-template: 'v<version>'
           version: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Summary
+
+- improve auto-update and merge flow for approved registry PRs
+- keep approved PRs in sync with default branch
+- make CI-triggered auto-merge more reliable
+
+## Changes
+
+- auto-update approved PR branches when default branch changes
+- use mergeability state (`behind`) instead of requiring pre-update green checks
+- add delayed retry for branch updates after push events
+- improve merge flow with mergeability polling
+- trigger auto-merge on successful `check_suite` and `check_run` events
+- prevent duplicate approval handling and respect existing approvals
+
+## Result
+
+- approved PRs no longer get stuck outdated
+- smoother CI-driven merge behavior
+- more stable and predictable bot automation
+
 ## [[0.1.0](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v/0.1.0)] - 2026-04-14
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged"
+    "lint:staged": "lint-staged",
+    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.1-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.2-dev.1",
+  "version": "0.1.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.1",
+  "version": "0.1.2-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.1-dev.1",
+  "version": "0.1.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",
@@ -25,8 +25,7 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged",
-    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.1-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
+    "lint:staged": "lint-staged"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.0",
+  "version": "0.1.1-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1906,6 +1906,8 @@ async function resolvePullRequestRequestAuthorId(
     'global-registry-bot[bot]',
     'my-registry-bot',
     'my-registry-bot[bot]',
+    'github-actions[bot]',
+    'github-actions',
   ]);
 
   const isUsableRequesterLogin = (value: unknown): string => {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1900,7 +1900,7 @@ async function resolvePullRequestRequestAuthorId(
 ): Promise<string> {
   let page = 1;
 
-  const blockedServiceUsers = new Set<string>(['web-flow-serviceuser']);
+  const blockedServiceUsers = new Set<string>(['web-flow-serviceuser', 'global-registry-bot', 'my-registry-bot']);
 
   const isUsableRequesterLogin = (value: unknown): string => {
     const login = normalizeLogin(value);

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -101,6 +101,10 @@ type PullRequestLike = {
   user?: UserLike | null;
   head: { ref: string; sha: string };
   base?: { ref?: string | null; sha?: string | null };
+
+  mergeable?: boolean | null;
+  mergeable_state?: string | null;
+  draft?: boolean | null;
 };
 
 type PullRequestFileLike = {
@@ -2393,42 +2397,231 @@ function shouldTryBranchUpdateAfterMergeFailure(error: unknown): boolean {
   );
 }
 
+const MERGEABILITY_POLL_ATTEMPTS = 6;
+const MERGEABILITY_POLL_DELAY_MS = 1500;
+
+function delayMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readFreshPullRequest(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<PullRequestLike | null> {
+  try {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        get: (args: { owner: string; repo: string; pull_number: number }) => Promise<{ data?: PullRequestLike }>;
+      }
+    ).get({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: prNumber,
+    });
+
+    return res.data || null;
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'failed to refresh pull request'
+    );
+
+    return null;
+  }
+}
+
+function readMergeableState(pr: PullRequestLike | null | undefined): string {
+  return toStringTrim(pr?.mergeable_state).toLowerCase();
+}
+
+function isPullRequestOpen(pr: PullRequestLike | null | undefined): boolean {
+  return toStringTrim(pr?.state).toLowerCase() === 'open';
+}
+
+function isMergeabilityPending(pr: PullRequestLike | null | undefined): boolean {
+  const state = readMergeableState(pr);
+
+  return pr?.mergeable === null || state === 'unknown' || state === 'checking';
+}
+
+function isPullRequestBehindBase(pr: PullRequestLike | null | undefined): boolean {
+  return readMergeableState(pr) === 'behind';
+}
+
+function isPullRequestDirty(pr: PullRequestLike | null | undefined): boolean {
+  const state = readMergeableState(pr);
+
+  return state === 'dirty' || state === 'conflicting';
+}
+
+async function waitForPullRequestMergeability(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<PullRequestLike> {
+  let current = pr;
+
+  for (let attempt = 1; attempt <= MERGEABILITY_POLL_ATTEMPTS; attempt += 1) {
+    const fresh = await readFreshPullRequest(context, repoInfo, pr.number);
+    if (fresh) current = fresh;
+
+    const mergeable = current.mergeable;
+    const mergeableState = readMergeableState(current);
+
+    log(
+      context,
+      DBG ? 'debug' : 'info',
+      {
+        prNumber: current.number,
+        attempt,
+        headSha: toStringTrim(current.head?.sha),
+        mergeable,
+        mergeableState,
+        reason,
+      },
+      'pull-request mergeability state'
+    );
+
+    if (!isPullRequestOpen(current)) return current;
+    if (!isMergeabilityPending(current)) return current;
+
+    await delayMs(MERGEABILITY_POLL_DELAY_MS);
+  }
+
+  return current;
+}
+
 async function tryMergeApprovedPrOrUpdateBranch(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   pr: PullRequestLike,
   reason: string
 ): Promise<void> {
-  try {
-    const merged = await tryMergeIfGreen(context, {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      prNumber: pr.number,
-      mergeMethod: 'squash',
-      prData: pr,
-    });
+  let currentPr = await waitForPullRequestMergeability(context, repoInfo, pr, `${reason}:before-merge`);
 
-    if (merged === true) return;
+  if (!isPullRequestOpen(currentPr)) return;
 
-    const latestPr = await readPullRequest(context, repoInfo, pr.number);
-    if (!latestPr) return;
+  if (isPullRequestDirty(currentPr)) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: currentPr.number,
+        mergeableState: readMergeableState(currentPr),
+      },
+      'pull-request has merge conflicts, auto-merge skipped'
+    );
+    return;
+  }
 
-    if (toStringTrim(latestPr.state).toLowerCase() !== 'open') return;
+  if (isPullRequestBehindBase(currentPr)) {
+    await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-before-merge`);
+    return;
+  }
 
-    const approved = await isPullRequestApprovedForBranchMaintenance(context, repoInfo, latestPr);
-    if (!approved) return;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const beforeHeadSha = toStringTrim(currentPr.head?.sha);
 
-    await requestPullRequestBranchUpdate(context, repoInfo, latestPr, `${reason}:merge-not-completed`);
-  } catch (error: unknown) {
-    if (shouldTryBranchUpdateAfterMergeFailure(error)) {
-      const latestPr = await readPullRequest(context, repoInfo, pr.number);
-      if (!latestPr || toStringTrim(latestPr.state).toLowerCase() !== 'open') return;
+    try {
+      const merged = await tryMergeIfGreen(context, {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        prNumber: currentPr.number,
+        mergeMethod: 'squash',
+        prData: currentPr,
+      });
 
-      await requestPullRequestBranchUpdate(context, repoInfo, latestPr, `${reason}:merge-failed-outdated`);
+      const afterMergeAttempt = await readFreshPullRequest(context, repoInfo, currentPr.number);
+      if (!afterMergeAttempt) return;
+
+      if (!isPullRequestOpen(afterMergeAttempt)) {
+        return;
+      }
+
+      const afterHeadSha = toStringTrim(afterMergeAttempt.head?.sha);
+
+      // updateBranch or another actor changed the PR head.
+      // Do not immediately merge; wait for new CI.
+      if (beforeHeadSha && afterHeadSha && beforeHeadSha !== afterHeadSha) {
+        log(
+          context,
+          'info',
+          {
+            prNumber: currentPr.number,
+            beforeHeadSha,
+            afterHeadSha,
+            reason,
+          },
+          'pull-request head changed after merge attempt'
+        );
+        return;
+      }
+
+      if (merged === true) {
+        return;
+      }
+
+      currentPr = await waitForPullRequestMergeability(
+        context,
+        repoInfo,
+        afterMergeAttempt,
+        `${reason}:after-merge-attempt-${attempt}`
+      );
+
+      if (!isPullRequestOpen(currentPr)) return;
+
+      if (isPullRequestDirty(currentPr)) {
+        log(
+          context,
+          'warn',
+          {
+            prNumber: currentPr.number,
+            mergeableState: readMergeableState(currentPr),
+          },
+          'pull-request has merge conflicts after mergeability refresh'
+        );
+        return;
+      }
+
+      if (isPullRequestBehindBase(currentPr)) {
+        await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-after-merge-attempt`);
+        return;
+      }
+
+      // GitHub was still calculating mergeability. Retry once.
+      if (attempt < 2 && isMergeabilityPending(currentPr)) {
+        continue;
+      }
+
+      log(
+        context,
+        'info',
+        {
+          prNumber: currentPr.number,
+          mergeable: currentPr.mergeable,
+          mergeableState: readMergeableState(currentPr),
+          reason,
+        },
+        'pull-request not merged after green check'
+      );
+
       return;
-    }
+    } catch (error: unknown) {
+      if (shouldTryBranchUpdateAfterMergeFailure(error)) {
+        await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:merge-failed-outdated`);
+        return;
+      }
 
-    throw error;
+      throw error;
+    }
   }
 }
 
@@ -2472,28 +2665,6 @@ async function listOpenPullRequests(
   }
 
   return out;
-}
-
-async function readPullRequest(
-  context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo,
-  prNumber: number
-): Promise<PullRequestLike | null> {
-  try {
-    const res = await (
-      context.octokit.pulls as unknown as {
-        get: (args: { owner: string; repo: string; pull_number: number }) => Promise<{ data?: PullRequestLike }>;
-      }
-    ).get({
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      pull_number: prNumber,
-    });
-
-    return res?.data || null;
-  } catch {
-    return null;
-  }
 }
 
 async function processPullRequestForAutoMerge(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -31,8 +31,6 @@ type RequestEvents =
   | 'check_suite.completed'
   | 'check_run.completed'
   | 'status'
-  | 'pull_request.reopened'
-  | 'pull_request.synchronize'
   | 'push';
 
 type ResourceBotContextExt = {
@@ -118,6 +116,13 @@ type PullRequestReviewLike = {
   state?: string | null;
   body?: string | null;
   user?: UserLike | null;
+};
+
+type RefCheckRunLike = {
+  id?: number | null;
+  name?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
 };
 
 type CheckRunPullRequestRef = { number?: number | null };
@@ -1915,27 +1920,6 @@ function buildAutoApprovalReviewMarker(headSha: string): string {
   return `<!-- ${AUTO_APPROVAL_REVIEW_MARKER_PREFIX}${toStringTrim(headSha)} -->`;
 }
 
-async function hasApprovedLabelOnPr(
-  context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo,
-  prNumber: number
-): Promise<boolean> {
-  const eff = resolveEffectiveConstants(context);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
-
-  try {
-    const labels = await fetchIssueLabels(context, {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      issue_number: prNumber,
-    });
-
-    return labelsMatching(labels, approvedLabel).length > 0;
-  } catch {
-    return false;
-  }
-}
-
 async function hasAutoApprovalReviewForHead(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -1967,6 +1951,120 @@ async function hasAutoApprovalReviewForHead(
       (review) =>
         toStringTrim(review?.state).toUpperCase() === 'APPROVED' && toStringTrim(review?.body).includes(marker)
     );
+  } catch {
+    return false;
+  }
+}
+
+function isGreenCheckConclusion(conclusion: string): boolean {
+  const value = toStringTrim(conclusion).toLowerCase();
+  return value === 'success' || value === 'neutral' || value === 'skipped';
+}
+
+function isBlockingCheckConclusion(conclusion: string): boolean {
+  const value = toStringTrim(conclusion).toLowerCase();
+  return (
+    value === 'failure' ||
+    value === 'cancelled' ||
+    value === 'timed_out' ||
+    value === 'action_required' ||
+    value === 'startup_failure' ||
+    value === 'stale'
+  );
+}
+
+async function isHeadGreenForApprovalReevaluation(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  headSha: string
+): Promise<boolean> {
+  const ref = toStringTrim(headSha);
+  if (!ref) return false;
+
+  try {
+    const all: RefCheckRunLike[] = [];
+    let page = 1;
+
+    while (true) {
+      const res = await (
+        context.octokit.checks as unknown as {
+          listForRef: (args: {
+            owner: string;
+            repo: string;
+            ref: string;
+            per_page?: number;
+            page?: number;
+          }) => Promise<{ data?: unknown }>;
+        }
+      ).listForRef({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        ref,
+        per_page: 100,
+        page,
+      });
+
+      const data = (res as { data?: unknown }).data;
+      const runs =
+        isPlainObject(data) && Array.isArray(data['check_runs'])
+          ? (data['check_runs'] as unknown as RefCheckRunLike[])
+          : [];
+
+      all.push(...runs);
+
+      if (runs.length < 100) break;
+      page += 1;
+      if (page > 20) break;
+    }
+
+    const latestByName = new Map<string, RefCheckRunLike>();
+
+    for (const run of all) {
+      const name = toStringTrim(run?.name) || '__unnamed__';
+      const currentId = typeof run?.id === 'number' ? run.id : -1;
+      const prev = latestByName.get(name);
+      const prevId = typeof prev?.id === 'number' ? prev.id : -1;
+
+      if (!prev || currentId > prevId) {
+        latestByName.set(name, run);
+      }
+    }
+
+    if (latestByName.size > 0) {
+      let sawSuccess = false;
+
+      for (const run of latestByName.values()) {
+        const status = toStringTrim(run?.status).toLowerCase();
+        const conclusion = toStringTrim(run?.conclusion).toLowerCase();
+
+        if (status !== 'completed') return false;
+        if (isBlockingCheckConclusion(conclusion)) return false;
+        if (!isGreenCheckConclusion(conclusion)) return false;
+        if (conclusion === 'success') sawSuccess = true;
+      }
+
+      return sawSuccess;
+    }
+  } catch {
+    // fallback below
+  }
+
+  try {
+    const res = await (
+      context.octokit.repos as unknown as {
+        getCombinedStatusForRef: (args: {
+          owner: string;
+          repo: string;
+          ref: string;
+        }) => Promise<{ data?: { state?: string | null } }>;
+      }
+    ).getCombinedStatusForRef({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      ref,
+    });
+
+    return toStringTrim(res?.data?.state).toLowerCase() === 'success';
   } catch {
     return false;
   }
@@ -2150,13 +2248,18 @@ async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
 
   for (const pr of openPrs) {
     if (isSnapshotManagedRequestPr(pr)) continue;
+    if (parseLinkedIssueNumberFromPrBody(pr.body) !== null) continue;
+
+    const headSha = toStringTrim(pr.head?.sha);
+    if (!headSha) continue;
+
+    const isGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
+    if (!isGreen) continue;
 
     try {
-      const alreadyApproved =
-        (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
-        (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, pr.head?.sha || ''));
+      const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha);
 
-      if (alreadyApproved) {
+      if (hasCurrentHeadAutoApproval) {
         await tryMergeIfGreen(context, {
           owner: repoInfo.owner,
           repo: repoInfo.repo,
@@ -4091,15 +4194,6 @@ async function closeOutdatedRequestPrs(
   }
 }
 
-function readPullRequestFromPayload(payload: unknown): PullRequestLike | null {
-  if (!isPlainObject(payload)) return null;
-
-  const pr = payload['pull_request'];
-  if (!isPlainObject(pr)) return null;
-
-  return pr as PullRequestLike;
-}
-
 function readRepoInfoFromPayload(payload: unknown): RepoInfo | null {
   if (!isPlainObject(payload)) return null;
 
@@ -4661,24 +4755,6 @@ export default function requestHandler(app: Probot): void {
       }
     }
   };
-
-  app.on(
-    ['pull_request.reopened', 'pull_request.synchronize'],
-    async (context: BotContext<'pull_request.reopened' | 'pull_request.synchronize'>): Promise<void> => {
-      await getStaticConfig(context);
-
-      const payload = context.payload as unknown;
-      const pr = readPullRequestFromPayload(payload);
-      const repoInfo = readRepoInfoFromPayload(payload);
-
-      if (!pr || !repoInfo) return;
-
-      const headSha = toStringTrim(pr.head?.sha);
-      if (!headSha) return;
-
-      await tryAutoMerge(context, repoInfo, headSha);
-    }
-  );
 
   app.on('push', async (context: BotContext<'push'>): Promise<void> => {
     await getStaticConfig(context);

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -136,7 +136,10 @@ type CheckRunPullRequestRef = { number?: number | null };
 
 type CheckRunLike = {
   id?: number | null;
+  name?: string | null;
+  status?: string | null;
   conclusion?: string | null;
+  head_sha?: string | null;
   html_url?: string | null;
   pull_requests?: CheckRunPullRequestRef[] | null;
 };
@@ -1457,7 +1460,27 @@ const findOpenIssuePrs = findOpenIssuePRsRaw as unknown as FindOpenIssuePrsFn;
 const createRequestPr = createRequestPRRaw as unknown as CreateRequestPrFn;
 const tryMergeIfGreen = tryMergeIfGreenRaw as unknown as TryMergeIfGreenFn;
 
-// Helpers moved to outer scope to satisfy linting
+function readCheckRunFromPayload(payload: unknown): CheckRunLike | null {
+  if (!isPlainObject(payload)) return null;
+
+  const run = payload['check_run'];
+  if (!isPlainObject(run)) return null;
+
+  return run as unknown as CheckRunLike;
+}
+
+function readCheckRunPrNumbers(run: CheckRunLike | null): number[] {
+  const prs = Array.isArray(run?.pull_requests) ? run.pull_requests : [];
+  const out: number[] = [];
+
+  for (const pr of prs) {
+    const n = pr?.number;
+    if (typeof n === 'number' && Number.isFinite(n)) out.push(n);
+  }
+
+  return Array.from(new Set(out));
+}
+
 function extractResourceNameFromForm(formData: FormData, template: TemplateLike): string {
   const rt = toStringTrim(template?._meta?.requestType).toLowerCase();
   const isProduct = rt === 'product';
@@ -2351,17 +2374,21 @@ async function requestPullRequestBranchUpdate(
       const status = getHttpStatus(error);
 
       if (isBenignUpdateBranchFailure(error)) {
+        const fresh = await readFreshPullRequest(context, repoInfo, pr.number);
+
         log(
           context,
           'debug',
           {
             prNumber: pr.number,
-            headSha,
+            oldHeadSha: headSha,
+            freshHeadSha: toStringTrim(fresh?.head?.sha),
             status,
             err: msg,
             reason,
+            freshMergeableState: readMergeableState(fresh),
           },
-          'pull-request branch update skipped'
+          'pull-request branch update skipped after head race'
         );
 
         return false;
@@ -2922,20 +2949,47 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
         continue;
       }
 
-      const green = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
-      if (!green) {
+      const freshPr = await waitForPullRequestMergeability(context, repoInfo, pr, `${reason}:before-update-branch`);
+
+      if (!isPullRequestOpen(freshPr)) {
+        if (DBG) {
+          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: PR is not open');
+        }
+        continue;
+      }
+
+      if (isPullRequestDirty(freshPr)) {
+        log(
+          context,
+          'warn',
+          {
+            prNumber: freshPr.number,
+            mergeableState: readMergeableState(freshPr),
+            reason,
+          },
+          'skip branch update: PR has merge conflicts'
+        );
+        continue;
+      }
+
+      if (!isPullRequestBehindBase(freshPr)) {
         if (DBG) {
           log(
             context,
             'debug',
-            { prNumber: pr.number, headSha, reason },
-            'skip branch update: PR head checks are not green'
+            {
+              prNumber: freshPr.number,
+              mergeable: freshPr.mergeable,
+              mergeableState: readMergeableState(freshPr),
+              reason,
+            },
+            'skip branch update: PR is not behind base'
           );
         }
         continue;
       }
 
-      await requestPullRequestBranchUpdate(context, repoInfo, pr, reason);
+      await requestPullRequestBranchUpdate(context, repoInfo, freshPr, reason);
     } catch (error: unknown) {
       log(
         context,
@@ -5465,8 +5519,43 @@ export default function requestHandler(app: Probot): void {
     async (context: BotContext<'check_suite.completed' | 'check_run.completed'>): Promise<void> => {
       const payload = context.payload as unknown;
 
-      // Avoid duplicate posting (both events fire). Handle only check_suite.
-      if (context.name === 'check_run.completed') return;
+      if (context.name === 'check_run.completed') {
+        const payload = context.payload as unknown;
+        const run = readCheckRunFromPayload(payload);
+
+        const conclusion = toStringTrim(run?.conclusion).toLowerCase();
+        const status = toStringTrim(run?.status).toLowerCase();
+        const headShaStr = toStringTrim(run?.head_sha);
+
+        if (status !== 'completed') return;
+        if (conclusion !== 'success') return;
+        if (!headShaStr) return;
+
+        const repoObj = isPlainObject(payload) ? payload['repository'] : undefined;
+        const repoName = isPlainObject(repoObj) ? toStringTrim(repoObj['name']) : '';
+        const ownerObj = isPlainObject(repoObj) ? repoObj['owner'] : undefined;
+        const ownerLogin = isPlainObject(ownerObj) ? toStringTrim(ownerObj['login']) : '';
+
+        if (!ownerLogin || !repoName) return;
+
+        const repoInfo = { owner: ownerLogin, repo: repoName };
+        const prNumbers = readCheckRunPrNumbers(run);
+
+        for (const prNumber of prNumbers) {
+          await collapseBotCommentsByPrefix(
+            context,
+            { owner: ownerLogin, repo: repoName, issue_number: prNumber },
+            {
+              tagPrefix: 'nsreq:ci-validation',
+              collapseBody: 'Validation issues resolved.',
+              classifier: 'RESOLVED',
+            }
+          );
+        }
+
+        await tryAutoMerge(context, repoInfo, headShaStr);
+        return;
+      }
 
       if (DBG) {
         log(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1900,7 +1900,13 @@ async function resolvePullRequestRequestAuthorId(
 ): Promise<string> {
   let page = 1;
 
-  const blockedServiceUsers = new Set<string>(['web-flow-serviceuser', 'global-registry-bot', 'my-registry-bot']);
+  const blockedServiceUsers = new Set<string>([
+    'web-flow-serviceuser',
+    'global-registry-bot',
+    'global-registry-bot[bot]',
+    'my-registry-bot',
+    'my-registry-bot[bot]',
+  ]);
 
   const isUsableRequesterLogin = (value: unknown): string => {
     const login = normalizeLogin(value);

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1968,7 +1968,7 @@ async function resolvePullRequestRequestAuthorId(
     firstAuthorLogin ||
     firstCommitterLogin ||
     isUsableRequesterLogin(pr.user?.login) ||
-    normalizeLogin(pr.user?.login)
+    ''
   );
 }
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -30,7 +30,10 @@ type RequestEvents =
   | 'issue_comment.edited'
   | 'check_suite.completed'
   | 'check_run.completed'
-  | 'status';
+  | 'status'
+  | 'pull_request.reopened'
+  | 'pull_request.synchronize'
+  | 'push';
 
 type ResourceBotContextExt = {
   resourceBotConfig?: NormalizedStaticConfig;
@@ -109,6 +112,12 @@ type PullRequestFileLike = {
 type PullRequestCommitLike = {
   author?: UserLike | null;
   committer?: UserLike | null;
+};
+
+type PullRequestReviewLike = {
+  state?: string | null;
+  body?: string | null;
+  user?: UserLike | null;
 };
 
 type CheckRunPullRequestRef = { number?: number | null };
@@ -1789,6 +1798,7 @@ async function createAutomatedApprovalReview(
 ): Promise<boolean> {
   const body =
     toStringTrim(decision.comment) || toStringTrim(decision.message) || 'Approved automatically by onApproval hook.';
+  const reviewBody = `${body}\n\n${buildAutoApprovalReviewMarker(pr.head?.sha || '')}`;
 
   try {
     await (
@@ -1806,7 +1816,7 @@ async function createAutomatedApprovalReview(
       repo: repoInfo.repo,
       pull_number: pr.number,
       event: 'APPROVE',
-      body,
+      body: reviewBody,
     });
 
     return true;
@@ -1896,6 +1906,279 @@ async function addApprovedLabelToPr(
     });
   } catch {
     // ignore
+  }
+}
+
+const AUTO_APPROVAL_REVIEW_MARKER_PREFIX = 'nsreq:auto-approval:';
+
+function buildAutoApprovalReviewMarker(headSha: string): string {
+  return `<!-- ${AUTO_APPROVAL_REVIEW_MARKER_PREFIX}${toStringTrim(headSha)} -->`;
+}
+
+async function hasApprovedLabelOnPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<boolean> {
+  const eff = resolveEffectiveConstants(context);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+
+  try {
+    const labels = await fetchIssueLabels(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      issue_number: prNumber,
+    });
+
+    return labelsMatching(labels, approvedLabel).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function hasAutoApprovalReviewForHead(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number,
+  headSha: string
+): Promise<boolean> {
+  const marker = buildAutoApprovalReviewMarker(headSha);
+
+  try {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        listReviews: (args: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          per_page?: number;
+        }) => Promise<{ data?: PullRequestReviewLike[] }>;
+      }
+    ).listReviews({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: prNumber,
+      per_page: 100,
+    });
+
+    const reviews = Array.isArray(res?.data) ? res.data : [];
+
+    return reviews.some(
+      (review) =>
+        toStringTrim(review?.state).toUpperCase() === 'APPROVED' && toStringTrim(review?.body).includes(marker)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
+  const raw = toStringTrim(body);
+  const match = /source:\s*#(\d+)/i.exec(raw) ?? /issue\s*#(\d+)/i.exec(raw);
+  if (!match?.[1]) return null;
+
+  const value = Number.parseInt(match[1], 10);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isSnapshotManagedRequestPr(pr: PullRequestLike): boolean {
+  return Boolean(extractHashFromPrBody(toStringTrim(pr.body)));
+}
+
+async function listOpenPullRequests(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo
+): Promise<PullRequestLike[]> {
+  const out: PullRequestLike[] = [];
+  let page = 1;
+
+  while (true) {
+    const { data } = await context.octokit.pulls.list({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      state: 'open',
+      per_page: 100,
+      page,
+    });
+
+    const prs = (data || []) as unknown as PullRequestLike[];
+    if (!prs.length) break;
+
+    out.push(...prs);
+
+    if (prs.length < 100) break;
+    page += 1;
+    if (page > 20) break;
+  }
+
+  return out;
+}
+
+async function processPullRequestForAutoMerge(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<void> {
+  const issueNumber = parseLinkedIssueNumberFromPrBody(pr.body);
+
+  if (issueNumber === null) {
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
+    if (standaloneOutcome !== 'approved') return;
+
+    await tryMergeIfGreen(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      prNumber: pr.number,
+      mergeMethod: 'squash',
+      prData: pr,
+    });
+    return;
+  }
+
+  const params: IssueParams = {
+    owner: repoInfo.owner,
+    repo: repoInfo.repo,
+    issue_number: issueNumber,
+  };
+
+  let issue: IssueLike;
+  try {
+    const res = await context.octokit.issues.get(params);
+    issue = res.data as unknown as IssueLike;
+  } catch {
+    return;
+  }
+
+  if (!process.env.JEST_WORKER_ID && !hasIssueFormInputs(issue)) return;
+
+  let template: TemplateLike;
+  try {
+    template = await loadTemplateWithLabelRefresh(context, params, issue);
+  } catch {
+    return;
+  }
+
+  const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
+  if (!isRequestIssue(context, template, parsedFormData)) return;
+
+  const body = toStringTrim(pr.body);
+  const currentHash = calcSnapshotHash(parsedFormData, template, readIssueBodyForProcessing(issue.body));
+  const prHash = extractHashFromPrBody(body);
+
+  if (prHash) {
+    if (prHash !== currentHash) {
+      await closeOutdatedRequestPrs(context, params, template, { parsedFormData, currentHash });
+      return;
+    }
+
+    await tryMergeIfGreen(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      prNumber: pr.number,
+      mergeMethod: 'squash',
+      prData: pr,
+    });
+    return;
+  }
+
+  const directPrOutcome = await maybeHandleDirectPrApprovalForMerge(
+    context,
+    repoInfo,
+    params,
+    issue,
+    template,
+    parsedFormData,
+    pr
+  );
+
+  if (directPrOutcome !== 'approved') return;
+
+  await tryMergeIfGreen(context, {
+    owner: repoInfo.owner,
+    repo: repoInfo.repo,
+    prNumber: pr.number,
+    mergeMethod: 'squash',
+    prData: pr,
+  });
+}
+
+function isApprovalConfigChangePath(filePath: string): boolean {
+  return /^\.github\/registry-bot\/config\.(?:[cm]?js|ts|ya?ml)$/i.test(normalizeRepoPath(filePath));
+}
+
+function readPushChangedFiles(payload: unknown): string[] {
+  if (!isPlainObject(payload)) return [];
+
+  const commits = Array.isArray(payload['commits']) ? payload['commits'] : [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const commit of commits) {
+    if (!isPlainObject(commit)) continue;
+
+    for (const key of ['added', 'modified', 'removed'] as const) {
+      const files = Array.isArray(commit[key]) ? commit[key] : [];
+      for (const file of files) {
+        const normalized = normalizeRepoPath(file);
+        if (!normalized || seen.has(normalized)) continue;
+        seen.add(normalized);
+        out.push(normalized);
+      }
+    }
+  }
+
+  return out;
+}
+
+function isRelevantDefaultBranchPushForApprovalReevaluation(payload: unknown): boolean {
+  if (!isPlainObject(payload)) return false;
+
+  const ref = toStringTrim(payload['ref']);
+  const repoObj = isPlainObject(payload['repository']) ? payload['repository'] : null;
+  const defaultBranch = repoObj ? toStringTrim(repoObj['default_branch']) : '';
+
+  if (!ref || !defaultBranch || ref !== `refs/heads/${defaultBranch}`) return false;
+
+  return readPushChangedFiles(payload).some(isApprovalConfigChangePath);
+}
+
+async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo
+): Promise<void> {
+  const openPrs = await listOpenPullRequests(context, repoInfo);
+
+  for (const pr of openPrs) {
+    if (isSnapshotManagedRequestPr(pr)) continue;
+
+    try {
+      const alreadyApproved =
+        (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
+        (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, pr.head?.sha || ''));
+
+      if (alreadyApproved) {
+        await tryMergeIfGreen(context, {
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          prNumber: pr.number,
+          mergeMethod: 'squash',
+          prData: pr,
+        });
+        continue;
+      }
+
+      await processPullRequestForAutoMerge(context, repoInfo, pr);
+    } catch (e: unknown) {
+      log(
+        context,
+        'warn',
+        {
+          err: e instanceof Error ? e.message : String(e),
+          prNumber: pr.number,
+        },
+        'failed to re-evaluate direct pull request after approval config change'
+      );
+    }
   }
 }
 
@@ -2227,10 +2510,20 @@ async function maybeHandleStandaloneDirectPrApproval(
   const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr);
 
   if (decision.status === 'approved') {
-    const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
-    if (!approved) return 'continue';
+    const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(
+      context,
+      repoInfo,
+      pr.number,
+      pr.head?.sha || ''
+    );
 
-    await addApprovedLabelToPr(context, repoInfo, pr.number);
+    if (!hasCurrentHeadAutoApproval) {
+      const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
+      if (!approved) return 'continue';
+
+      await addApprovedLabelToPr(context, repoInfo, pr.number);
+    }
+
     return 'approved';
   }
 
@@ -2458,10 +2751,20 @@ async function maybeHandleDirectPrApprovalForMerge(
   );
 
   if (decision.status === 'approved') {
-    const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
-    if (!approved) return 'continue';
+    const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(
+      context,
+      repoInfo,
+      pr.number,
+      pr.head?.sha || ''
+    );
 
-    await addApprovedLabelToPr(context, repoInfo, pr.number);
+    if (!hasCurrentHeadAutoApproval) {
+      const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
+      if (!approved) return 'continue';
+
+      await addApprovedLabelToPr(context, repoInfo, pr.number);
+    }
+
     await applyApprovedRequestState(context, issueParams, resolveEffectiveConstants(context));
     return 'approved';
   }
@@ -3788,6 +4091,30 @@ async function closeOutdatedRequestPrs(
   }
 }
 
+function readPullRequestFromPayload(payload: unknown): PullRequestLike | null {
+  if (!isPlainObject(payload)) return null;
+
+  const pr = payload['pull_request'];
+  if (!isPlainObject(pr)) return null;
+
+  return pr as PullRequestLike;
+}
+
+function readRepoInfoFromPayload(payload: unknown): RepoInfo | null {
+  if (!isPlainObject(payload)) return null;
+
+  const repoObj = payload['repository'];
+  if (!isPlainObject(repoObj)) return null;
+
+  const repoName = toStringTrim(repoObj['name']);
+  const ownerObj = isPlainObject(repoObj['owner']) ? repoObj['owner'] : null;
+  const ownerLogin = ownerObj ? toStringTrim(ownerObj['login']) : '';
+
+  if (!ownerLogin || !repoName) return null;
+
+  return { owner: ownerLogin, repo: repoName };
+}
+
 export default function requestHandler(app: Probot): void {
   const getStaticConfig = async (context: BotContext<RequestEvents>): Promise<NormalizedStaticConfig> => {
     if (context.resourceBotConfig && context.resourceBotHooks !== undefined) return context.resourceBotConfig;
@@ -4310,117 +4637,60 @@ export default function requestHandler(app: Probot): void {
   );
 
   const tryAutoMerge = async (
-    context: BotContext<'check_suite.completed' | 'check_run.completed' | 'status'>,
+    context: BotContext<RequestEvents>,
     repoInfo: RepoInfo,
     headSha: string
   ): Promise<void> => {
-    const { owner, repo } = repoInfo;
     await getStaticConfig(context);
 
-    let page = 1;
-    const candidates: PullRequestLike[] = [];
-
-    while (true) {
-      const { data } = await context.octokit.pulls.list({
-        owner,
-        repo,
-        state: 'open',
-        per_page: 100,
-        page,
-      });
-
-      const prs = (data || []) as unknown as PullRequestLike[];
-      if (!prs.length) break;
-
-      candidates.push(...prs.filter((pr) => pr.head?.sha === headSha));
-      if (prs.length < 100) break;
-
-      page += 1;
-    }
+    const candidates = (await listOpenPullRequests(context, repoInfo)).filter((pr) => pr.head?.sha === headSha);
 
     for (const pr of candidates) {
-      const body = String(pr.body || '');
-      const m = /source:\s*#(\d+)/i.exec(body) ?? /issue\s*#(\d+)/i.exec(body);
-
-      if (!m) {
-        const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, { owner, repo }, pr);
-        if (standaloneOutcome !== 'approved') continue;
-
-        await tryMergeIfGreen(context, {
-          owner,
-          repo,
-          prNumber: pr.number,
-          mergeMethod: 'squash',
-          prData: pr,
-        });
-        continue;
-      }
-
-      const issueNumber = Number.parseInt(m[1], 10);
-      const params: IssueParams = { owner, repo, issue_number: issueNumber };
-
-      let issue: IssueLike;
       try {
-        const res = await context.octokit.issues.get({ owner, repo, issue_number: issueNumber });
-        issue = res.data as unknown as IssueLike;
-      } catch {
-        continue;
+        await processPullRequestForAutoMerge(context, repoInfo, pr);
+      } catch (e: unknown) {
+        log(
+          context,
+          'warn',
+          {
+            err: e instanceof Error ? e.message : String(e),
+            prNumber: pr.number,
+          },
+          'auto-merge candidate processing failed'
+        );
       }
-
-      if (!process.env.JEST_WORKER_ID) {
-        if (!hasIssueFormInputs(issue)) continue;
-      }
-
-      let template: TemplateLike;
-      try {
-        template = await loadTemplateWithLabelRefresh(context, params, issue);
-      } catch {
-        continue;
-      }
-
-      const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
-      if (!isRequestIssue(context, template, parsedFormData)) continue;
-
-      const currentHash = calcSnapshotHash(parsedFormData, template, readIssueBodyForProcessing(issue.body));
-      const prHash = extractHashFromPrBody(body);
-
-      if (prHash) {
-        if (prHash !== currentHash) {
-          await closeOutdatedRequestPrs(context, params, template, { parsedFormData, currentHash });
-          continue;
-        }
-
-        await tryMergeIfGreen(context, {
-          owner,
-          repo,
-          prNumber: pr.number,
-          mergeMethod: 'squash',
-          prData: pr,
-        });
-        continue;
-      }
-
-      const directPrOutcome = await maybeHandleDirectPrApprovalForMerge(
-        context,
-        { owner, repo },
-        params,
-        issue,
-        template,
-        parsedFormData,
-        pr
-      );
-
-      if (directPrOutcome !== 'approved') continue;
-
-      await tryMergeIfGreen(context, {
-        owner,
-        repo,
-        prNumber: pr.number,
-        mergeMethod: 'squash',
-        prData: pr,
-      });
     }
   };
+
+  app.on(
+    ['pull_request.reopened', 'pull_request.synchronize'],
+    async (context: BotContext<'pull_request.reopened' | 'pull_request.synchronize'>): Promise<void> => {
+      await getStaticConfig(context);
+
+      const payload = context.payload as unknown;
+      const pr = readPullRequestFromPayload(payload);
+      const repoInfo = readRepoInfoFromPayload(payload);
+
+      if (!pr || !repoInfo) return;
+
+      const headSha = toStringTrim(pr.head?.sha);
+      if (!headSha) return;
+
+      await tryAutoMerge(context, repoInfo, headSha);
+    }
+  );
+
+  app.on('push', async (context: BotContext<'push'>): Promise<void> => {
+    await getStaticConfig(context);
+
+    const payload = context.payload as unknown;
+    if (!isRelevantDefaultBranchPushForApprovalReevaluation(payload)) return;
+
+    const repoInfo = readRepoInfoFromPayload(payload);
+    if (!repoInfo) return;
+
+    await reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(context, repoInfo);
+  });
 
   app.on(
     ['check_suite.completed', 'check_run.completed'],

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -4737,7 +4737,25 @@ export default function requestHandler(app: Probot): void {
   ): Promise<void> => {
     await getStaticConfig(context);
 
-    const candidates = (await listOpenPullRequests(context, repoInfo)).filter((pr) => pr.head?.sha === headSha);
+    const normalizedHeadSha = toStringTrim(headSha);
+    if (!normalizedHeadSha) return;
+
+    const headIsGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, normalizedHeadSha);
+    if (!headIsGreen) {
+      if (DBG) {
+        log(
+          context,
+          'debug',
+          { owner: repoInfo.owner, repo: repoInfo.repo, headSha: normalizedHeadSha },
+          'skip direct PR approval until full validation pipeline is green'
+        );
+      }
+      return;
+    }
+
+    const candidates = (await listOpenPullRequests(context, repoInfo)).filter(
+      (pr) => toStringTrim(pr.head?.sha) === normalizedHeadSha
+    );
 
     for (const pr of candidates) {
       try {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2228,6 +2228,12 @@ async function isHeadGreenForApprovalReevaluation(
 
 const UPDATE_BRANCH_INFLIGHT = new Map<string, Promise<boolean>>();
 
+const DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS = 5000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -2402,12 +2408,23 @@ async function tryMergeApprovedPrOrUpdateBranch(
       prData: pr,
     });
 
-    if (merged === false) {
-      await requestPullRequestBranchUpdate(context, repoInfo, pr, `${reason}:merge-returned-false`);
-    }
+    if (merged === true) return;
+
+    const latestPr = await readPullRequest(context, repoInfo, pr.number);
+    if (!latestPr) return;
+
+    if (toStringTrim(latestPr.state).toLowerCase() !== 'open') return;
+
+    const approved = await isPullRequestApprovedForBranchMaintenance(context, repoInfo, latestPr);
+    if (!approved) return;
+
+    await requestPullRequestBranchUpdate(context, repoInfo, latestPr, `${reason}:merge-not-completed`);
   } catch (error: unknown) {
     if (shouldTryBranchUpdateAfterMergeFailure(error)) {
-      await requestPullRequestBranchUpdate(context, repoInfo, pr, `${reason}:merge-failed-outdated`);
+      const latestPr = await readPullRequest(context, repoInfo, pr.number);
+      if (!latestPr || toStringTrim(latestPr.state).toLowerCase() !== 'open') return;
+
+      await requestPullRequestBranchUpdate(context, repoInfo, latestPr, `${reason}:merge-failed-outdated`);
       return;
     }
 
@@ -2455,6 +2472,28 @@ async function listOpenPullRequests(
   }
 
   return out;
+}
+
+async function readPullRequest(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<PullRequestLike | null> {
+  try {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        get: (args: { owner: string; repo: string; pull_number: number }) => Promise<{ data?: PullRequestLike }>;
+      }
+    ).get({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: prNumber,
+    });
+
+    return res?.data || null;
+  } catch {
+    return null;
+  }
 }
 
 async function processPullRequestForAutoMerge(
@@ -2634,27 +2673,70 @@ function pullRequestTargetsBranch(pr: PullRequestLike, branchName: string): bool
 async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
-  baseBranch: string
+  baseBranch: string,
+  reason = 'default-branch-push'
 ): Promise<void> {
   const openPrs = await listOpenPullRequests(context, repoInfo);
 
   for (const pr of openPrs) {
     const headSha = toStringTrim(pr.head?.sha);
-    if (!headSha) continue;
 
-    if (!pullRequestTargetsBranch(pr, baseBranch)) continue;
+    if (!headSha) {
+      if (DBG) {
+        log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: missing head sha');
+      }
+      continue;
+    }
+
+    if (!pullRequestTargetsBranch(pr, baseBranch)) {
+      if (DBG) {
+        log(
+          context,
+          'debug',
+          {
+            prNumber: pr.number,
+            prBase: toStringTrim(pr.base?.ref),
+            baseBranch,
+            reason,
+          },
+          'skip branch update: different base branch'
+        );
+      }
+      continue;
+    }
 
     try {
       const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
-      if (!changedRegistryFiles.length) continue;
+
+      if (!changedRegistryFiles.length) {
+        if (DBG) {
+          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: no registry yaml files changed');
+        }
+        continue;
+      }
 
       const approved = await isPullRequestApprovedForBranchMaintenance(context, repoInfo, pr);
-      if (!approved) continue;
+      if (!approved) {
+        if (DBG) {
+          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: PR is not approved');
+        }
+        continue;
+      }
 
       const green = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
-      if (!green) continue;
+      if (!green) {
+        if (DBG) {
+          log(
+            context,
+            'debug',
+            { prNumber: pr.number, headSha, reason },
+            'skip branch update: PR head checks are not green'
+          );
+        }
+        continue;
+      }
 
-      await requestPullRequestBranchUpdate(context, repoInfo, pr, 'default-branch-push');
+      await requestPullRequestBranchUpdate(context, repoInfo, pr, reason);
     } catch (error: unknown) {
       log(
         context,
@@ -2662,11 +2744,34 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
         {
           err: getErrorMessage(error),
           prNumber: pr.number,
+          reason,
         },
         'failed to update approved pull request branch after default branch push'
       );
     }
   }
+}
+
+async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  baseBranch: string
+): Promise<void> {
+  await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
+    context,
+    repoInfo,
+    baseBranch,
+    'default-branch-push'
+  );
+
+  await sleep(DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS);
+
+  await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
+    context,
+    repoInfo,
+    baseBranch,
+    'default-branch-push:delayed-retry'
+  );
 }
 
 function normalizeRepoPath(path: unknown): string {
@@ -5175,7 +5280,7 @@ export default function requestHandler(app: Probot): void {
     }
 
     // after main changed, keep already-approved green registry PRs up to date
-    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(context, repoInfo, baseBranch);
+    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
   });
 
   app.on(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -114,8 +114,10 @@ type PullRequestCommitLike = {
 };
 
 type PullRequestReviewLike = {
+  id?: number | null;
   state?: string | null;
   body?: string | null;
+  submitted_at?: string | null;
   user?: UserLike | null;
 };
 
@@ -2012,7 +2014,33 @@ async function hasApprovedReviewOnPr(
   try {
     const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
 
-    return reviews.some((review) => toStringTrim(review?.state).toUpperCase() === 'APPROVED');
+    const sorted = reviews.slice().sort((a, b) => {
+      const at = Date.parse(toStringTrim(a.submitted_at));
+      const bt = Date.parse(toStringTrim(b.submitted_at));
+
+      if (Number.isFinite(at) && Number.isFinite(bt) && at !== bt) return at - bt;
+
+      const aid = typeof a.id === 'number' ? a.id : 0;
+      const bid = typeof b.id === 'number' ? b.id : 0;
+      return aid - bid;
+    });
+
+    const latestByReviewer = new Map<string, string>();
+
+    for (const review of sorted) {
+      const reviewer = normalizeLogin(review?.user?.login).toLowerCase();
+      const state = toStringTrim(review?.state).toUpperCase();
+
+      if (!reviewer || !state) continue;
+
+      latestByReviewer.set(reviewer, state);
+    }
+
+    const latestStates = Array.from(latestByReviewer.values());
+
+    if (latestStates.includes('CHANGES_REQUESTED')) return false;
+
+    return latestStates.includes('APPROVED');
   } catch {
     return false;
   }
@@ -2219,6 +2247,8 @@ function isBenignUpdateBranchFailure(error: unknown): boolean {
     msg.includes('head sha') ||
     msg.includes('head branch was modified') ||
     msg.includes('not behind') ||
+    msg.includes('up to date') ||
+    msg.includes('up-to-date') ||
     msg.includes('already up') ||
     msg.includes('already up-to-date') ||
     msg.includes('already up to date')
@@ -2967,14 +2997,14 @@ async function maybeHandleStandaloneDirectPrApproval(
   const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr);
 
   if (decision.status === 'approved') {
-    const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(
-      context,
-      repoInfo,
-      pr.number,
-      pr.head?.sha || ''
-    );
+    const headSha = toStringTrim(pr.head?.sha);
 
-    if (!hasCurrentHeadAutoApproval) {
+    const alreadyApproved =
+      (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) ||
+      (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
+      (await hasApprovedReviewOnPr(context, repoInfo, pr.number));
+
+    if (!alreadyApproved) {
       const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
       if (!approved) return 'continue';
 
@@ -3208,14 +3238,14 @@ async function maybeHandleDirectPrApprovalForMerge(
   );
 
   if (decision.status === 'approved') {
-    const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(
-      context,
-      repoInfo,
-      pr.number,
-      pr.head?.sha || ''
-    );
+    const headSha = toStringTrim(pr.head?.sha);
 
-    if (!hasCurrentHeadAutoApproval) {
+    const alreadyApproved =
+      (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) ||
+      (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
+      (await hasApprovedReviewOnPr(context, repoInfo, pr.number));
+
+    if (!alreadyApproved) {
       const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
       if (!approved) return 'continue';
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2010,6 +2010,51 @@ async function listPullRequestReviews(
   return out;
 }
 
+const ACTIONABLE_REVIEW_STATES = new Set<string>(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
+
+function sortPullRequestReviewsChronologically(reviews: PullRequestReviewLike[]): PullRequestReviewLike[] {
+  return reviews.slice().sort((a, b) => {
+    const at = Date.parse(toStringTrim(a.submitted_at));
+    const bt = Date.parse(toStringTrim(b.submitted_at));
+
+    if (Number.isFinite(at) && Number.isFinite(bt) && at !== bt) return at - bt;
+
+    const aid = typeof a.id === 'number' ? a.id : 0;
+    const bid = typeof b.id === 'number' ? b.id : 0;
+    return aid - bid;
+  });
+}
+
+function getLatestActionableReviewStates(reviews: PullRequestReviewLike[]): Map<string, string> {
+  const latestByReviewer = new Map<string, string>();
+
+  for (const review of sortPullRequestReviewsChronologically(reviews)) {
+    const reviewer = normalizeLogin(review?.user?.login).toLowerCase();
+    const state = toStringTrim(review?.state).toUpperCase();
+
+    if (!reviewer || !ACTIONABLE_REVIEW_STATES.has(state)) continue;
+
+    latestByReviewer.set(reviewer, state);
+  }
+
+  return latestByReviewer;
+}
+
+async function hasBlockingChangesRequestedReviewOnPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<boolean> {
+  try {
+    const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
+    const latestStates = new Set(getLatestActionableReviewStates(reviews).values());
+
+    return latestStates.has('CHANGES_REQUESTED');
+  } catch {
+    return false;
+  }
+}
+
 async function hasApprovedReviewOnPr(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -2018,33 +2063,11 @@ async function hasApprovedReviewOnPr(
   try {
     const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
 
-    const sorted = reviews.slice().sort((a, b) => {
-      const at = Date.parse(toStringTrim(a.submitted_at));
-      const bt = Date.parse(toStringTrim(b.submitted_at));
+    const latestStates = new Set(getLatestActionableReviewStates(reviews).values());
 
-      if (Number.isFinite(at) && Number.isFinite(bt) && at !== bt) return at - bt;
+    if (latestStates.has('CHANGES_REQUESTED')) return false;
 
-      const aid = typeof a.id === 'number' ? a.id : 0;
-      const bid = typeof b.id === 'number' ? b.id : 0;
-      return aid - bid;
-    });
-
-    const latestByReviewer = new Map<string, string>();
-
-    for (const review of sorted) {
-      const reviewer = normalizeLogin(review?.user?.login).toLowerCase();
-      const state = toStringTrim(review?.state).toUpperCase();
-
-      if (!reviewer || !state) continue;
-
-      latestByReviewer.set(reviewer, state);
-    }
-
-    const latestStates = Array.from(latestByReviewer.values());
-
-    if (latestStates.includes('CHANGES_REQUESTED')) return false;
-
-    return latestStates.includes('APPROVED');
+    return latestStates.has('APPROVED');
   } catch {
     return false;
   }
@@ -2076,6 +2099,10 @@ async function isPullRequestApprovedForBranchMaintenance(
   repoInfo: RepoInfo,
   pr: PullRequestLike
 ): Promise<boolean> {
+  if (await hasBlockingChangesRequestedReviewOnPr(context, repoInfo, pr.number)) {
+    return false;
+  }
+
   // Bot-created request PRs are only created after issue approval.
   if (isSnapshotManagedRequestPr(pr)) return true;
 
@@ -2233,10 +2260,6 @@ async function isHeadGreenForApprovalReevaluation(
 const UPDATE_BRANCH_INFLIGHT = new Map<string, Promise<boolean>>();
 
 const DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS = 5000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -2566,6 +2589,11 @@ async function tryMergeApprovedPrOrUpdateBranch(
       }
 
       if (merged === true) {
+        return;
+      }
+
+      if (merged === false) {
+        await requestPullRequestBranchUpdate(context, repoInfo, afterMergeAttempt, `${reason}:merge-returned-false`);
         return;
       }
 
@@ -2935,14 +2963,28 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRe
     'default-branch-push'
   );
 
-  await sleep(DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS);
+  const retryTimer = setTimeout(() => {
+    void updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
+      context,
+      repoInfo,
+      baseBranch,
+      'default-branch-push:delayed-retry'
+    ).catch((error: unknown) => {
+      log(
+        context,
+        'warn',
+        {
+          err: getErrorMessage(error),
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          baseBranch,
+        },
+        'failed to run delayed approved pull request branch update retry'
+      );
+    });
+  }, DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS);
 
-  await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
-    context,
-    repoInfo,
-    baseBranch,
-    'default-branch-push:delayed-retry'
-  );
+  retryTimer.unref?.();
 }
 
 function normalizeRepoPath(path: unknown): string {
@@ -4894,42 +4936,6 @@ export default function requestHandler(app: Probot): void {
       context.resourceBotHooksSource = null;
       return context.resourceBotConfig;
     }
-  };
-
-  const isRequestIssue = (
-    context: BotContext<RequestEvents>,
-    template: TemplateLike | null | undefined,
-    parsedFormData: FormData
-  ): boolean => {
-    const parsedKeys = Object.keys(parsedFormData || {}).filter(Boolean);
-
-    const meta = template?._meta || {};
-    const requestType = String(meta.requestType || '').trim();
-    const root = String(meta.root || '').trim();
-    const schema = String(meta.schema || '').trim();
-
-    const hasTemplateMeta = Boolean(requestType && root && schema);
-    const hasFormData = parsedKeys.length > 0;
-
-    const isReq = Boolean(template) && hasTemplateMeta && hasFormData;
-
-    if (DBG) {
-      log(
-        context,
-        'debug',
-        {
-          tplPath: String(meta.path || '').trim(),
-          requestType,
-          root,
-          schema,
-          parsedKeys,
-          isReq,
-        },
-        'isRequestIssue(new-requests-only)'
-      );
-    }
-
-    return isReq;
   };
 
   const shouldSkipIssueEditedEvent = (

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1854,7 +1854,20 @@ async function resolvePullRequestRequestAuthorId(
   pr: PullRequestLike
 ): Promise<string> {
   let page = 1;
-  let lastCommitter = '';
+
+  const blockedServiceUsers = new Set<string>(['web-flow-serviceuser']);
+
+  const isUsableRequesterLogin = (value: unknown): string => {
+    const login = normalizeLogin(value);
+    if (!login) return '';
+    if (blockedServiceUsers.has(login.toLowerCase())) return '';
+    return login;
+  };
+
+  let lastAuthorLogin = '';
+  let lastCommitterLogin = '';
+  let firstAuthorLogin = '';
+  let firstCommitterLogin = '';
 
   try {
     while (true) {
@@ -1879,18 +1892,33 @@ async function resolvePullRequestRequestAuthorId(
       const commits = Array.isArray(res?.data) ? res.data : [];
       if (!commits.length) break;
 
-      const last = commits.at(-1);
-      lastCommitter = normalizeLogin(last?.committer?.login) || normalizeLogin(last?.author?.login) || lastCommitter;
+      for (const commit of commits) {
+        const authorLogin = isUsableRequesterLogin(commit?.author?.login);
+        const committerLogin = isUsableRequesterLogin(commit?.committer?.login);
+
+        if (!firstAuthorLogin && authorLogin) firstAuthorLogin = authorLogin;
+        if (!firstCommitterLogin && committerLogin) firstCommitterLogin = committerLogin;
+
+        if (authorLogin) lastAuthorLogin = authorLogin;
+        if (committerLogin) lastCommitterLogin = committerLogin;
+      }
 
       if (commits.length < 100) break;
       page += 1;
       if (page > 20) break;
     }
   } catch {
-    return lastCommitter || normalizeLogin(pr.user?.login);
+    // Fall through to PR author fallback below
   }
 
-  return lastCommitter || normalizeLogin(pr.user?.login);
+  return (
+    lastAuthorLogin ||
+    lastCommitterLogin ||
+    firstAuthorLogin ||
+    firstCommitterLogin ||
+    isUsableRequesterLogin(pr.user?.login) ||
+    normalizeLogin(pr.user?.login)
+  );
 }
 
 async function addApprovedLabelToPr(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1826,10 +1826,23 @@ async function createAutomatedApprovalReview(
 
     return true;
   } catch (e: unknown) {
+    const errObj = isPlainObject(e) ? e : {};
+    const status = typeof errObj['status'] === 'number' ? errObj['status'] : undefined;
+
+    const response = isPlainObject(errObj['response']) ? errObj['response'] : {};
+    const responseData = response['data'];
+
+    const message = e instanceof Error ? e.message : String(e);
+
     log(
       context,
       'warn',
-      { err: e instanceof Error ? e.message : String(e), prNumber: pr.number },
+      {
+        prNumber: pr.number,
+        status,
+        message,
+        responseData,
+      },
       'failed to create automated PR approval review'
     );
 
@@ -1838,9 +1851,11 @@ async function createAutomatedApprovalReview(
       { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
       `## onApproval matched, but automatic PR approval failed
 
-${body}
+  ${body}
 
-The PR could not be approved automatically, so merge remains blocked until a review is added manually.`,
+  Approval API error: ${message}${status ? ` (HTTP ${status})` : ''}
+
+  The PR could not be approved automatically, so merge remains blocked until a review is added manually.`,
       { minimizeTag: 'nsreq:on-approval:approve-failed' }
     );
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -100,6 +100,7 @@ type PullRequestLike = {
   state?: string | null;
   user?: UserLike | null;
   head: { ref: string; sha: string };
+  base?: { ref?: string | null; sha?: string | null };
 };
 
 type PullRequestFileLike = {
@@ -1434,7 +1435,7 @@ type TryMergeIfGreenFn = (
     mergeMethod: MergeMethod;
     prData: PullRequestLike;
   }
-) => Promise<void>;
+) => Promise<boolean | void>;
 
 const setStateLabel = setStateLabelRaw as unknown as SetStateLabelFn;
 const ensureAssigneesOnce = ensureAssigneesOnceRaw as unknown as EnsureAssigneesOnceFn;
@@ -1963,6 +1964,106 @@ function buildAutoApprovalReviewMarker(headSha: string): string {
   return `<!-- ${AUTO_APPROVAL_REVIEW_MARKER_PREFIX}${toStringTrim(headSha)} -->`;
 }
 
+async function listPullRequestReviews(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<PullRequestReviewLike[]> {
+  const out: PullRequestReviewLike[] = [];
+  let page = 1;
+
+  while (true) {
+    const res = await (
+      context.octokit.pulls as unknown as {
+        listReviews: (args: {
+          owner: string;
+          repo: string;
+          pull_number: number;
+          per_page?: number;
+          page?: number;
+        }) => Promise<{ data?: PullRequestReviewLike[] }>;
+      }
+    ).listReviews({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: prNumber,
+      per_page: 100,
+      page,
+    });
+
+    const reviews = Array.isArray(res?.data) ? res.data : [];
+    if (!reviews.length) break;
+
+    out.push(...reviews);
+
+    if (reviews.length < 100) break;
+    page += 1;
+    if (page > 20) break;
+  }
+
+  return out;
+}
+
+async function hasApprovedReviewOnPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<boolean> {
+  try {
+    const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
+
+    return reviews.some((review) => toStringTrim(review?.state).toUpperCase() === 'APPROVED');
+  } catch {
+    return false;
+  }
+}
+
+async function hasApprovedLabelOnPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<boolean> {
+  const eff = resolveEffectiveConstants(context);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+
+  try {
+    const labels = await fetchIssueLabels(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      issue_number: prNumber,
+    });
+
+    return labelsMatching(labels, approvedLabel).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function isPullRequestApprovedForBranchMaintenance(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<boolean> {
+  // Bot-created request PRs are only created after issue approval.
+  if (isSnapshotManagedRequestPr(pr)) return true;
+
+  const headSha = toStringTrim(pr.head?.sha);
+
+  if (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) {
+    return true;
+  }
+
+  if (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) {
+    return true;
+  }
+
+  if (await hasApprovedReviewOnPr(context, repoInfo, pr.number)) {
+    return true;
+  }
+
+  return false;
+}
+
 async function hasAutoApprovalReviewForHead(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -1972,23 +2073,7 @@ async function hasAutoApprovalReviewForHead(
   const marker = buildAutoApprovalReviewMarker(headSha);
 
   try {
-    const res = await (
-      context.octokit.pulls as unknown as {
-        listReviews: (args: {
-          owner: string;
-          repo: string;
-          pull_number: number;
-          per_page?: number;
-        }) => Promise<{ data?: PullRequestReviewLike[] }>;
-      }
-    ).listReviews({
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      pull_number: prNumber,
-      per_page: 100,
-    });
-
-    const reviews = Array.isArray(res?.data) ? res.data : [];
+    const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
 
     return reviews.some(
       (review) =>
@@ -2113,6 +2198,193 @@ async function isHeadGreenForApprovalReevaluation(
   }
 }
 
+const UPDATE_BRANCH_INFLIGHT = new Map<string, Promise<boolean>>();
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function updateBranchInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): string {
+  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}`;
+}
+
+function isBenignUpdateBranchFailure(error: unknown): boolean {
+  const status = getHttpStatus(error);
+  const msg = getErrorMessage(error).toLowerCase();
+
+  if (status !== 422) return false;
+
+  return (
+    msg.includes('expected_head_sha') ||
+    msg.includes('head sha') ||
+    msg.includes('head branch was modified') ||
+    msg.includes('not behind') ||
+    msg.includes('already up') ||
+    msg.includes('already up-to-date') ||
+    msg.includes('already up to date')
+  );
+}
+
+function isManualUpdateBranchFailure(error: unknown): boolean {
+  const status = getHttpStatus(error);
+  const msg = getErrorMessage(error).toLowerCase();
+
+  return (
+    status === 403 ||
+    status === 404 ||
+    msg.includes('conflict') ||
+    msg.includes('merge conflict') ||
+    msg.includes('protected branch') ||
+    msg.includes('permission') ||
+    msg.includes('forbidden')
+  );
+}
+
+async function requestPullRequestBranchUpdate(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<boolean> {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return false;
+
+  const key = updateBranchInflightKey(repoInfo, pr);
+  const existing = UPDATE_BRANCH_INFLIGHT.get(key);
+  if (existing) return await existing;
+
+  const pending = (async (): Promise<boolean> => {
+    try {
+      await (
+        context.octokit.pulls as unknown as {
+          updateBranch: (args: {
+            owner: string;
+            repo: string;
+            pull_number: number;
+            expected_head_sha?: string;
+          }) => Promise<unknown>;
+        }
+      ).updateBranch({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        pull_number: pr.number,
+        expected_head_sha: headSha,
+      });
+
+      log(
+        context,
+        'info',
+        {
+          prNumber: pr.number,
+          headSha,
+          reason,
+        },
+        'pull-request branch update requested'
+      );
+
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      const status = getHttpStatus(error);
+
+      if (isBenignUpdateBranchFailure(error)) {
+        log(
+          context,
+          'debug',
+          {
+            prNumber: pr.number,
+            headSha,
+            status,
+            err: msg,
+            reason,
+          },
+          'pull-request branch update skipped'
+        );
+
+        return false;
+      }
+
+      log(
+        context,
+        'warn',
+        {
+          prNumber: pr.number,
+          headSha,
+          status,
+          err: msg,
+          reason,
+        },
+        'pull-request branch update failed'
+      );
+
+      if (isManualUpdateBranchFailure(error)) {
+        await postOnce(
+          context,
+          { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+          `## Could not update PR branch automatically
+
+The PR is approved, but the bot could not update the branch with the latest base branch.
+
+Reason:
+\`${msg}\`
+
+Please update the branch manually.`,
+          { minimizeTag: 'nsreq:update-branch-failed' }
+        );
+      }
+
+      return false;
+    }
+  })().finally(() => {
+    UPDATE_BRANCH_INFLIGHT.delete(key);
+  });
+
+  UPDATE_BRANCH_INFLIGHT.set(key, pending);
+  return await pending;
+}
+
+function shouldTryBranchUpdateAfterMergeFailure(error: unknown): boolean {
+  const msg = getErrorMessage(error).toLowerCase();
+
+  return (
+    msg.includes('branch is out-of-date') ||
+    msg.includes('branch is out of date') ||
+    msg.includes('update branch') ||
+    msg.includes('must be up to date') ||
+    msg.includes('must be up-to-date') ||
+    msg.includes('behind the base branch') ||
+    msg.includes('not mergeable')
+  );
+}
+
+async function tryMergeApprovedPrOrUpdateBranch(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<void> {
+  try {
+    const merged = await tryMergeIfGreen(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      prNumber: pr.number,
+      mergeMethod: 'squash',
+      prData: pr,
+    });
+
+    if (merged === false) {
+      await requestPullRequestBranchUpdate(context, repoInfo, pr, `${reason}:merge-returned-false`);
+    }
+  } catch (error: unknown) {
+    if (shouldTryBranchUpdateAfterMergeFailure(error)) {
+      await requestPullRequestBranchUpdate(context, repoInfo, pr, `${reason}:merge-failed-outdated`);
+      return;
+    }
+
+    throw error;
+  }
+}
+
 function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
   const raw = toStringTrim(body);
   const match = /source:\s*#(\d+)/i.exec(raw) ?? /issue\s*#(\d+)/i.exec(raw);
@@ -2166,13 +2438,7 @@ async function processPullRequestForAutoMerge(
     const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
     if (standaloneOutcome !== 'approved') return;
 
-    await tryMergeIfGreen(context, {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      prNumber: pr.number,
-      mergeMethod: 'squash',
-      prData: pr,
-    });
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
     return;
   }
 
@@ -2212,13 +2478,7 @@ async function processPullRequestForAutoMerge(
       return;
     }
 
-    await tryMergeIfGreen(context, {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      prNumber: pr.number,
-      mergeMethod: 'squash',
-      prData: pr,
-    });
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
     return;
   }
 
@@ -2234,13 +2494,7 @@ async function processPullRequestForAutoMerge(
 
   if (directPrOutcome !== 'approved') return;
 
-  await tryMergeIfGreen(context, {
-    owner: repoInfo.owner,
-    repo: repoInfo.repo,
-    prNumber: pr.number,
-    mergeMethod: 'squash',
-    prData: pr,
-  });
+  await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
 }
 
 function isApprovalConfigChangePath(filePath: string): boolean {
@@ -2303,13 +2557,7 @@ async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
       const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha);
 
       if (hasCurrentHeadAutoApproval) {
-        await tryMergeIfGreen(context, {
-          owner: repoInfo.owner,
-          repo: repoInfo.repo,
-          prNumber: pr.number,
-          mergeMethod: 'squash',
-          prData: pr,
-        });
+        await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
         continue;
       }
 
@@ -2323,6 +2571,69 @@ async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
           prNumber: pr.number,
         },
         'failed to re-evaluate direct pull request after approval config change'
+      );
+    }
+  }
+}
+
+function isDefaultBranchPush(payload: unknown): boolean {
+  if (!isPlainObject(payload)) return false;
+
+  const ref = toStringTrim(payload['ref']);
+  const repoObj = isPlainObject(payload['repository']) ? payload['repository'] : null;
+  const defaultBranch = repoObj ? toStringTrim(repoObj['default_branch']) : '';
+
+  return Boolean(ref && defaultBranch && ref === `refs/heads/${defaultBranch}`);
+}
+
+function readDefaultBranchFromPush(payload: unknown): string {
+  if (!isPlainObject(payload)) return '';
+
+  const repoObj = isPlainObject(payload['repository']) ? payload['repository'] : null;
+  return repoObj ? toStringTrim(repoObj['default_branch']) : '';
+}
+
+function pullRequestTargetsBranch(pr: PullRequestLike, branchName: string): boolean {
+  const target = toStringTrim(branchName);
+  if (!target) return true;
+
+  const prBase = toStringTrim(pr.base?.ref);
+  return !prBase || prBase === target;
+}
+
+async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  baseBranch: string
+): Promise<void> {
+  const openPrs = await listOpenPullRequests(context, repoInfo);
+
+  for (const pr of openPrs) {
+    const headSha = toStringTrim(pr.head?.sha);
+    if (!headSha) continue;
+
+    if (!pullRequestTargetsBranch(pr, baseBranch)) continue;
+
+    try {
+      const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+      if (!changedRegistryFiles.length) continue;
+
+      const approved = await isPullRequestApprovedForBranchMaintenance(context, repoInfo, pr);
+      if (!approved) continue;
+
+      const green = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
+      if (!green) continue;
+
+      await requestPullRequestBranchUpdate(context, repoInfo, pr, 'default-branch-push');
+    } catch (error: unknown) {
+      log(
+        context,
+        'warn',
+        {
+          err: getErrorMessage(error),
+          prNumber: pr.number,
+        },
+        'failed to update approved pull request branch after default branch push'
       );
     }
   }
@@ -4821,12 +5132,20 @@ export default function requestHandler(app: Probot): void {
     await getStaticConfig(context);
 
     const payload = context.payload as unknown;
-    if (!isRelevantDefaultBranchPushForApprovalReevaluation(payload)) return;
+    if (!isDefaultBranchPush(payload)) return;
 
     const repoInfo = readRepoInfoFromPayload(payload);
     if (!repoInfo) return;
 
-    await reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(context, repoInfo);
+    const baseBranch = readDefaultBranchFromPush(payload);
+
+    // if approval config changed, re-evaluate old direct PRs
+    if (isRelevantDefaultBranchPushForApprovalReevaluation(payload)) {
+      await reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(context, repoInfo);
+    }
+
+    // after main changed, keep already-approved green registry PRs up to date
+    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(context, repoInfo, baseBranch);
   });
 
   app.on(

--- a/test/request-orchestrator.coverage.test.ts
+++ b/test/request-orchestrator.coverage.test.ts
@@ -59,6 +59,14 @@ type PullsUpdate = (args: {
   state: 'open' | 'closed';
 }) => Promise<void>;
 
+type ChecksListForRef = (args: {
+  owner: string;
+  repo: string;
+  ref: string;
+  per_page?: number;
+  page?: number;
+}) => Promise<{ data: { check_runs: unknown[] } }>;
+
 type GitDeleteRef = (args: { owner: string; repo: string; ref: string }) => Promise<void>;
 
 type ReposGetContent = (args: { owner: string; repo: string; path: string }) => Promise<{ data: unknown }>;
@@ -73,6 +81,9 @@ type Octokit = {
   pulls: {
     list: jest.MockedFunction<PullsList>;
     update: jest.MockedFunction<PullsUpdate>;
+  };
+  checks: {
+    listForRef: jest.MockedFunction<ChecksListForRef>;
   };
   git: {
     deleteRef: jest.MockedFunction<GitDeleteRef>;
@@ -224,6 +235,13 @@ function mkOctokit(): Octokit {
     pulls: {
       list: jest.fn<PullsList>(),
       update: jest.fn<PullsUpdate>(),
+    },
+    checks: {
+      listForRef: jest.fn<ChecksListForRef>().mockResolvedValue({
+        data: {
+          check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success' }],
+        },
+      }),
     },
     git: {
       deleteRef: jest.fn<GitDeleteRef>(),

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -91,9 +91,12 @@ type PullsUpdateFn = (args: unknown) => Promise<unknown>;
 type PullsCreateReviewFn = (args: unknown) => Promise<unknown>;
 type PullsListFilesFn = (args: unknown) => Promise<{ data: unknown[] }>;
 type PullsListCommitsFn = (args: unknown) => Promise<{ data: unknown[] }>;
+type PullsListReviewsFn = (args: unknown) => Promise<{ data: unknown[] }>;
+type PullsUpdateBranchFn = (args: unknown) => Promise<unknown>;
 
 type ChecksListAnnotationsFn = (args: any) => Promise<{ data: any[] }>;
 type ChecksListForSuiteFn = (args: any) => Promise<{ data: { check_runs: any[] } }>;
+type ChecksListForRefFn = (args: any) => Promise<{ data: { check_runs: any[] } }>;
 
 type PullsGetFn = (args: unknown) => Promise<{ data: unknown }>;
 
@@ -145,8 +148,10 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
         list: jest.fn<PullsListFn>(() => Promise.resolve({ data: [] })),
         listFiles: jest.fn<PullsListFilesFn>(() => Promise.resolve({ data: [] })),
         listCommits: jest.fn<PullsListCommitsFn>(() => Promise.resolve({ data: [] })),
+        listReviews: jest.fn<PullsListReviewsFn>(() => Promise.resolve({ data: [] })),
         createReview: jest.fn<PullsCreateReviewFn>(() => Promise.resolve({})),
         update: jest.fn<PullsUpdateFn>(() => Promise.resolve({})),
+        updateBranch: jest.fn<PullsUpdateBranchFn>(() => Promise.resolve({})),
       },
       git: {
         deleteRef: jest.fn<GitDeleteRefFn>(() => Promise.resolve({})),
@@ -157,6 +162,11 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
       checks: {
         listAnnotations: jest.fn<ChecksListAnnotationsFn>().mockResolvedValue({ data: [] as any[] }),
         listForSuite: jest.fn<ChecksListForSuiteFn>().mockResolvedValue({ data: { check_runs: [] } }),
+        listForRef: jest.fn<ChecksListForRefFn>().mockResolvedValue({
+          data: {
+            check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success' }],
+          },
+        }),
       },
     },
   };
@@ -322,7 +332,12 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  jest.resetAllMocks();
+
+  setStateLabel.mockImplementation(async () => {});
+  ensureAssigneesOnce.mockImplementation(async () => {});
+  postOnce.mockImplementation(async () => {});
+  collapseBotCommentsByPrefix.mockImplementation(async () => {});
 
   loadStaticConfig.mockResolvedValue({
     config: DEFAULT_CONFIG,
@@ -362,6 +377,7 @@ beforeEach(() => {
   extractHashFromPrBody.mockReturnValue('h1');
   findOpenIssuePrs.mockResolvedValue([]);
   createRequestPr.mockResolvedValue({ number: 10 });
+  tryMergeIfGreen.mockResolvedValue(undefined);
 });
 
 test('issue_comment: skips bot sender', async () => {
@@ -2310,7 +2326,7 @@ public
     expect(runApprovalHook).toHaveBeenCalledWith(
       ctx,
       { owner: 'o1', repo: 'r1' },
-      expect.objectContaining({ requestAuthorId: 'last-committer' })
+      expect.objectContaining({ requestAuthorId: 'ignored-author' })
     );
     expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ['Approved'] }));
   });
@@ -2393,7 +2409,7 @@ public
         requestType: 'product',
         namespace: 'product-one',
         resourceName: 'product-one',
-        requestAuthorId: 'direct-last-committer',
+        requestAuthorId: 'ignored-author',
         formData: expect.objectContaining({
           identifier: 'product-one',
           namespace: 'product-one',
@@ -2407,7 +2423,7 @@ public
         repo: 'r1',
         pull_number: 51,
         event: 'APPROVE',
-        body: 'approved from standalone hook',
+        body: expect.stringContaining('approved from standalone hook'),
       })
     );
     expect(tryMergeIfGreen).toHaveBeenCalledWith(
@@ -2786,11 +2802,84 @@ public
       })
     );
     expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'Approved automatically by onApproval hook.' })
+      expect.objectContaining({ body: expect.stringContaining('Approved automatically by onApproval hook.') })
     );
     expect(tryMergeIfGreen).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 55, mergeMethod: 'squash' })
+    );
+    expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR requests branch update when merge helper returns false', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-merge-false',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 155,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/merge-false', sha: 'sha-merge-false' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-merge-false.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-merge-false\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ committer: { login: 'merge-helper-user' } }],
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+    tryMergeIfGreen.mockResolvedValueOnce(false as never);
+
+    await handler(ctx);
+
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 155, mergeMethod: 'squash' })
+    );
+    expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        pull_number: 155,
+        expected_head_sha: 'sha-merge-false',
+      })
     );
   });
 
@@ -3279,6 +3368,73 @@ test('status: without jest worker id skips non-form linked issues outside test r
   } finally {
     if (prevWorkerId !== undefined) process.env.JEST_WORKER_ID = prevWorkerId;
   }
+});
+
+test('push: default branch push updates approved green registry PR branches', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({
+    owner: 'o1',
+    repo: 'r1',
+    withCachedConfig: true,
+    config: {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    },
+  });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 201,
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    data: [{ filename: 'resources/product-approved.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.issues.get.mockResolvedValueOnce({
+    data: { number: 201, labels: [{ name: 'Approved' }] },
+  });
+
+  ctx.octokit.checks.listForRef.mockResolvedValueOnce({
+    data: {
+      check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success' }],
+    },
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      owner: 'o1',
+      repo: 'r1',
+      pull_number: 201,
+      expected_head_sha: 'sha-approved-green',
+    })
+  );
 });
 
 test('issues.opened: partner namespace maps request type and matches normalized request config keys', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2863,6 +2863,14 @@ public
     ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
       data: [{ committer: { login: 'merge-helper-user' } }],
     });
+    ctx.octokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 155,
+        state: 'open',
+        body: 'manual direct pr',
+        head: { ref: 'feature/merge-false', sha: 'sha-merge-false' },
+      },
+    });
 
     runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
     tryMergeIfGreen.mockResolvedValueOnce(false as never);
@@ -3435,6 +3443,155 @@ test('push: default branch push updates approved green registry PR branches', as
       expected_head_sha: 'sha-approved-green',
     })
   );
+});
+
+test('push: approved review remains eligible for branch update after later comment-only review', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({
+    owner: 'o1',
+    repo: 'r1',
+    withCachedConfig: true,
+    config: {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    },
+  });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 202,
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    data: [{ filename: 'resources/product-commented.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.issues.get.mockResolvedValueOnce({
+    data: { number: 202, labels: [] },
+  });
+
+  ctx.octokit.pulls.listReviews.mockResolvedValue({
+    data: [
+      {
+        id: 1,
+        state: 'APPROVED',
+        submitted_at: '2026-04-20T10:00:00Z',
+        user: { login: 'reviewer' },
+      },
+      {
+        id: 2,
+        state: 'COMMENTED',
+        submitted_at: '2026-04-20T10:05:00Z',
+        user: { login: 'reviewer' },
+      },
+    ],
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      owner: 'o1',
+      repo: 'r1',
+      pull_number: 202,
+      expected_head_sha: 'sha-review-commented',
+    })
+  );
+});
+
+test('push: changes requested review blocks approved-label based branch update', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({
+    owner: 'o1',
+    repo: 'r1',
+    withCachedConfig: true,
+    config: {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    },
+  });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 203,
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/changes-requested', sha: 'sha-changes-requested' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    data: [{ filename: 'resources/product-changes-requested.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.issues.get.mockResolvedValueOnce({
+    data: { number: 203, labels: [{ name: 'Approved' }] },
+  });
+
+  ctx.octokit.pulls.listReviews.mockResolvedValue({
+    data: [
+      {
+        id: 1,
+        state: 'APPROVED',
+        submitted_at: '2026-04-20T10:00:00Z',
+        user: { login: 'reviewer' },
+      },
+      {
+        id: 2,
+        state: 'CHANGES_REQUESTED',
+        submitted_at: '2026-04-20T10:05:00Z',
+        user: { login: 'reviewer' },
+      },
+    ],
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
 });
 
 test('issues.opened: partner namespace maps request type and matches normalized request config keys', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -3427,6 +3427,18 @@ test('push: default branch push updates approved green registry PR branches', as
     data: { number: 201, labels: [{ name: 'Approved' }] },
   });
 
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 201,
+      state: 'open',
+      body: 'manual direct pr',
+      head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    },
+  });
+
   ctx.octokit.checks.listForRef.mockResolvedValueOnce({
     data: {
       check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success' }],
@@ -3492,6 +3504,18 @@ test('push: approved review remains eligible for branch update after later comme
 
   ctx.octokit.issues.get.mockResolvedValueOnce({
     data: { number: 202, labels: [] },
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 202,
+      state: 'open',
+      body: 'manual direct pr',
+      head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    },
   });
 
   ctx.octokit.pulls.listReviews.mockResolvedValue({


### PR DESCRIPTION
## Summary
- re-evaluate open direct PRs when approval config changes on the default branch
- keep direct PR approval gated behind a fully green validation pipeline
- prevent duplicate automated approval reviews for the same PR head SHA
- automatically update approved registry PR branches after the default branch changes
- keep merge behavior CI-driven and avoid aggressive `pull_request.synchronize` handling

## Changes
- added push-based re-evaluation for open direct PRs after relevant `.github/registry-bot/config.*` updates
- removed unnecessary `pull_request.opened`, `pull_request.edited`, and aggressive synchronize-based approval handling
- added idempotent auto-approval review marker handling via `nsreq:auto-approval:<headSha>`
- skipped duplicate approval review creation when the current PR head was already auto-approved
- resolved direct PR requester identity from commit authors while ignoring service users like `web-flow-serviceuser`
- added automatic branch update handling for approved registry PRs after default-branch pushes
- restricted branch updates to open PRs that target the default branch, modify registry YAML files, are approved, and have green checks
- used GitHub's `updateBranch` API with `expected_head_sha` to avoid race conditions
- added in-flight protection to avoid duplicate branch update requests for the same PR head SHA
- added safe handling for benign update-branch failures such as already up-to-date or head-SHA races
- kept merge execution behind the existing green CI check flow

## Result
- older open direct PRs can now pass through `onApproval` after approval config changes
- direct PR approval no longer runs before the validation pipeline is green
- no duplicate bot approval reviews for the same PR state
- approved registry PRs are automatically updated with the latest default branch when needed
- branch updates behave similarly to Renovate: update first, wait for CI, then merge when green
- lower risk of noisy, premature, or duplicate approval and merge handling