### PR TITLE
Re-evaluate old direct PRs against latest default branch config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Direct PR flow: update stale branches **before** approval re-evaluation
 - Approval now runs only on the **latest PR head (fresh CI state)**
 - Merge gating tightened: requires valid approval + green checks on current head
-- Cross-repo PR handling: approval + evaluation now use the **actual PR head repo/branch**, not only base repo
+- Cross-repo PR handling: approval + evaluation now use the **actual PR head repo/branch**
+- Registry PR maintenance is now **sequential (one-by-one)** to avoid GHES overload
+- Only PRs with **registry YAML changes** are considered for branch updates
 
 ### Added
 
@@ -20,13 +22,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fallback detection for changed registry files (tree diff)
 - Robust auto-approval tied to specific commit SHA
 - Full **onApproval support for cross-repo / fork PRs**
+- Sequential PR processing with **active PR tracking and skip logic**
 
 ### Fixed
 
 - Removed stale-head approvals causing blocked merges
 - Prevented merge/update loops (branch protection vs outdated handling)
 - Improved updateBranch retry handling
-- Fixed cross-repo PRs being skipped or stuck due to missing head access / wrong issue resolution
+- Fixed cross-repo PRs being skipped due to missing head access / wrong resolution
+- Prevented GHES overload by avoiding parallel rebases of multiple PRs
+- Fixed pipeline blocking: failed PRs are now **skipped instead of stopping the flow**
 
 ## [[0.1.1](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.1)] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Direct PR flow: update stale branches **before** approval re-evaluation
 - Approval now runs only on the **latest PR head (fresh CI state)**
 - Merge gating tightened: requires valid approval + green checks on current head
+- Cross-repo PR handling: approval + evaluation now use the **actual PR head repo/branch**, not only base repo
 
 ### Added
 
 - Automatic re-evaluation of open direct PRs on default-branch updates
 - Fallback detection for changed registry files (tree diff)
 - Robust auto-approval tied to specific commit SHA
+- Full **onApproval support for cross-repo / fork PRs**
 
 ### Fixed
 
 - Removed stale-head approvals causing blocked merges
 - Prevented merge/update loops (branch protection vs outdated handling)
-- Improved updateBranch retry handling (`expected_head_sha` + cooldown/inflight guards)
+- Improved updateBranch retry handling
+- Fixed cross-repo PRs being skipped or stuck due to missing head access / wrong issue resolution
 
 ## [[0.1.1](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.1)] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Changed
+
+- Direct PR flow: update stale branches **before** approval re-evaluation
+- Approval now runs only on the **latest PR head (fresh CI state)**
+- Merge gating tightened: requires valid approval + green checks on current head
+
+### Added
+
+- Automatic re-evaluation of open direct PRs on default-branch updates
+- Fallback detection for changed registry files (tree diff)
+- Robust auto-approval tied to specific commit SHA
+
+### Fixed
+
+- Removed stale-head approvals causing blocked merges
+- Prevented merge/update loops (branch protection vs outdated handling)
+- Improved updateBranch retry handling (`expected_head_sha` + cooldown/inflight guards)
+
 ## [[0.1.1](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.1)] - 2026-04-21
 
 ## Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Direct PR flow: update stale branches **before** approval re-evaluation
-- Approval now runs only on the **latest PR head (fresh CI state)**
-- Merge gating tightened: requires valid approval + green checks on current head
-- Cross-repo PR handling: approval + evaluation now use the **actual PR head repo/branch**
-- Registry PR maintenance is now **sequential (one-by-one)** to avoid GHES overload
-- Only PRs with **registry YAML changes** are considered for branch updates
+- Direct PRs are re-evaluated on every default branch update.
+- Old open direct PRs now use the latest default branch config.
+- Stale direct PR branches are updated before approval re-evaluation.
+- Approval is only evaluated on the latest PR head with fresh CI state.
+- Merge gating now requires valid approval and green checks on the current head.
+- Linked issue detection now checks PR body, title, and branch name.
+- Requester resolution avoids using bot users for linked direct PRs.
+- Registry PR maintenance now runs sequentially to avoid GHES overload.
+- Only PRs with registry YAML changes are considered for branch updates.
 
 ### Added
 
-- Automatic re-evaluation of open direct PRs on default-branch updates
-- Fallback detection for changed registry files (tree diff)
-- Robust auto-approval tied to specific commit SHA
-- Full **onApproval support for cross-repo / fork PRs**
-- Sequential PR processing with **active PR tracking and skip logic**
+- Automatic re-evaluation of open direct PRs on default branch updates.
+- Tree-diff fallback for detecting changed registry files.
+- SHA-specific auto-approval checks.
+- onApproval support for cross-repo and fork PRs.
+- Sequential PR processing with active PR tracking and skip logic.
 
 ### Fixed
 
-- Removed stale-head approvals causing blocked merges
-- Prevented merge/update loops (branch protection vs outdated handling)
-- Improved updateBranch retry handling
-- Fixed cross-repo PRs being skipped due to missing head access / wrong resolution
-- Prevented GHES overload by avoiding parallel rebases of multiple PRs
-- Fixed pipeline blocking: failed PRs are now **skipped instead of stopping the flow**
+- Removed stale-head approvals causing blocked merges.
+- Prevented merge/update loops.
+- Improved updateBranch retry handling.
+- Fixed cross-repo PRs being skipped due to wrong head resolution.
+- Prevented parallel registry PR rebases from overloading GHES.
+- Failed PRs are now skipped instead of blocking the queue.
 
 ## [[0.1.1](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.1)] - 2026-04-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.2-dev.1",
+  "version": "0.1.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged"
+    "lint:staged": "lint-staged",
+    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.3-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3-dev.1",
+  "version": "0.1.4-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",
@@ -26,7 +26,7 @@
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
     "lint:staged": "lint-staged",
-    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.3-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
+    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.4-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.1",
+  "version": "0.1.2-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.4-dev.1",
+  "version": "0.1.2",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",
@@ -25,8 +25,7 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged",
-    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.4-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
+    "lint:staged": "lint-staged"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3",
+  "version": "0.1.3-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.1",
+  "version": "0.1.3-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3-dev.1",
+  "version": "0.1.3",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.2",
+  "version": "0.1.2-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.2-dev.1",
+  "version": "0.1.2",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -4892,10 +4892,19 @@ async function closeLinkedIssuePrs(
   repoInfo: RepoInfo,
   issueNumber: number
 ): Promise<number[]> {
-  const prs = (await listOpenPullRequests(context, repoInfo)).filter(
-    (pr) => parseLinkedIssueNumberFromPr(pr, repoInfo) === issueNumber
-  );
+  let prs: PullRequestLike[] = [];
 
+  try {
+    prs = await findOpenIssuePRsRaw(context, repoInfo, issueNumber);
+  } catch {
+    prs = [];
+  }
+
+  if (prs.length === 0) {
+    prs = (await listOpenPullRequests(context, repoInfo)).filter(
+      (pr) => parseLinkedIssueNumberFromPr(pr, repoInfo) === issueNumber
+    );
+  }
   const closed: number[] = [];
 
   for (const pr of prs) {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -39,6 +39,10 @@ type ResourceBotContextExt = {
   resourceBotHooksSource?: string | null;
 };
 
+type StaticConfigLoadOptions = {
+  forceReload?: boolean;
+};
+
 type BotContext<E extends RequestEvents> = Context<E> & ResourceBotContextExt;
 
 type RepoInfo = { owner: string; repo: string };
@@ -150,6 +154,21 @@ type CheckRunAnnotationLike = {
   title?: string | null;
   annotation_level?: string | null;
   raw_details?: string | null;
+};
+
+type HeadGreenRunSummary = {
+  id?: number;
+  name: string;
+  status: string;
+  conclusion: string;
+};
+
+type HeadGreenEvaluation = {
+  green: boolean;
+  reason: string;
+  latestRuns: HeadGreenRunSummary[];
+  blockingRuns: HeadGreenRunSummary[];
+  statusState?: string;
 };
 
 type ValidateRequestIssueResult = {
@@ -726,8 +745,10 @@ type CheckSuitePullRequestRef = { number?: number | null };
 
 type CheckSuiteLike = {
   id?: number | null;
+  status?: string | null;
   conclusion?: string | null;
   head_sha?: string | null;
+  head_branch?: string | null;
   pull_requests?: CheckSuitePullRequestRef[] | null;
 };
 
@@ -2191,13 +2212,31 @@ function isBlockingCheckConclusion(conclusion: string): boolean {
   );
 }
 
-async function isHeadGreenForApprovalReevaluation(
+function summarizeHeadGreenRun(run: RefCheckRunLike): HeadGreenRunSummary {
+  const id = typeof run?.id === 'number' && Number.isFinite(run.id) ? run.id : undefined;
+
+  return {
+    ...(id !== undefined ? { id } : {}),
+    name: toStringTrim(run?.name) || '__unnamed__',
+    status: toStringTrim(run?.status).toLowerCase(),
+    conclusion: toStringTrim(run?.conclusion).toLowerCase(),
+  };
+}
+
+async function evaluateHeadGreenForApprovalReevaluation(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   headSha: string
-): Promise<boolean> {
+): Promise<HeadGreenEvaluation> {
   const ref = toStringTrim(headSha);
-  if (!ref) return false;
+  if (!ref) {
+    return {
+      green: false,
+      reason: 'missing-head-sha',
+      latestRuns: [],
+      blockingRuns: [],
+    };
+  }
 
   try {
     const all: RefCheckRunLike[] = [];
@@ -2249,22 +2288,61 @@ async function isHeadGreenForApprovalReevaluation(
     }
 
     if (latestByName.size > 0) {
-      let sawSuccess = false;
+      const latestRuns = Array.from(latestByName.values()).map(summarizeHeadGreenRun);
 
-      for (const run of latestByName.values()) {
-        const status = toStringTrim(run?.status).toLowerCase();
-        const conclusion = toStringTrim(run?.conclusion).toLowerCase();
-
-        if (status !== 'completed') return false;
-        if (isBlockingCheckConclusion(conclusion)) return false;
-        if (!isGreenCheckConclusion(conclusion)) return false;
-        if (conclusion === 'success') sawSuccess = true;
+      const incompleteRuns = latestRuns.filter((run) => run.status !== 'completed');
+      if (incompleteRuns.length) {
+        return {
+          green: false,
+          reason: 'check-runs-not-completed',
+          latestRuns,
+          blockingRuns: incompleteRuns,
+        };
       }
 
-      return sawSuccess;
+      const blockingRuns = latestRuns.filter(
+        (run) => isBlockingCheckConclusion(run.conclusion) || !isGreenCheckConclusion(run.conclusion)
+      );
+
+      if (blockingRuns.length) {
+        return {
+          green: false,
+          reason: 'check-runs-blocking-or-not-green',
+          latestRuns,
+          blockingRuns,
+        };
+      }
+
+      const sawSuccess = latestRuns.some((run) => run.conclusion === 'success');
+      if (!sawSuccess) {
+        return {
+          green: false,
+          reason: 'no-success-check-run',
+          latestRuns,
+          blockingRuns: [],
+        };
+      }
+
+      return {
+        green: true,
+        reason: 'check-runs-green',
+        latestRuns,
+        blockingRuns: [],
+      };
     }
-  } catch {
-    // fallback below
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        headSha: ref,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'head-green:check-runs-fetch-failed'
+    );
   }
 
   try {
@@ -2282,9 +2360,22 @@ async function isHeadGreenForApprovalReevaluation(
       ref,
     });
 
-    return toStringTrim(res?.data?.state).toLowerCase() === 'success';
-  } catch {
-    return false;
+    const statusState = toStringTrim(res?.data?.state).toLowerCase();
+
+    return {
+      green: statusState === 'success',
+      reason: statusState === 'success' ? 'combined-status-success' : 'combined-status-not-success',
+      latestRuns: [],
+      blockingRuns: [],
+      statusState,
+    };
+  } catch (_error: unknown) {
+    return {
+      green: false,
+      reason: 'combined-status-fetch-failed',
+      latestRuns: [],
+      blockingRuns: [],
+    };
   }
 }
 
@@ -2709,14 +2800,23 @@ function parseIssueNumberFromText(value: unknown, patterns: RegExp[]): number | 
 }
 
 function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
-  return parseIssueNumberFromText(body, [/source:\s*#(\d+)/i, /\bissue\s*#\s*(\d+)\b/i, /\bissue\s+(\d+)\b/i]);
+  return parseIssueNumberFromText(body, [
+    /<!--\s*nsreq:issue:(\d+)\s*-->/i,
+    /\bsource\s*:\s*#(\d+)\b/i,
+    /\bissue\s*#\s*(\d+)\b/i,
+    /\bissue\s+(\d+)\b/i,
+    /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s*:?\s*#(\d+)\b/i,
+  ]);
 }
 
 function parseLinkedIssueNumberFromPr(pr: PullRequestLike): number | null {
   return (
     parseLinkedIssueNumberFromPrBody(pr.body) ??
     parseIssueNumberFromText(pr.head?.ref, [/(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i]) ??
-    parseIssueNumberFromText(pr.title, [/\bissue\s*#?\s*(\d+)\b/i])
+    parseIssueNumberFromText(pr.title, [
+      /\bissue\s*#?\s*(\d+)\b/i,
+      /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s*:?\s*#(\d+)\b/i,
+    ])
   );
 }
 
@@ -2778,21 +2878,81 @@ async function processPullRequestForAutoMerge(
   try {
     const res = await context.octokit.issues.get(params);
     issue = res.data as unknown as IssueLike;
-  } catch {
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        issueNumber,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'direct-pr:linked-issue-read-failed'
+    );
     return;
   }
 
-  if (!process.env.JEST_WORKER_ID && !hasIssueFormInputs(issue)) return;
+  if (!process.env.JEST_WORKER_ID && !hasIssueFormInputs(issue)) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        issueNumber,
+      },
+      'direct-pr:linked-issue-not-request-form-fallback-standalone'
+    );
+
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
+    if (standaloneOutcome !== 'approved') return;
+
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
+    return;
+  }
 
   let template: TemplateLike;
   try {
     template = await loadTemplateWithLabelRefresh(context, params, issue);
-  } catch {
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        issueNumber,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'direct-pr:linked-issue-template-load-failed-fallback-standalone'
+    );
+
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
+    if (standaloneOutcome !== 'approved') return;
+
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
     return;
   }
 
   const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
-  if (!isRequestIssue(context, template, parsedFormData)) return;
+  if (!isRequestIssue(context, template, parsedFormData)) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        issueNumber,
+        parsedKeys: Object.keys(parsedFormData || {}),
+      },
+      'direct-pr:linked-issue-not-request-issue-fallback-standalone'
+    );
+
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
+    if (standaloneOutcome !== 'approved') return;
+
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
+    return;
+  }
 
   const body = toStringTrim(pr.body);
   const currentHash = calcSnapshotHash(parsedFormData, template, readIssueBodyForProcessing(issue.body));
@@ -2851,18 +3011,6 @@ function readPushChangedFiles(payload: unknown): string[] {
   return out;
 }
 
-function isRelevantDefaultBranchPushForApprovalReevaluation(payload: unknown): boolean {
-  if (!isPlainObject(payload)) return false;
-
-  const ref = toStringTrim(payload['ref']);
-  const repoObj = isPlainObject(payload['repository']) ? payload['repository'] : null;
-  const defaultBranch = repoObj ? toStringTrim(repoObj['default_branch']) : '';
-
-  if (!ref || !defaultBranch || ref !== `refs/heads/${defaultBranch}`) return false;
-
-  return readPushChangedFiles(payload).some(isApprovalConfigChangePath);
-}
-
 async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -2871,33 +3019,58 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
 ): Promise<void> {
   const openPrs = await listOpenPullRequests(context, repoInfo);
 
-  for (const pr of openPrs) {
-    // Snapshot-managed request PRs are already treated as approved branch-maintenance candidates.
-    // This pass is for direct/manual registry PRs that need onApproval re-evaluation.
-    if (isSnapshotManagedRequestPr(pr)) continue;
+  log(
+    context,
+    'info',
+    {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      baseBranch,
+      reason,
+      openPrCount: openPrs.length,
+      hooksSource: context.resourceBotHooksSource,
+    },
+    'direct-pr-reeval:start'
+  );
 
+  let processed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const pr of openPrs) {
     const headSha = toStringTrim(pr.head?.sha);
+    const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr);
+    const snapshotManaged = isSnapshotManagedRequestPr(pr);
+
+    const baseLog = {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      prNumber: pr.number,
+      title: toStringTrim(pr.title),
+      headSha,
+      headRef: toStringTrim(pr.head?.ref),
+      prBase: toStringTrim(pr.base?.ref),
+      baseBranch,
+      linkedIssueNumber,
+      snapshotManaged,
+      reason,
+    };
+
+    if (snapshotManaged) {
+      skipped += 1;
+      log(context, 'info', { ...baseLog, skipReason: 'snapshot-managed-request-pr' }, 'direct-pr-reeval:skip');
+      continue;
+    }
+
     if (!headSha) {
-      if (DBG) {
-        log(context, 'debug', { prNumber: pr.number, reason }, 'skip direct PR re-evaluation: missing head sha');
-      }
+      skipped += 1;
+      log(context, 'info', { ...baseLog, skipReason: 'missing-head-sha' }, 'direct-pr-reeval:skip');
       continue;
     }
 
     if (!pullRequestTargetsBranch(pr, baseBranch)) {
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          {
-            prNumber: pr.number,
-            prBase: toStringTrim(pr.base?.ref),
-            baseBranch,
-            reason,
-          },
-          'skip direct PR re-evaluation: different base branch'
-        );
-      }
+      skipped += 1;
+      log(context, 'info', { ...baseLog, skipReason: 'different-base-branch' }, 'direct-pr-reeval:skip');
       continue;
     }
 
@@ -2905,67 +3078,102 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
 
       if (!changedRegistryFiles.length) {
-        if (DBG) {
-          log(
-            context,
-            'debug',
-            { prNumber: pr.number, reason },
-            'skip direct PR re-evaluation: no registry yaml files changed'
-          );
-        }
+        skipped += 1;
+        log(
+          context,
+          'info',
+          { ...baseLog, changedRegistryFiles, skipReason: 'no-registry-yaml-files-changed' },
+          'direct-pr-reeval:skip'
+        );
         continue;
       }
 
-      const isGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
-      if (!isGreen) {
-        if (DBG) {
-          log(
-            context,
-            'debug',
-            { prNumber: pr.number, headSha, reason },
-            'skip direct PR re-evaluation: PR head checks are not green'
-          );
-        }
+      const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
+
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          changedRegistryFiles,
+          green: greenResult.green,
+          greenReason: greenResult.reason,
+          statusState: greenResult.statusState,
+          blockingRuns: greenResult.blockingRuns,
+          latestRuns: greenResult.latestRuns.slice(0, 30),
+        },
+        'direct-pr-reeval:head-green'
+      );
+
+      if (!greenResult.green) {
+        skipped += 1;
+        log(
+          context,
+          'info',
+          {
+            ...baseLog,
+            changedRegistryFiles,
+            skipReason: 'pr-head-checks-not-green',
+            greenReason: greenResult.reason,
+            blockingRuns: greenResult.blockingRuns,
+          },
+          'direct-pr-reeval:skip'
+        );
         continue;
       }
 
       const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha);
 
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          changedRegistryFiles,
+          hasCurrentHeadAutoApproval,
+          hooksSource: context.resourceBotHooksSource,
+        },
+        'direct-pr-reeval:candidate'
+      );
+
       if (hasCurrentHeadAutoApproval) {
+        processed += 1;
         await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, reason);
         continue;
       }
 
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          {
-            prNumber: pr.number,
-            headSha,
-            baseBranch,
-            changedRegistryFiles,
-            linkedIssueNumber: parseLinkedIssueNumberFromPr(pr),
-            reason,
-          },
-          're-evaluate direct PR against latest default-branch config'
-        );
-      }
-
+      processed += 1;
       await processPullRequestForAutoMerge(context, repoInfo, pr);
     } catch (e: unknown) {
+      failed += 1;
       log(
         context,
         'warn',
         {
+          ...baseLog,
           err: e instanceof Error ? e.message : String(e),
-          prNumber: pr.number,
-          reason,
+          status: getHttpStatus(e),
         },
-        'failed to re-evaluate direct pull request after default branch push'
+        'direct-pr-reeval:failed'
       );
     }
   }
+
+  log(
+    context,
+    'info',
+    {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      baseBranch,
+      reason,
+      openPrCount: openPrs.length,
+      processed,
+      skipped,
+      failed,
+    },
+    'direct-pr-reeval:done'
+  );
 }
 
 function isDefaultBranchPush(payload: unknown): boolean {
@@ -2978,11 +3186,15 @@ function isDefaultBranchPush(payload: unknown): boolean {
   return Boolean(ref && defaultBranch && ref === `refs/heads/${defaultBranch}`);
 }
 
-function readDefaultBranchFromPush(payload: unknown): string {
+function readDefaultBranchFromPayload(payload: unknown): string {
   if (!isPlainObject(payload)) return '';
 
   const repoObj = isPlainObject(payload['repository']) ? payload['repository'] : null;
   return repoObj ? toStringTrim(repoObj['default_branch']) : '';
+}
+
+function readDefaultBranchFromPush(payload: unknown): string {
+  return readDefaultBranchFromPayload(payload);
 }
 
 function pullRequestTargetsBranch(pr: PullRequestLike, branchName: string): boolean {
@@ -3423,12 +3635,33 @@ async function evaluateChangedResourceApproval(
 async function evaluateDirectPrOnApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
-  pr: PullRequestLike
+  pr: PullRequestLike,
+  requestAuthorIdOverride?: string
 ): Promise<ApprovalDecision> {
   const changedFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
-  if (!changedFiles.length) return {};
 
-  const requestAuthorId = await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
+  const fallbackRequestAuthorId = requestAuthorIdOverride
+    ? ''
+    : await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
+
+  const requestAuthorId = toStringTrim(requestAuthorIdOverride) || fallbackRequestAuthorId;
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      headSha: toStringTrim(pr.head?.sha),
+      headRef: toStringTrim(pr.head?.ref),
+      requestAuthorId,
+      changedFiles,
+      linkedIssueNumber: parseLinkedIssueNumberFromPr(pr),
+      hooksSource: context.resourceBotHooksSource,
+    },
+    'direct-pr:on-approval:start'
+  );
+
+  if (!changedFiles.length) return {};
 
   let sawApproved = false;
   let sawUnknown = false;
@@ -3436,6 +3669,21 @@ async function evaluateDirectPrOnApproval(
 
   for (const filePath of changedFiles) {
     const decision = await evaluateChangedResourceApproval(context, repoInfo, pr, filePath, requestAuthorId);
+
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        filePath,
+        requestAuthorId,
+        status: toStringTrim(decision.status) || 'none',
+        reason: toStringTrim(decision.reason),
+        message: toStringTrim(decision.message),
+        path: toStringTrim(decision.path),
+      },
+      'direct-pr:on-approval:file-decision'
+    );
 
     if (decision.status === 'rejected') {
       return decision;
@@ -3515,7 +3763,10 @@ async function closeLinkedIssuePrs(
   repoInfo: RepoInfo,
   issueNumber: number
 ): Promise<number[]> {
-  const prs = await findOpenIssuePrs(context, repoInfo, issueNumber);
+  const prs = (await listOpenPullRequests(context, repoInfo)).filter(
+    (pr) => parseLinkedIssueNumberFromPr(pr) === issueNumber
+  );
+
   const closed: number[] = [];
 
   for (const pr of prs) {
@@ -3692,20 +3943,29 @@ async function maybeHandleDirectPrApprovalForMerge(
   repoInfo: RepoInfo,
   issueParams: IssueParams,
   issue: IssueLike,
-  template: TemplateLike,
-  parsedFormData: FormData,
+  _template: TemplateLike,
+  _parsedFormData: FormData,
   pr: PullRequestLike
 ): Promise<ApprovalHandlingResult> {
-  const requestAuthorId = await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
+  const issueAuthorId = normalizeLogin(issue.user?.login);
+  const prRequesterId = await resolvePullRequestRequestAuthorId(context, repoInfo, pr);
+  const requestAuthorId = issueAuthorId || prRequesterId;
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      linkedIssueNumber: issue.number,
+      issueAuthorId,
+      prRequesterId,
+      requestAuthorId,
+    },
+    'direct-pr:linked-issue-requester-resolved'
+  );
+
   const decision = normalizeApprovalDecision(
-    await runApprovalHook(context, repoInfo, {
-      requestType: resolveEffectiveRequestType(template, parsedFormData),
-      namespace: toStringTrim(parsedFormData['namespace'] || parsedFormData['identifier']),
-      resourceName: extractResourceNameFromForm(parsedFormData, template),
-      formData: parsedFormData,
-      requestAuthorId: requestAuthorId || undefined,
-      issue,
-    })
+    await evaluateDirectPrOnApproval(context, repoInfo, pr, requestAuthorId || undefined)
   );
 
   if (decision.status === 'approved') {
@@ -3734,6 +3994,17 @@ async function maybeHandleDirectPrApprovalForMerge(
       buildApprovalRejectedBody(decision),
       { minimizeTag: 'nsreq:on-approval:rejected' }
     );
+
+    try {
+      await context.octokit.pulls.update({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        pull_number: pr.number,
+        state: 'closed',
+      });
+    } catch {
+      // ignore
+    }
 
     await rejectRequestFromApprovalHook(context, issueParams, issue, decision, {
       closeLinkedPrs: true,
@@ -5065,28 +5336,51 @@ function readRepoInfoFromPayload(payload: unknown): RepoInfo | null {
 }
 
 export default function requestHandler(app: Probot): void {
-  const getStaticConfig = async (context: BotContext<RequestEvents>): Promise<NormalizedStaticConfig> => {
-    if (context.resourceBotConfig && context.resourceBotHooks !== undefined) return context.resourceBotConfig;
+  const getStaticConfig = async (
+    context: BotContext<RequestEvents>,
+    options: StaticConfigLoadOptions = {}
+  ): Promise<NormalizedStaticConfig> => {
+    const forceReload = options.forceReload === true;
+
+    if (!forceReload && context.resourceBotConfig && context.resourceBotHooks !== undefined) {
+      return context.resourceBotConfig;
+    }
 
     try {
       const { config, hooks, hooksSource } = await loadStaticConfig(context, {
         validate: false,
         updateIssue: false,
+        forceReload,
       });
 
       context.resourceBotConfig = config;
       context.resourceBotHooks = hooks;
       context.resourceBotHooksSource = hooksSource || null;
 
+      log(
+        context,
+        'info',
+        {
+          forceReload,
+          hooksSource: context.resourceBotHooksSource,
+        },
+        'static-config:context-loaded'
+      );
+
       return context.resourceBotConfig;
     } catch (err: unknown) {
       (app.log || console).warn?.(
-        { err: err instanceof Error ? err.message : String(err) },
+        {
+          err: err instanceof Error ? err.message : String(err),
+          forceReload,
+        },
         'failed to load resource-bot static config, using defaults'
       );
+
       context.resourceBotConfig = DEFAULT_CONFIG;
       context.resourceBotHooks = null;
       context.resourceBotHooksSource = null;
+
       return context.resourceBotConfig;
     }
   };
@@ -5557,23 +5851,53 @@ export default function requestHandler(app: Probot): void {
     await getStaticConfig(context);
 
     const normalizedHeadSha = toStringTrim(headSha);
-    if (!normalizedHeadSha) return;
-
-    const headIsGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, normalizedHeadSha);
-    if (!headIsGreen) {
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          { owner: repoInfo.owner, repo: repoInfo.repo, headSha: normalizedHeadSha },
-          'skip direct PR approval until full validation pipeline is green'
-        );
-      }
+    if (!normalizedHeadSha) {
+      log(
+        context,
+        'info',
+        {
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+        },
+        'auto-merge:skip-missing-head-sha'
+      );
       return;
     }
 
+    const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, normalizedHeadSha);
+
+    log(
+      context,
+      'info',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        headSha: normalizedHeadSha,
+        green: greenResult.green,
+        greenReason: greenResult.reason,
+        statusState: greenResult.statusState,
+        blockingRuns: greenResult.blockingRuns,
+        latestRuns: greenResult.latestRuns.slice(0, 30),
+      },
+      'auto-merge:head-green'
+    );
+
+    if (!greenResult.green) return;
+
     const candidates = (await listOpenPullRequests(context, repoInfo)).filter(
       (pr) => toStringTrim(pr.head?.sha) === normalizedHeadSha
+    );
+
+    log(
+      context,
+      'info',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        headSha: normalizedHeadSha,
+        candidatePrNumbers: candidates.map((pr) => pr.number),
+      },
+      'auto-merge:candidates'
     );
 
     for (const pr of candidates) {
@@ -5593,23 +5917,130 @@ export default function requestHandler(app: Probot): void {
     }
   };
 
+  const maybeHandleDefaultBranchCheckSuiteSuccess = async (
+    context: BotContext<RequestEvents>,
+    payload: unknown,
+    checkSuite: CheckSuiteLike | null,
+    repoInfo: RepoInfo
+  ): Promise<void> => {
+    const defaultBranch = readDefaultBranchFromPayload(payload);
+    const headBranch = toStringTrim(checkSuite?.head_branch);
+    const headSha = toStringTrim(checkSuite?.head_sha);
+    const conclusion = toStringTrim(checkSuite?.conclusion).toLowerCase();
+    const status = toStringTrim(checkSuite?.status).toLowerCase();
+
+    let isDefaultBranchSuite = Boolean(defaultBranch && headBranch && headBranch === defaultBranch);
+    let defaultBranchHeadSha = '';
+
+    if (!isDefaultBranchSuite && defaultBranch && headSha) {
+      try {
+        const branch = await context.octokit.repos.getBranch({
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          branch: defaultBranch,
+        });
+
+        defaultBranchHeadSha = toStringTrim(
+          (branch as unknown as { data?: { commit?: { sha?: string | null } } })?.data?.commit?.sha
+        );
+
+        isDefaultBranchSuite = Boolean(defaultBranchHeadSha && defaultBranchHeadSha === headSha);
+      } catch (error: unknown) {
+        log(
+          context,
+          'warn',
+          {
+            owner: repoInfo.owner,
+            repo: repoInfo.repo,
+            defaultBranch,
+            headSha,
+            err: getErrorMessage(error),
+            status: getHttpStatus(error),
+          },
+          'default-branch-check-suite:branch-head-read-failed'
+        );
+      }
+    }
+
+    log(
+      context,
+      'info',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        defaultBranch,
+        headBranch,
+        headSha,
+        defaultBranchHeadSha,
+        conclusion,
+        status,
+        isDefaultBranchSuite,
+      },
+      'default-branch-check-suite:evaluated'
+    );
+
+    if (!isDefaultBranchSuite) return;
+    if (status && status !== 'completed') return;
+    if (conclusion !== 'success') return;
+
+    await getStaticConfig(context, { forceReload: true });
+
+    await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
+      context,
+      repoInfo,
+      defaultBranch,
+      'default-branch-check-suite:direct-pr-reevaluation'
+    );
+
+    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, defaultBranch);
+  };
+
   app.on('push', async (context: BotContext<'push'>): Promise<void> => {
-    await getStaticConfig(context);
-
     const payload = context.payload as unknown;
-    if (!isDefaultBranchPush(payload)) return;
-
     const repoInfo = readRepoInfoFromPayload(payload);
-    if (!repoInfo) return;
-
+    const ref = isPlainObject(payload) ? toStringTrim(payload['ref']) : '';
     const baseBranch = readDefaultBranchFromPush(payload);
+    const changedFiles = readPushChangedFiles(payload);
+    const approvalConfigChangedFiles = changedFiles.filter(isApprovalConfigChangePath);
+    const defaultBranchPush = isDefaultBranchPush(payload);
 
-    const directPrReevaluationReason = isRelevantDefaultBranchPushForApprovalReevaluation(payload)
+    log(
+      context,
+      'info',
+      {
+        event: toStringTrim((context as unknown as { name?: string }).name),
+        ref,
+        defaultBranch: baseBranch,
+        isDefaultBranchPush: defaultBranchPush,
+        owner: repoInfo?.owner,
+        repo: repoInfo?.repo,
+        changedFilesCount: changedFiles.length,
+        approvalConfigChangedFiles,
+      },
+      'default-branch-push:received'
+    );
+
+    if (!defaultBranchPush) return;
+
+    if (!repoInfo) {
+      log(
+        context,
+        'warn',
+        {
+          ref,
+          defaultBranch: baseBranch,
+        },
+        'default-branch-push:missing-repo-info'
+      );
+      return;
+    }
+
+    await getStaticConfig(context, { forceReload: true });
+
+    const directPrReevaluationReason = approvalConfigChangedFiles.length
       ? 'default-branch-push:approval-config-change'
       : 'default-branch-push:direct-pr-reevaluation';
 
-    // Re-evaluate old open direct registry PRs against the latest default-branch config.
-    // This also covers PRs that existed before the current bot version was deployed.
     await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       context,
       repoInfo,
@@ -5617,7 +6048,6 @@ export default function requestHandler(app: Probot): void {
       directPrReevaluationReason
     );
 
-    // after main changed, keep already-approved registry PRs up to date
     await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
   });
 
@@ -5625,33 +6055,78 @@ export default function requestHandler(app: Probot): void {
     ['check_suite.completed', 'check_run.completed'],
     async (context: BotContext<'check_suite.completed' | 'check_run.completed'>): Promise<void> => {
       const payload = context.payload as unknown;
+      const action = isPlainObject(payload) ? toStringTrim(payload['action']).toLowerCase() : '';
+      const eventName = toStringTrim((context as unknown as { name?: string }).name);
+      const run = readCheckRunFromPayload(payload);
+      const checkSuite = readCheckSuiteFromPayload(payload);
+      const repoInfo = readRepoInfoFromPayload(payload);
 
-      if (context.name === 'check_run.completed') {
-        const payload = context.payload as unknown;
-        const run = readCheckRunFromPayload(payload);
+      log(
+        context,
+        'info',
+        {
+          event: eventName,
+          action,
+          hasCheckRun: Boolean(run),
+          hasCheckSuite: Boolean(checkSuite),
+          checkRunHeadSha: toStringTrim(run?.head_sha),
+          checkRunStatus: toStringTrim(run?.status).toLowerCase(),
+          checkRunConclusion: toStringTrim(run?.conclusion).toLowerCase(),
+          checkSuiteHeadSha: toStringTrim(checkSuite?.head_sha),
+          checkSuiteHeadBranch: toStringTrim(checkSuite?.head_branch),
+          checkSuiteStatus: toStringTrim(checkSuite?.status).toLowerCase(),
+          checkSuiteConclusion: toStringTrim(checkSuite?.conclusion).toLowerCase(),
+          owner: repoInfo?.owner,
+          repo: repoInfo?.repo,
+        },
+        'checks:event-classification'
+      );
 
+      if (run) {
         const conclusion = toStringTrim(run?.conclusion).toLowerCase();
         const status = toStringTrim(run?.status).toLowerCase();
         const headShaStr = toStringTrim(run?.head_sha);
+
+        if (!repoInfo) {
+          log(
+            context,
+            'warn',
+            {
+              event: eventName,
+              action,
+              conclusion,
+              status,
+              headShaStr,
+            },
+            'checks:check-run-missing-repo-info'
+          );
+          return;
+        }
+
+        const prNumbers = readCheckRunPrNumbers(run);
+
+        log(
+          context,
+          'info',
+          {
+            owner: repoInfo.owner,
+            repo: repoInfo.repo,
+            conclusion,
+            status,
+            headShaStr,
+            prNumbers,
+          },
+          'checks:check-run resolved'
+        );
 
         if (status !== 'completed') return;
         if (conclusion !== 'success') return;
         if (!headShaStr) return;
 
-        const repoObj = isPlainObject(payload) ? payload['repository'] : undefined;
-        const repoName = isPlainObject(repoObj) ? toStringTrim(repoObj['name']) : '';
-        const ownerObj = isPlainObject(repoObj) ? repoObj['owner'] : undefined;
-        const ownerLogin = isPlainObject(ownerObj) ? toStringTrim(ownerObj['login']) : '';
-
-        if (!ownerLogin || !repoName) return;
-
-        const repoInfo = { owner: ownerLogin, repo: repoName };
-        const prNumbers = readCheckRunPrNumbers(run);
-
         for (const prNumber of prNumbers) {
           await collapseBotCommentsByPrefix(
             context,
-            { owner: ownerLogin, repo: repoName, issue_number: prNumber },
+            { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: prNumber },
             {
               tagPrefix: 'nsreq:ci-validation',
               collapseBody: 'Validation issues resolved.',
@@ -5664,48 +6139,30 @@ export default function requestHandler(app: Probot): void {
         return;
       }
 
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          { event: context.name, action: isPlainObject(payload) ? payload['action'] : undefined },
-          'dbg:checks:event received'
-        );
-      }
+      if (!checkSuite) return;
+      if (!repoInfo) return;
 
-      const suite = isPlainObject(payload) && 'check_suite' in payload ? payload['check_suite'] : undefined;
+      const conclusion = toStringTrim(checkSuite.conclusion).toLowerCase();
+      const headShaStr = toStringTrim(checkSuite.head_sha);
+      const ownerLogin = repoInfo.owner;
+      const repoName = repoInfo.repo;
 
-      let conclusionRaw: unknown;
-      if (isPlainObject(suite)) conclusionRaw = suite['conclusion'];
+      const prNumbers = await resolveCheckSuitePrNumbers(context, repoInfo, checkSuite, headShaStr);
 
-      let headShaRaw: unknown;
-      if (isPlainObject(suite)) headShaRaw = suite['head_sha'];
-
-      const conclusion = toStringTrim(conclusionRaw).toLowerCase();
-      const headShaStr = toStringTrim(headShaRaw);
-
-      const repoObj = isPlainObject(payload) ? payload['repository'] : undefined;
-      const repoName = isPlainObject(repoObj) ? toStringTrim(repoObj['name']) : '';
-      const ownerObj = isPlainObject(repoObj) ? repoObj['owner'] : undefined;
-      const ownerLogin = isPlainObject(ownerObj) ? toStringTrim(ownerObj['login']) : '';
-
-      if (!ownerLogin || !repoName) return;
-      const checkSuite = readCheckSuiteFromPayload(context.payload as unknown);
-      const prNumbers = await resolveCheckSuitePrNumbers(
+      log(
         context,
-        { owner: ownerLogin, repo: repoName },
-        checkSuite,
-        headShaStr
+        'info',
+        {
+          ownerLogin,
+          repoName,
+          conclusion,
+          headShaStr,
+          checkSuiteHeadBranch: toStringTrim(checkSuite.head_branch),
+          checkSuiteStatus: toStringTrim(checkSuite.status).toLowerCase(),
+          prNumbers,
+        },
+        'checks:context resolved'
       );
-
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          { ownerLogin, repoName, conclusion, headShaStr, prNumbers },
-          'dbg:checks:context resolved'
-        );
-      }
 
       // success -> collapse old CI validation comments + keep existing auto-merge behavior
       if (conclusion === 'success') {
@@ -5720,6 +6177,11 @@ export default function requestHandler(app: Probot): void {
             }
           );
         }
+
+        await maybeHandleDefaultBranchCheckSuiteSuccess(context, payload, checkSuite, {
+          owner: ownerLogin,
+          repo: repoName,
+        });
 
         if (!headShaStr) return;
         await tryAutoMerge(context, { owner: ownerLogin, repo: repoName }, headShaStr);

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -97,14 +97,26 @@ type CollapseBotCommentsByPrefixOptions = {
   classifier?: 'OUTDATED' | 'RESOLVED' | 'DUPLICATE' | 'OFF_TOPIC' | 'SPAM' | 'ABUSE';
 };
 
+type PullRequestRepoLike = {
+  name?: string | null;
+  full_name?: string | null;
+  owner?: UserLike | null;
+};
+
+type PullRequestBranchLike = {
+  ref: string;
+  sha: string;
+  repo?: PullRequestRepoLike | null;
+};
+
 type PullRequestLike = {
   number: number;
   title?: string | null;
   body?: string | null;
   state?: string | null;
   user?: UserLike | null;
-  head: { ref: string; sha: string };
-  base?: { ref?: string | null; sha?: string | null };
+  head: PullRequestBranchLike;
+  base?: PullRequestBranchLike;
 
   mergeable?: boolean | null;
   mergeable_state?: string | null;
@@ -3096,15 +3108,20 @@ function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
   ]);
 }
 
-function parseLinkedIssueNumberFromPr(pr: PullRequestLike): number | null {
-  return (
-    parseLinkedIssueNumberFromPrBody(pr.body) ??
-    parseIssueNumberFromText(pr.head?.ref, [/(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i]) ??
-    parseIssueNumberFromText(pr.title, [
-      /\bissue\s*#?\s*(\d+)\b/i,
-      /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s*:?\s*#(\d+)\b/i,
-    ])
-  );
+function parseLinkedIssueNumberFromPr(pr: PullRequestLike, repoInfo?: RepoInfo): number | null {
+  const fromBody = parseLinkedIssueNumberFromPrBody(pr.body);
+  if (fromBody !== null) return fromBody;
+
+  const fromTitle = parseIssueNumberFromText(pr.title, [
+    /\bissue\s*#?\s*(\d+)\b/i,
+    /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s*:?\s*#(\d+)\b/i,
+  ]);
+
+  if (fromTitle !== null) return fromTitle;
+
+  if (repoInfo && isCrossRepositoryPullRequest(pr, repoInfo)) return null;
+
+  return parseIssueNumberFromText(pr.head?.ref, [/(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i]);
 }
 
 function isSnapshotManagedRequestPr(pr: PullRequestLike): boolean {
@@ -3145,7 +3162,7 @@ async function processPullRequestForAutoMerge(
   repoInfo: RepoInfo,
   pr: PullRequestLike
 ): Promise<void> {
-  const issueNumber = parseLinkedIssueNumberFromPr(pr);
+  const issueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
 
   if (issueNumber === null) {
     const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
@@ -3179,9 +3196,20 @@ async function processPullRequestForAutoMerge(
         issueNumber,
         err: getErrorMessage(error),
         status: getHttpStatus(error),
+        crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
       },
-      'direct-pr:linked-issue-read-failed'
+      'direct-pr:linked-issue-read-failed-fallback-standalone'
     );
+
+    const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, freshPr, {
+      baseBranch: toStringTrim(freshPr.base?.ref),
+    });
+
+    if (standaloneOutcome !== 'approved') return;
+
+    const approvedPr = (await readFreshPullRequest(context, repoInfo, freshPr.number)) || freshPr;
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, approvedPr, 'auto-merge');
     return;
   }
 
@@ -4045,23 +4073,203 @@ function registryYamlTreeEntryPath(context: BotContext<RequestEvents>, entry: Gi
   return path;
 }
 
+type PullRequestHeadReadCandidate = {
+  repoInfo: RepoInfo;
+  ref: string;
+  source: string;
+};
+
+function sameRepoInfo(a: RepoInfo, b: RepoInfo): boolean {
+  return a.owner.toLowerCase() === b.owner.toLowerCase() && a.repo.toLowerCase() === b.repo.toLowerCase();
+}
+
+function resolveRepoInfoFromRepoLike(repoLike: PullRequestRepoLike | null | undefined): RepoInfo | null {
+  const fullName = toStringTrim(repoLike?.full_name);
+  if (fullName) {
+    const parts = fullName
+      .split('/')
+      .map((part) => toStringTrim(part))
+      .filter(Boolean);
+
+    if (parts.length === 2) {
+      return { owner: parts[0], repo: parts[1] };
+    }
+  }
+
+  const owner = normalizeLogin(repoLike?.owner?.login);
+  const repo = toStringTrim(repoLike?.name);
+
+  return owner && repo ? { owner, repo } : null;
+}
+
+function resolvePullRequestHeadRepoInfo(pr: PullRequestLike, fallbackRepoInfo: RepoInfo): RepoInfo {
+  return resolveRepoInfoFromRepoLike(pr.head?.repo) || fallbackRepoInfo;
+}
+
+function isCrossRepositoryPullRequest(pr: PullRequestLike, baseRepoInfo: RepoInfo): boolean {
+  return !sameRepoInfo(resolvePullRequestHeadRepoInfo(pr, baseRepoInfo), baseRepoInfo);
+}
+
+function buildPullRequestHeadReadCandidates(repoInfo: RepoInfo, pr: PullRequestLike): PullRequestHeadReadCandidate[] {
+  const headRepoInfo = resolvePullRequestHeadRepoInfo(pr, repoInfo);
+  const headSha = toStringTrim(pr.head?.sha);
+  const headRef = toStringTrim(pr.head?.ref);
+  const isCrossRepo = !sameRepoInfo(headRepoInfo, repoInfo);
+
+  const out: PullRequestHeadReadCandidate[] = [];
+  const seen = new Set<string>();
+
+  const add = (candidateRepoInfo: RepoInfo, ref: string, source: string): void => {
+    const normalizedRef = toStringTrim(ref);
+    if (!normalizedRef) return;
+
+    const key = `${candidateRepoInfo.owner}/${candidateRepoInfo.repo}:${normalizedRef}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    out.push({
+      repoInfo: candidateRepoInfo,
+      ref: normalizedRef,
+      source,
+    });
+  };
+
+  add(repoInfo, headSha, 'base-repo:head-sha');
+  add(repoInfo, `refs/pull/${pr.number}/head`, 'base-repo:pull-ref-full');
+  add(repoInfo, `pull/${pr.number}/head`, 'base-repo:pull-ref-short');
+
+  if (!isCrossRepo) {
+    add(repoInfo, headRef, 'base-repo:head-ref');
+  }
+
+  add(headRepoInfo, headSha, 'head-repo:head-sha');
+  add(headRepoInfo, headRef, 'head-repo:head-ref');
+
+  return out;
+}
+
+async function readPullRequestHeadFileText(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  path: string
+): Promise<string | null> {
+  const candidates = buildPullRequestHeadReadCandidates(repoInfo, pr);
+  const normalizedPath = normalizeRepoPath(path);
+
+  for (const candidate of candidates) {
+    const raw = await readRepoFileTextAtRef(context, candidate.repoInfo, normalizedPath, candidate.ref);
+    if (raw === null) continue;
+
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        path: normalizedPath,
+        source: candidate.source,
+        owner: candidate.repoInfo.owner,
+        repo: candidate.repoInfo.repo,
+        ref: candidate.ref,
+        crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+      },
+      'pull-request head file resolved'
+    );
+
+    return raw;
+  }
+
+  log(
+    context,
+    'warn',
+    {
+      prNumber: pr.number,
+      path: normalizedPath,
+      baseOwner: repoInfo.owner,
+      baseRepo: repoInfo.repo,
+      headOwner: resolvePullRequestHeadRepoInfo(pr, repoInfo).owner,
+      headRepo: resolvePullRequestHeadRepoInfo(pr, repoInfo).repo,
+      headRef: toStringTrim(pr.head?.ref),
+      headSha: toStringTrim(pr.head?.sha),
+      crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+      candidates: candidates.map((candidate) => ({
+        source: candidate.source,
+        owner: candidate.repoInfo.owner,
+        repo: candidate.repoInfo.repo,
+        ref: candidate.ref,
+      })),
+    },
+    'pull-request head file read failed'
+  );
+
+  return null;
+}
+
+async function readPullRequestHeadTreeEntries(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<GitTreeEntryLike[]> {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return [];
+
+  const headRepoInfo = resolvePullRequestHeadRepoInfo(pr, repoInfo);
+  const candidates: PullRequestHeadReadCandidate[] = [
+    {
+      repoInfo,
+      ref: headSha,
+      source: 'base-repo:head-sha',
+    },
+  ];
+
+  if (!sameRepoInfo(headRepoInfo, repoInfo)) {
+    candidates.push({
+      repoInfo: headRepoInfo,
+      ref: headSha,
+      source: 'head-repo:head-sha',
+    });
+  }
+
+  for (const candidate of candidates) {
+    const entries = await readRecursiveGitTreeEntries(context, candidate.repoInfo, candidate.ref);
+    if (!entries.length) continue;
+
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        source: candidate.source,
+        owner: candidate.repoInfo.owner,
+        repo: candidate.repoInfo.repo,
+        ref: candidate.ref,
+        crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+        entries: entries.length,
+      },
+      'pull-request head tree resolved'
+    );
+
+    return entries;
+  }
+
+  return [];
+}
+
 async function listChangedYamlFilesForPrAgainstCurrentBase(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   pr: PullRequestLike,
   baseBranch: string
 ): Promise<string[]> {
-  const headSha = toStringTrim(pr.head?.sha);
   const baseRef = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
-
-  if (!headSha || !baseRef) return [];
+  if (!baseRef) return [];
 
   const baseSha = await readBranchHeadSha(context, repoInfo, baseRef);
   if (!baseSha) return [];
 
   const [baseEntries, headEntries] = await Promise.all([
     readRecursiveGitTreeEntries(context, repoInfo, baseSha),
-    readRecursiveGitTreeEntries(context, repoInfo, headSha),
+    readPullRequestHeadTreeEntries(context, repoInfo, pr),
   ]);
 
   const baseByPath = new Map<string, string>();
@@ -4132,6 +4340,7 @@ async function isPullRequestBehindCurrentBase(
   baseBranch: string
 ): Promise<boolean> {
   const headSha = toStringTrim(pr.head?.sha);
+  const headRef = toStringTrim(pr.head?.ref);
   const baseRef = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
 
   if (!headSha || !baseRef) return false;
@@ -4139,42 +4348,69 @@ async function isPullRequestBehindCurrentBase(
   const baseHeadSha = await readBranchHeadSha(context, repoInfo, baseRef);
   if (!baseHeadSha || baseHeadSha === headSha) return false;
 
-  try {
-    const res = await (
-      context.octokit.repos as unknown as {
-        compareCommitsWithBasehead: (args: {
-          owner: string;
-          repo: string;
-          basehead: string;
-        }) => Promise<{ data?: { status?: string | null; ahead_by?: number | null } }>;
-      }
-    ).compareCommitsWithBasehead({
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      basehead: `${headSha}...${baseHeadSha}`,
-    });
+  const headRepoInfo = resolvePullRequestHeadRepoInfo(pr, repoInfo);
+  const candidates: string[] = [`${headSha}...${baseHeadSha}`];
 
-    const status = toStringTrim(res?.data?.status).toLowerCase();
-    const aheadBy = typeof res?.data?.ahead_by === 'number' ? res.data.ahead_by : 0;
-
-    return status === 'ahead' || status === 'diverged' || aheadBy > 0;
-  } catch (error: unknown) {
-    log(
-      context,
-      'warn',
-      {
-        prNumber: pr.number,
-        headSha,
-        baseBranch: baseRef,
-        baseHeadSha,
-        err: getErrorMessage(error),
-        status: getHttpStatus(error),
-      },
-      'pull-request behind-current-base check failed'
-    );
-
-    return isPullRequestBehindBase(pr);
+  if (!sameRepoInfo(headRepoInfo, repoInfo) && headRef) {
+    candidates.push(`${headRepoInfo.owner}:${headRef}...${repoInfo.owner}:${baseRef}`);
   }
+
+  for (const basehead of candidates) {
+    try {
+      const res = await (
+        context.octokit.repos as unknown as {
+          compareCommitsWithBasehead: (args: {
+            owner: string;
+            repo: string;
+            basehead: string;
+          }) => Promise<{ data?: { status?: string | null; ahead_by?: number | null } }>;
+        }
+      ).compareCommitsWithBasehead({
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        basehead,
+      });
+
+      const status = toStringTrim(res?.data?.status).toLowerCase();
+      const aheadBy = typeof res?.data?.ahead_by === 'number' ? res.data.ahead_by : 0;
+
+      log(
+        context,
+        'info',
+        {
+          prNumber: pr.number,
+          basehead,
+          status,
+          aheadBy,
+          headSha,
+          baseHeadSha,
+          crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+        },
+        'pull-request behind-current-base compare'
+      );
+
+      if (status === 'ahead' || status === 'diverged' || aheadBy > 0) return true;
+      if (status === 'identical') return false;
+    } catch (error: unknown) {
+      log(
+        context,
+        'warn',
+        {
+          prNumber: pr.number,
+          basehead,
+          headSha,
+          baseBranch: baseRef,
+          baseHeadSha,
+          err: getErrorMessage(error),
+          status: getHttpStatus(error),
+          crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+        },
+        'pull-request behind-current-base compare failed'
+      );
+    }
+  }
+
+  return isPullRequestBehindBase(pr);
 }
 
 async function shouldUpdatePullRequestBranch(
@@ -4222,10 +4458,10 @@ async function readRepoFileTextAtRef(
 async function readRegistryDocForApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
-  filePath: string,
-  ref: string
+  pr: PullRequestLike,
+  filePath: string
 ): Promise<Record<string, unknown> | null> {
-  const raw = await readRepoFileTextAtRef(context, repoInfo, filePath, ref);
+  const raw = await readPullRequestHeadFileText(context, repoInfo, pr, filePath);
   if (!raw) return null;
 
   try {
@@ -4243,8 +4479,27 @@ async function evaluateChangedResourceApproval(
   filePath: string,
   requestAuthorId?: string
 ): Promise<ApprovalDecision> {
-  const parsed = await readRegistryDocForApproval(context, repoInfo, filePath, pr.head.ref);
-  if (!parsed) return { status: 'unknown' };
+  const parsed = await readRegistryDocForApproval(context, repoInfo, pr, filePath);
+  if (!parsed) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        filePath,
+        baseOwner: repoInfo.owner,
+        baseRepo: repoInfo.repo,
+        headOwner: resolvePullRequestHeadRepoInfo(pr, repoInfo).owner,
+        headRepo: resolvePullRequestHeadRepoInfo(pr, repoInfo).repo,
+        headRef: toStringTrim(pr.head?.ref),
+        headSha: toStringTrim(pr.head?.sha),
+        crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+      },
+      'direct-pr:on-approval:registry-doc-read-failed'
+    );
+
+    return { status: 'unknown' };
+  }
 
   const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
   if (!requestType) return { status: 'unknown' };
@@ -4295,7 +4550,10 @@ async function evaluateDirectPrOnApproval(
       headRef: toStringTrim(pr.head?.ref),
       requestAuthorId,
       changedFiles,
-      linkedIssueNumber: parseLinkedIssueNumberFromPr(pr),
+      linkedIssueNumber: parseLinkedIssueNumberFromPr(pr, repoInfo),
+      crossRepo: isCrossRepositoryPullRequest(pr, repoInfo),
+      headOwner: resolvePullRequestHeadRepoInfo(pr, repoInfo).owner,
+      headRepo: resolvePullRequestHeadRepoInfo(pr, repoInfo).repo,
       hooksSource: context.resourceBotHooksSource,
     },
     'direct-pr:on-approval:start'
@@ -4407,7 +4665,7 @@ async function closeLinkedIssuePrs(
   issueNumber: number
 ): Promise<number[]> {
   const prs = (await listOpenPullRequests(context, repoInfo)).filter(
-    (pr) => parseLinkedIssueNumberFromPr(pr) === issueNumber
+    (pr) => parseLinkedIssueNumberFromPr(pr, repoInfo) === issueNumber
   );
 
   const closed: number[] = [];

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1911,8 +1911,6 @@ async function createAutomatedApprovalReview(
       'automated PR approval review created'
     );
 
-    await delayMs(1000);
-
     return true;
   } catch (e: unknown) {
     const errObj = isPlainObject(e) ? e : {};

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -3135,7 +3135,9 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRe
     });
   }, DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS);
 
-  retryTimer.unref?.();
+  if (retryTimer && typeof (retryTimer as { unref?: () => void }).unref === 'function') {
+    retryTimer.unref();
+  }
 }
 
 function normalizeRepoPath(path: unknown): string {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -3359,7 +3359,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
 
   for (const pr of openPrs) {
     const headSha = toStringTrim(pr.head?.sha);
-    const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr);
+    const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
     const snapshotManaged = isSnapshotManagedRequestPr(pr);
 
     const baseLog = {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2688,13 +2688,36 @@ async function tryMergeApprovedPrOrUpdateBranch(
   }
 }
 
-function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
-  const raw = toStringTrim(body);
-  const match = /source:\s*#(\d+)/i.exec(raw) ?? /issue\s*#(\d+)/i.exec(raw);
-  if (!match?.[1]) return null;
+function parsePositiveIssueNumber(value: string | undefined): number | null {
+  if (!value) return null;
 
-  const value = Number.parseInt(match[1], 10);
-  return Number.isFinite(value) ? value : null;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function parseIssueNumberFromText(value: unknown, patterns: RegExp[]): number | null {
+  const raw = toStringTrim(value);
+  if (!raw) return null;
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(raw);
+    const parsed = parsePositiveIssueNumber(match?.[1]);
+    if (parsed !== null) return parsed;
+  }
+
+  return null;
+}
+
+function parseLinkedIssueNumberFromPrBody(body: unknown): number | null {
+  return parseIssueNumberFromText(body, [/source:\s*#(\d+)/i, /\bissue\s*#\s*(\d+)\b/i, /\bissue\s+(\d+)\b/i]);
+}
+
+function parseLinkedIssueNumberFromPr(pr: PullRequestLike): number | null {
+  return (
+    parseLinkedIssueNumberFromPrBody(pr.body) ??
+    parseIssueNumberFromText(pr.head?.ref, [/(?:^|[-_/])issue[-_/]?(\d+)(?:$|[-_/])/i]) ??
+    parseIssueNumberFromText(pr.title, [/\bissue\s*#?\s*(\d+)\b/i])
+  );
 }
 
 function isSnapshotManagedRequestPr(pr: PullRequestLike): boolean {
@@ -2735,7 +2758,7 @@ async function processPullRequestForAutoMerge(
   repoInfo: RepoInfo,
   pr: PullRequestLike
 ): Promise<void> {
-  const issueNumber = parseLinkedIssueNumberFromPrBody(pr.body);
+  const issueNumber = parseLinkedIssueNumberFromPr(pr);
 
   if (issueNumber === null) {
     const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
@@ -2840,28 +2863,93 @@ function isRelevantDefaultBranchPushForApprovalReevaluation(payload: unknown): b
   return readPushChangedFiles(payload).some(isApprovalConfigChangePath);
 }
 
-async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
+async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
   context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo
+  repoInfo: RepoInfo,
+  baseBranch: string,
+  reason = 'default-branch-push:direct-pr-reevaluation'
 ): Promise<void> {
   const openPrs = await listOpenPullRequests(context, repoInfo);
 
   for (const pr of openPrs) {
+    // Snapshot-managed request PRs are already treated as approved branch-maintenance candidates.
+    // This pass is for direct/manual registry PRs that need onApproval re-evaluation.
     if (isSnapshotManagedRequestPr(pr)) continue;
-    if (parseLinkedIssueNumberFromPrBody(pr.body) !== null) continue;
 
     const headSha = toStringTrim(pr.head?.sha);
-    if (!headSha) continue;
+    if (!headSha) {
+      if (DBG) {
+        log(context, 'debug', { prNumber: pr.number, reason }, 'skip direct PR re-evaluation: missing head sha');
+      }
+      continue;
+    }
 
-    const isGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
-    if (!isGreen) continue;
+    if (!pullRequestTargetsBranch(pr, baseBranch)) {
+      if (DBG) {
+        log(
+          context,
+          'debug',
+          {
+            prNumber: pr.number,
+            prBase: toStringTrim(pr.base?.ref),
+            baseBranch,
+            reason,
+          },
+          'skip direct PR re-evaluation: different base branch'
+        );
+      }
+      continue;
+    }
 
     try {
+      const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+
+      if (!changedRegistryFiles.length) {
+        if (DBG) {
+          log(
+            context,
+            'debug',
+            { prNumber: pr.number, reason },
+            'skip direct PR re-evaluation: no registry yaml files changed'
+          );
+        }
+        continue;
+      }
+
+      const isGreen = await isHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
+      if (!isGreen) {
+        if (DBG) {
+          log(
+            context,
+            'debug',
+            { prNumber: pr.number, headSha, reason },
+            'skip direct PR re-evaluation: PR head checks are not green'
+          );
+        }
+        continue;
+      }
+
       const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha);
 
       if (hasCurrentHeadAutoApproval) {
-        await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
+        await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, reason);
         continue;
+      }
+
+      if (DBG) {
+        log(
+          context,
+          'debug',
+          {
+            prNumber: pr.number,
+            headSha,
+            baseBranch,
+            changedRegistryFiles,
+            linkedIssueNumber: parseLinkedIssueNumberFromPr(pr),
+            reason,
+          },
+          're-evaluate direct PR against latest default-branch config'
+        );
       }
 
       await processPullRequestForAutoMerge(context, repoInfo, pr);
@@ -2872,8 +2960,9 @@ async function reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(
         {
           err: e instanceof Error ? e.message : String(e),
           prNumber: pr.number,
+          reason,
         },
-        'failed to re-evaluate direct pull request after approval config change'
+        'failed to re-evaluate direct pull request after default branch push'
       );
     }
   }
@@ -3612,7 +3701,7 @@ async function maybeHandleDirectPrApprovalForMerge(
       namespace: toStringTrim(parsedFormData['namespace'] || parsedFormData['identifier']),
       resourceName: extractResourceNameFromForm(parsedFormData, template),
       formData: parsedFormData,
-      requestAuthorId,
+      requestAuthorId: requestAuthorId || undefined,
       issue,
     })
   );
@@ -5513,12 +5602,20 @@ export default function requestHandler(app: Probot): void {
 
     const baseBranch = readDefaultBranchFromPush(payload);
 
-    // if approval config changed, re-evaluate old direct PRs
-    if (isRelevantDefaultBranchPushForApprovalReevaluation(payload)) {
-      await reevaluateOpenDirectPullRequestsAfterApprovalConfigChange(context, repoInfo);
-    }
+    const directPrReevaluationReason = isRelevantDefaultBranchPushForApprovalReevaluation(payload)
+      ? 'default-branch-push:approval-config-change'
+      : 'default-branch-push:direct-pr-reevaluation';
 
-    // after main changed, keep already-approved green registry PRs up to date
+    // Re-evaluate old open direct registry PRs against the latest default-branch config.
+    // This also covers PRs that existed before the current bot version was deployed.
+    await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
+      context,
+      repoInfo,
+      baseBranch,
+      directPrReevaluationReason
+    );
+
+    // after main changed, keep already-approved registry PRs up to date
     await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
   });
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1889,6 +1889,18 @@ async function createAutomatedApprovalReview(
       body: reviewBody,
     });
 
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+      },
+      'automated PR approval review created'
+    );
+
+    await delayMs(1000);
+
     return true;
   } catch (e: unknown) {
     const errObj = isPlainObject(e) ? e : {};
@@ -2394,15 +2406,27 @@ function mergeInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): string {
 }
 
 const UPDATE_BRANCH_INFLIGHT = new Map<string, Promise<boolean>>();
+const UPDATE_BRANCH_COOLDOWN_UNTIL = new Map<string, number>();
 
 const DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS = 5000;
+const UPDATE_BRANCH_RETRY_DELAY_MS = 2000;
+const UPDATE_BRANCH_COOLDOWN_MS = 15000;
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 function updateBranchInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): string {
-  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}`;
+  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}`;
+}
+
+function isUpdateBranchCooldownActive(key: string): boolean {
+  const until = UPDATE_BRANCH_COOLDOWN_UNTIL.get(key) || 0;
+  return until > Date.now();
+}
+
+function markUpdateBranchCooldown(key: string): void {
+  UPDATE_BRANCH_COOLDOWN_UNTIL.set(key, Date.now() + UPDATE_BRANCH_COOLDOWN_MS);
 }
 
 function isBenignUpdateBranchFailure(error: unknown): boolean {
@@ -2439,6 +2463,40 @@ function isManualUpdateBranchFailure(error: unknown): boolean {
   );
 }
 
+async function callPullRequestBranchUpdate(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number,
+  expectedHeadSha?: string
+): Promise<void> {
+  const args: {
+    owner: string;
+    repo: string;
+    pull_number: number;
+    expected_head_sha?: string;
+  } = {
+    owner: repoInfo.owner,
+    repo: repoInfo.repo,
+    pull_number: prNumber,
+  };
+
+  const normalizedExpectedHeadSha = toStringTrim(expectedHeadSha);
+  if (normalizedExpectedHeadSha) {
+    args.expected_head_sha = normalizedExpectedHeadSha;
+  }
+
+  await (
+    context.octokit.pulls as unknown as {
+      updateBranch: (args: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        expected_head_sha?: string;
+      }) => Promise<unknown>;
+    }
+  ).updateBranch(args);
+}
+
 async function requestPullRequestBranchUpdate(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -2449,26 +2507,30 @@ async function requestPullRequestBranchUpdate(
   if (!headSha) return false;
 
   const key = updateBranchInflightKey(repoInfo, pr);
+
+  if (isUpdateBranchCooldownActive(key)) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha,
+        reason,
+      },
+      'pull-request branch update skipped: cooldown active'
+    );
+
+    return false;
+  }
+
   const existing = UPDATE_BRANCH_INFLIGHT.get(key);
   if (existing) return await existing;
 
   const pending = (async (): Promise<boolean> => {
     try {
-      await (
-        context.octokit.pulls as unknown as {
-          updateBranch: (args: {
-            owner: string;
-            repo: string;
-            pull_number: number;
-            expected_head_sha?: string;
-          }) => Promise<unknown>;
-        }
-      ).updateBranch({
-        owner: repoInfo.owner,
-        repo: repoInfo.repo,
-        pull_number: pr.number,
-        expected_head_sha: headSha,
-      });
+      await callPullRequestBranchUpdate(context, repoInfo, pr.number, headSha);
+
+      markUpdateBranchCooldown(key);
 
       log(
         context,
@@ -2488,20 +2550,87 @@ async function requestPullRequestBranchUpdate(
 
       if (isBenignUpdateBranchFailure(error)) {
         const fresh = await readFreshPullRequest(context, repoInfo, pr.number);
+        const freshHeadSha = toStringTrim(fresh?.head?.sha);
+        const freshMergeableState = readMergeableState(fresh);
+        const stillBehind = Boolean(fresh && isPullRequestBehindBase(fresh));
+
+        if (freshHeadSha && freshHeadSha !== headSha) {
+          log(
+            context,
+            'info',
+            {
+              prNumber: pr.number,
+              oldHeadSha: headSha,
+              freshHeadSha,
+              status,
+              err: msg,
+              reason,
+              freshMergeableState,
+            },
+            'pull-request branch update skipped: head already changed'
+          );
+
+          return false;
+        }
+
+        if (stillBehind) {
+          await delayMs(UPDATE_BRANCH_RETRY_DELAY_MS);
+
+          try {
+            await callPullRequestBranchUpdate(context, repoInfo, pr.number);
+
+            markUpdateBranchCooldown(key);
+
+            log(
+              context,
+              'info',
+              {
+                prNumber: pr.number,
+                headSha,
+                freshHeadSha,
+                reason,
+              },
+              'pull-request branch update requested after expected-head retry'
+            );
+
+            return true;
+          } catch (retryError: unknown) {
+            markUpdateBranchCooldown(key);
+
+            log(
+              context,
+              'warn',
+              {
+                prNumber: pr.number,
+                headSha,
+                freshHeadSha,
+                status: getHttpStatus(retryError),
+                err: getErrorMessage(retryError),
+                originalStatus: status,
+                originalErr: msg,
+                reason,
+                freshMergeableState,
+              },
+              'pull-request branch update retry failed'
+            );
+
+            return false;
+          }
+        }
 
         log(
           context,
-          'debug',
+          'info',
           {
             prNumber: pr.number,
             oldHeadSha: headSha,
-            freshHeadSha: toStringTrim(fresh?.head?.sha),
+            freshHeadSha,
             status,
             err: msg,
             reason,
-            freshMergeableState: readMergeableState(fresh),
+            freshMergeableState,
           },
-          'pull-request branch update skipped after head race'
+          'pull-request branch update skipped after benign failure'
         );
 
         return false;
@@ -2555,8 +2684,20 @@ function shouldTryBranchUpdateAfterMergeFailure(error: unknown): boolean {
     msg.includes('update branch') ||
     msg.includes('must be up to date') ||
     msg.includes('must be up-to-date') ||
-    msg.includes('behind the base branch') ||
-    msg.includes('not mergeable')
+    msg.includes('behind the base branch')
+  );
+}
+
+function isMergeBlockedByBranchProtection(error: unknown): boolean {
+  const msg = getErrorMessage(error).toLowerCase();
+
+  return (
+    msg.includes('at least 1 approving review is required') ||
+    msg.includes('approving review is required') ||
+    msg.includes('required status check') ||
+    msg.includes('is expected') ||
+    msg.includes('protected branch') ||
+    msg.includes('pull request is not mergeable')
   );
 }
 
@@ -2715,6 +2856,47 @@ async function runMergeApprovedPrOrUpdateBranch(
     return;
   }
 
+  if (isPullRequestDirty(currentPr)) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: currentPr.number,
+        mergeableState: readMergeableState(currentPr),
+        reason,
+      },
+      'pull-request has merge conflicts, auto-merge skipped'
+    );
+
+    return;
+  }
+
+  if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
+    await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-before-merge`);
+    return;
+  }
+
+  const hasCurrentHeadAutoApproval = currentHeadSha
+    ? await hasAutoApprovalReviewForHead(context, repoInfo, currentPr.number, currentHeadSha)
+    : false;
+
+  const hasMergeApproval = isSnapshotManagedRequestPr(currentPr) || hasCurrentHeadAutoApproval;
+
+  if (!hasMergeApproval) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: currentPr.number,
+        headSha: currentHeadSha,
+        reason,
+      },
+      'pull-request merge skipped: no current automation approval'
+    );
+
+    return;
+  }
+
   if (currentHeadSha) {
     const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, currentHeadSha);
 
@@ -2736,44 +2918,6 @@ async function runMergeApprovedPrOrUpdateBranch(
     }
   }
 
-  const hasMergeApproval =
-    isSnapshotManagedRequestPr(currentPr) ||
-    (currentHeadSha && (await hasAutoApprovalReviewForHead(context, repoInfo, currentPr.number, currentHeadSha))) ||
-    (await hasApprovedReviewOnPr(context, repoInfo, currentPr.number));
-
-  if (!hasMergeApproval) {
-    log(
-      context,
-      'info',
-      {
-        prNumber: currentPr.number,
-        headSha: currentHeadSha,
-        reason,
-      },
-      'pull-request merge skipped: no current approving review'
-    );
-
-    return;
-  }
-
-  if (isPullRequestDirty(currentPr)) {
-    log(
-      context,
-      'warn',
-      {
-        prNumber: currentPr.number,
-        mergeableState: readMergeableState(currentPr),
-      },
-      'pull-request has merge conflicts, auto-merge skipped'
-    );
-    return;
-  }
-
-  if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
-    await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-before-merge`);
-    return;
-  }
-
   for (let attempt = 1; attempt <= 2; attempt += 1) {
     const beforeHeadSha = toStringTrim(currentPr.head?.sha);
 
@@ -2789,9 +2933,7 @@ async function runMergeApprovedPrOrUpdateBranch(
       const afterMergeAttempt = await readFreshPullRequest(context, repoInfo, currentPr.number);
       if (!afterMergeAttempt) return;
 
-      if (!isPullRequestOpen(afterMergeAttempt)) {
-        return;
-      }
+      if (!isPullRequestOpen(afterMergeAttempt)) return;
 
       const afterHeadSha = toStringTrim(afterMergeAttempt.head?.sha);
 
@@ -2807,21 +2949,13 @@ async function runMergeApprovedPrOrUpdateBranch(
           },
           'pull-request head changed after merge attempt'
         );
+
         return;
       }
 
-      if (merged === true) {
-        return;
-      }
+      if (merged === true) return;
 
       if (merged === false) {
-        const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, afterMergeAttempt, baseBranch);
-
-        if (mustUpdate) {
-          await requestPullRequestBranchUpdate(context, repoInfo, afterMergeAttempt, `${reason}:merge-returned-false`);
-          return;
-        }
-
         log(
           context,
           'info',
@@ -2854,9 +2988,11 @@ async function runMergeApprovedPrOrUpdateBranch(
           {
             prNumber: currentPr.number,
             mergeableState: readMergeableState(currentPr),
+            reason,
           },
           'pull-request has merge conflicts after mergeability refresh'
         );
+
         return;
       }
 
@@ -2883,11 +3019,27 @@ async function runMergeApprovedPrOrUpdateBranch(
 
       return;
     } catch (error: unknown) {
+      if (isMergeBlockedByBranchProtection(error)) {
+        log(
+          context,
+          'info',
+          {
+            prNumber: currentPr.number,
+            headSha: toStringTrim(currentPr.head?.sha),
+            err: getErrorMessage(error),
+            status: getHttpStatus(error),
+            reason,
+          },
+          'pull-request merge blocked by branch protection'
+        );
+
+        return;
+      }
+
       if (shouldTryBranchUpdateAfterMergeFailure(error)) {
         const freshPr = (await readFreshPullRequest(context, repoInfo, currentPr.number)) || currentPr;
-        const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
 
-        if (mustUpdate) {
+        if (await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch)) {
           await requestPullRequestBranchUpdate(context, repoInfo, freshPr, `${reason}:merge-failed-outdated`);
         } else {
           log(
@@ -2996,10 +3148,15 @@ async function processPullRequestForAutoMerge(
   const issueNumber = parseLinkedIssueNumberFromPr(pr);
 
   if (issueNumber === null) {
-    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr);
+    const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+    const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, freshPr, {
+      baseBranch: toStringTrim(freshPr.base?.ref),
+    });
+
     if (standaloneOutcome !== 'approved') return;
 
-    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'auto-merge');
+    const approvedPr = (await readFreshPullRequest(context, repoInfo, freshPr.number)) || freshPr;
+    await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, approvedPr, 'auto-merge');
     return;
   }
 
@@ -3223,13 +3380,97 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
         continue;
       }
 
-      const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha);
+      const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+      const freshHeadSha = toStringTrim(freshPr.head?.sha);
+
+      if (!isPullRequestOpen(freshPr)) {
+        skipped += 1;
+        log(
+          context,
+          'info',
+          {
+            ...baseLog,
+            freshHeadSha,
+            changedRegistryFiles,
+            skipReason: 'pr-not-open',
+          },
+          'direct-pr-reeval:skip'
+        );
+        continue;
+      }
+
+      if (isPullRequestDirty(freshPr)) {
+        skipped += 1;
+        log(
+          context,
+          'warn',
+          {
+            ...baseLog,
+            freshHeadSha,
+            changedRegistryFiles,
+            mergeableState: readMergeableState(freshPr),
+            skipReason: 'pr-has-merge-conflicts',
+          },
+          'direct-pr-reeval:skip'
+        );
+        continue;
+      }
+
+      const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
 
       log(
         context,
         'info',
         {
           ...baseLog,
+          freshHeadSha,
+          changedRegistryFiles,
+          mergeable: freshPr.mergeable,
+          mergeableState: readMergeableState(freshPr),
+          mustUpdate,
+        },
+        'direct-pr-reeval:update-check'
+      );
+
+      if (mustUpdate) {
+        const requested = await requestPullRequestBranchUpdate(
+          context,
+          repoInfo,
+          freshPr,
+          `${reason}:direct-pr-update-before-approval`
+        );
+
+        if (requested) {
+          processed += 1;
+        } else {
+          skipped += 1;
+        }
+
+        log(
+          context,
+          'info',
+          {
+            ...baseLog,
+            freshHeadSha,
+            changedRegistryFiles,
+            requested,
+          },
+          'direct-pr-reeval:update-before-approval-result'
+        );
+
+        continue;
+      }
+
+      const hasCurrentHeadAutoApproval = freshHeadSha
+        ? await hasAutoApprovalReviewForHead(context, repoInfo, freshPr.number, freshHeadSha)
+        : false;
+
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          freshHeadSha,
           changedRegistryFiles,
           hasCurrentHeadAutoApproval,
           hooksSource: context.resourceBotHooksSource,
@@ -3239,7 +3480,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
 
       const approvalOutcome = hasCurrentHeadAutoApproval
         ? 'approved'
-        : await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr, { baseBranch });
+        : await maybeHandleStandaloneDirectPrApproval(context, repoInfo, freshPr, { baseBranch });
 
       if (approvalOutcome === 'rejected') {
         processed += 1;
@@ -3253,6 +3494,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
           'info',
           {
             ...baseLog,
+            freshHeadSha,
             changedRegistryFiles,
             skipReason: 'on-approval-did-not-approve',
           },
@@ -3261,18 +3503,11 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
         continue;
       }
 
-      const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
-      const freshHeadSha = toStringTrim(freshPr.head?.sha);
-      const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+      const approvedPr = (await readFreshPullRequest(context, repoInfo, freshPr.number)) || freshPr;
+      const approvedHeadSha = toStringTrim(approvedPr.head?.sha);
 
-      if (mustUpdate) {
-        processed += 1;
-        await requestPullRequestBranchUpdate(context, repoInfo, freshPr, `${reason}:approved-direct-pr-behind`);
-        continue;
-      }
-
-      const greenResult = freshHeadSha
-        ? await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, freshHeadSha)
+      const greenResult = approvedHeadSha
+        ? await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, approvedHeadSha)
         : {
             green: false,
             reason: 'missing-head-sha',
@@ -3286,6 +3521,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
         {
           ...baseLog,
           freshHeadSha,
+          approvedHeadSha,
           changedRegistryFiles,
           green: greenResult.green,
           greenReason: greenResult.reason,
@@ -3303,7 +3539,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
           'info',
           {
             ...baseLog,
-            freshHeadSha,
+            approvedHeadSha,
             changedRegistryFiles,
             skipReason: 'approved-direct-pr-head-checks-not-green',
             greenReason: greenResult.reason,
@@ -3315,7 +3551,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       }
 
       processed += 1;
-      await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, freshPr, reason);
+      await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, approvedPr, reason);
     } catch (e: unknown) {
       failed += 1;
       log(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2459,8 +2459,15 @@ function updateBranchInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): strin
 }
 
 function isUpdateBranchCooldownActive(key: string): boolean {
-  const until = UPDATE_BRANCH_COOLDOWN_UNTIL.get(key) || 0;
-  return until > Date.now();
+  const until = UPDATE_BRANCH_COOLDOWN_UNTIL.get(key);
+  if (until == null) return false;
+
+  if (until <= Date.now()) {
+    UPDATE_BRANCH_COOLDOWN_UNTIL.delete(key);
+    return false;
+  }
+
+  return true;
 }
 
 function markUpdateBranchCooldown(key: string): void {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -156,6 +156,20 @@ type CheckRunAnnotationLike = {
   raw_details?: string | null;
 };
 
+type GitTreeEntryLike = {
+  path?: string | null;
+  type?: string | null;
+  sha?: string | null;
+};
+
+type GitTreeLike = {
+  tree?: GitTreeEntryLike[];
+};
+
+type DirectPrApprovalOptions = {
+  baseBranch?: string;
+};
+
 type HeadGreenRunSummary = {
   id?: number;
   name: string;
@@ -2016,6 +2030,26 @@ async function addApprovedLabelToPr(
   }
 }
 
+async function ensureAutomatedApprovalReviewForCurrentHead(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  decision: ApprovalDecision
+): Promise<boolean> {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return false;
+
+  if (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha)) {
+    return true;
+  }
+
+  const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
+  if (!approved) return false;
+
+  await addApprovedLabelToPr(context, repoInfo, pr.number);
+  return true;
+}
+
 const AUTO_APPROVAL_REVIEW_MARKER_PREFIX = 'nsreq:auto-approval:';
 
 function buildAutoApprovalReviewMarker(headSha: string): string {
@@ -2125,27 +2159,6 @@ async function hasApprovedReviewOnPr(
   }
 }
 
-async function hasApprovedLabelOnPr(
-  context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo,
-  prNumber: number
-): Promise<boolean> {
-  const eff = resolveEffectiveConstants(context);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
-
-  try {
-    const labels = await fetchIssueLabels(context, {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      issue_number: prNumber,
-    });
-
-    return labelsMatching(labels, approvedLabel).length > 0;
-  } catch {
-    return false;
-  }
-}
-
 async function isPullRequestApprovedForBranchMaintenance(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -2155,16 +2168,11 @@ async function isPullRequestApprovedForBranchMaintenance(
     return false;
   }
 
-  // Bot-created request PRs are only created after issue approval.
   if (isSnapshotManagedRequestPr(pr)) return true;
 
   const headSha = toStringTrim(pr.head?.sha);
 
   if (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) {
-    return true;
-  }
-
-  if (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) {
     return true;
   }
 
@@ -2377,6 +2385,12 @@ async function evaluateHeadGreenForApprovalReevaluation(
       blockingRuns: [],
     };
   }
+}
+
+const MERGE_INFLIGHT = new Map<string, Promise<void>>();
+
+function mergeInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): string {
+  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}`;
 }
 
 const UPDATE_BRANCH_INFLIGHT = new Map<string, Promise<boolean>>();
@@ -2654,9 +2668,93 @@ async function tryMergeApprovedPrOrUpdateBranch(
   pr: PullRequestLike,
   reason: string
 ): Promise<void> {
+  const key = mergeInflightKey(repoInfo, pr);
+  const existing = MERGE_INFLIGHT.get(key);
+
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const pending = runMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, reason).finally(() => {
+    MERGE_INFLIGHT.delete(key);
+  });
+
+  MERGE_INFLIGHT.set(key, pending);
+  await pending;
+}
+
+async function runMergeApprovedPrOrUpdateBranch(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<void> {
+  const originalHeadSha = toStringTrim(pr.head?.sha);
+  const baseBranch = toStringTrim(pr.base?.ref);
+
   let currentPr = await waitForPullRequestMergeability(context, repoInfo, pr, `${reason}:before-merge`);
 
   if (!isPullRequestOpen(currentPr)) return;
+
+  const currentHeadSha = toStringTrim(currentPr.head?.sha);
+
+  if (originalHeadSha && currentHeadSha && originalHeadSha !== currentHeadSha) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: currentPr.number,
+        originalHeadSha,
+        currentHeadSha,
+        reason,
+      },
+      'pull-request head changed before merge, waiting for new CI'
+    );
+
+    return;
+  }
+
+  if (currentHeadSha) {
+    const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, currentHeadSha);
+
+    if (!greenResult.green) {
+      log(
+        context,
+        'info',
+        {
+          prNumber: currentPr.number,
+          headSha: currentHeadSha,
+          greenReason: greenResult.reason,
+          blockingRuns: greenResult.blockingRuns,
+          reason,
+        },
+        'pull-request merge skipped: current head checks are not green'
+      );
+
+      return;
+    }
+  }
+
+  const hasMergeApproval =
+    isSnapshotManagedRequestPr(currentPr) ||
+    (currentHeadSha && (await hasAutoApprovalReviewForHead(context, repoInfo, currentPr.number, currentHeadSha))) ||
+    (await hasApprovedReviewOnPr(context, repoInfo, currentPr.number));
+
+  if (!hasMergeApproval) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: currentPr.number,
+        headSha: currentHeadSha,
+        reason,
+      },
+      'pull-request merge skipped: no current approving review'
+    );
+
+    return;
+  }
 
   if (isPullRequestDirty(currentPr)) {
     log(
@@ -2671,7 +2769,7 @@ async function tryMergeApprovedPrOrUpdateBranch(
     return;
   }
 
-  if (isPullRequestBehindBase(currentPr)) {
+  if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
     await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-before-merge`);
     return;
   }
@@ -2697,8 +2795,6 @@ async function tryMergeApprovedPrOrUpdateBranch(
 
       const afterHeadSha = toStringTrim(afterMergeAttempt.head?.sha);
 
-      // updateBranch or another actor changed the PR head.
-      // Do not immediately merge; wait for new CI.
       if (beforeHeadSha && afterHeadSha && beforeHeadSha !== afterHeadSha) {
         log(
           context,
@@ -2719,7 +2815,26 @@ async function tryMergeApprovedPrOrUpdateBranch(
       }
 
       if (merged === false) {
-        await requestPullRequestBranchUpdate(context, repoInfo, afterMergeAttempt, `${reason}:merge-returned-false`);
+        const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, afterMergeAttempt, baseBranch);
+
+        if (mustUpdate) {
+          await requestPullRequestBranchUpdate(context, repoInfo, afterMergeAttempt, `${reason}:merge-returned-false`);
+          return;
+        }
+
+        log(
+          context,
+          'info',
+          {
+            prNumber: afterMergeAttempt.number,
+            headSha: toStringTrim(afterMergeAttempt.head?.sha),
+            mergeable: afterMergeAttempt.mergeable,
+            mergeableState: readMergeableState(afterMergeAttempt),
+            reason,
+          },
+          'pull-request merge returned false, branch update not requested'
+        );
+
         return;
       }
 
@@ -2745,12 +2860,11 @@ async function tryMergeApprovedPrOrUpdateBranch(
         return;
       }
 
-      if (isPullRequestBehindBase(currentPr)) {
+      if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
         await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-after-merge-attempt`);
         return;
       }
 
-      // GitHub was still calculating mergeability. Retry once.
       if (attempt < 2 && isMergeabilityPending(currentPr)) {
         continue;
       }
@@ -2770,7 +2884,28 @@ async function tryMergeApprovedPrOrUpdateBranch(
       return;
     } catch (error: unknown) {
       if (shouldTryBranchUpdateAfterMergeFailure(error)) {
-        await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:merge-failed-outdated`);
+        const freshPr = (await readFreshPullRequest(context, repoInfo, currentPr.number)) || currentPr;
+        const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+
+        if (mustUpdate) {
+          await requestPullRequestBranchUpdate(context, repoInfo, freshPr, `${reason}:merge-failed-outdated`);
+        } else {
+          log(
+            context,
+            'info',
+            {
+              prNumber: freshPr.number,
+              headSha: toStringTrim(freshPr.head?.sha),
+              mergeable: freshPr.mergeable,
+              mergeableState: readMergeableState(freshPr),
+              err: getErrorMessage(error),
+              status: getHttpStatus(error),
+              reason,
+            },
+            'pull-request merge failed, branch update not requested'
+          );
+        }
+
         return;
       }
 
@@ -3075,7 +3210,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
     }
 
     try {
-      const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+      const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
 
       if (!changedRegistryFiles.length) {
         skipped += 1;
@@ -3083,40 +3218,6 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
           context,
           'info',
           { ...baseLog, changedRegistryFiles, skipReason: 'no-registry-yaml-files-changed' },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
-
-      log(
-        context,
-        'info',
-        {
-          ...baseLog,
-          changedRegistryFiles,
-          green: greenResult.green,
-          greenReason: greenResult.reason,
-          statusState: greenResult.statusState,
-          blockingRuns: greenResult.blockingRuns,
-          latestRuns: greenResult.latestRuns.slice(0, 30),
-        },
-        'direct-pr-reeval:head-green'
-      );
-
-      if (!greenResult.green) {
-        skipped += 1;
-        log(
-          context,
-          'info',
-          {
-            ...baseLog,
-            changedRegistryFiles,
-            skipReason: 'pr-head-checks-not-green',
-            greenReason: greenResult.reason,
-            blockingRuns: greenResult.blockingRuns,
-          },
           'direct-pr-reeval:skip'
         );
         continue;
@@ -3136,14 +3237,85 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
         'direct-pr-reeval:candidate'
       );
 
-      if (hasCurrentHeadAutoApproval) {
+      const approvalOutcome = hasCurrentHeadAutoApproval
+        ? 'approved'
+        : await maybeHandleStandaloneDirectPrApproval(context, repoInfo, pr, { baseBranch });
+
+      if (approvalOutcome === 'rejected') {
         processed += 1;
-        await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, reason);
+        continue;
+      }
+
+      if (approvalOutcome !== 'approved') {
+        skipped += 1;
+        log(
+          context,
+          'info',
+          {
+            ...baseLog,
+            changedRegistryFiles,
+            skipReason: 'on-approval-did-not-approve',
+          },
+          'direct-pr-reeval:skip'
+        );
+        continue;
+      }
+
+      const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+      const freshHeadSha = toStringTrim(freshPr.head?.sha);
+      const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+
+      if (mustUpdate) {
+        processed += 1;
+        await requestPullRequestBranchUpdate(context, repoInfo, freshPr, `${reason}:approved-direct-pr-behind`);
+        continue;
+      }
+
+      const greenResult = freshHeadSha
+        ? await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, freshHeadSha)
+        : {
+            green: false,
+            reason: 'missing-head-sha',
+            latestRuns: [],
+            blockingRuns: [],
+          };
+
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          freshHeadSha,
+          changedRegistryFiles,
+          green: greenResult.green,
+          greenReason: greenResult.reason,
+          statusState: greenResult.statusState,
+          blockingRuns: greenResult.blockingRuns,
+          latestRuns: greenResult.latestRuns.slice(0, 30),
+        },
+        'direct-pr-reeval:head-green'
+      );
+
+      if (!greenResult.green) {
+        skipped += 1;
+        log(
+          context,
+          'info',
+          {
+            ...baseLog,
+            freshHeadSha,
+            changedRegistryFiles,
+            skipReason: 'approved-direct-pr-head-checks-not-green',
+            greenReason: greenResult.reason,
+            blockingRuns: greenResult.blockingRuns,
+          },
+          'direct-pr-reeval:skip'
+        );
         continue;
       }
 
       processed += 1;
-      await processPullRequestForAutoMerge(context, repoInfo, pr);
+      await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, freshPr, reason);
     } catch (e: unknown) {
       failed += 1;
       log(
@@ -3241,7 +3413,7 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
     }
 
     try {
-      const changedRegistryFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+      const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
 
       if (!changedRegistryFiles.length) {
         if (DBG) {
@@ -3281,20 +3453,20 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
         continue;
       }
 
-      if (!isPullRequestBehindBase(freshPr)) {
-        if (DBG) {
-          log(
-            context,
-            'debug',
-            {
-              prNumber: freshPr.number,
-              mergeable: freshPr.mergeable,
-              mergeableState: readMergeableState(freshPr),
-              reason,
-            },
-            'skip branch update: PR is not behind base'
-          );
-        }
+      const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+
+      if (!mustUpdate) {
+        log(
+          context,
+          'info',
+          {
+            prNumber: freshPr.number,
+            mergeable: freshPr.mergeable,
+            mergeableState: readMergeableState(freshPr),
+            reason,
+          },
+          'skip branch update: PR is not behind current base'
+        );
         continue;
       }
 
@@ -3548,6 +3720,237 @@ async function listChangedYamlFilesForPr(
   return Array.from(new Set(out));
 }
 
+async function readBranchHeadSha(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  branchName: string
+): Promise<string> {
+  const branch = toStringTrim(branchName);
+  if (!branch) return '';
+
+  try {
+    const res = await context.octokit.repos.getBranch({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      branch,
+    });
+
+    return toStringTrim((res as unknown as { data?: { commit?: { sha?: string | null } } })?.data?.commit?.sha);
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        branch,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'branch-head-sha:read-failed'
+    );
+
+    return '';
+  }
+}
+
+async function readRecursiveGitTreeEntries(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  ref: string
+): Promise<GitTreeEntryLike[]> {
+  const treeSha = toStringTrim(ref);
+  if (!treeSha) return [];
+
+  try {
+    const res = await (
+      context.octokit.git as unknown as {
+        getTree: (args: {
+          owner: string;
+          repo: string;
+          tree_sha: string;
+          recursive?: 'true';
+        }) => Promise<{ data?: GitTreeLike }>;
+      }
+    ).getTree({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      tree_sha: treeSha,
+      recursive: 'true',
+    });
+
+    return Array.isArray(res?.data?.tree) ? res.data.tree : [];
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        ref: treeSha,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'git-tree:read-failed'
+    );
+
+    return [];
+  }
+}
+
+function registryYamlTreeEntryPath(context: BotContext<RequestEvents>, entry: GitTreeEntryLike): string {
+  const path = normalizeRepoPath(entry?.path);
+  const type = toStringTrim(entry?.type).toLowerCase();
+
+  if (type !== 'blob') return '';
+  if (!path || !isYamlPath(path)) return '';
+  if (!isRegistryEntryPath(context, path)) return '';
+
+  return path;
+}
+
+async function listChangedYamlFilesForPrAgainstCurrentBase(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch: string
+): Promise<string[]> {
+  const headSha = toStringTrim(pr.head?.sha);
+  const baseRef = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
+
+  if (!headSha || !baseRef) return [];
+
+  const baseSha = await readBranchHeadSha(context, repoInfo, baseRef);
+  if (!baseSha) return [];
+
+  const [baseEntries, headEntries] = await Promise.all([
+    readRecursiveGitTreeEntries(context, repoInfo, baseSha),
+    readRecursiveGitTreeEntries(context, repoInfo, headSha),
+  ]);
+
+  const baseByPath = new Map<string, string>();
+
+  for (const entry of baseEntries) {
+    const path = registryYamlTreeEntryPath(context, entry);
+    if (!path) continue;
+
+    const sha = toStringTrim(entry.sha);
+    if (sha) baseByPath.set(path, sha);
+  }
+
+  const changed: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of headEntries) {
+    const path = registryYamlTreeEntryPath(context, entry);
+    if (!path || seen.has(path)) continue;
+
+    const headEntrySha = toStringTrim(entry.sha);
+    const baseEntrySha = baseByPath.get(path) || '';
+
+    if (!headEntrySha) continue;
+    if (baseEntrySha && baseEntrySha === headEntrySha) continue;
+
+    seen.add(path);
+    changed.push(path);
+  }
+
+  return changed;
+}
+
+async function listChangedYamlFilesForPrWithFallback(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch?: string
+): Promise<string[]> {
+  const fromPullFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+  if (fromPullFiles.length) return fromPullFiles;
+
+  const fallbackBaseBranch = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
+  if (!fallbackBaseBranch) return [];
+
+  const fromTreeDiff = await listChangedYamlFilesForPrAgainstCurrentBase(context, repoInfo, pr, fallbackBaseBranch);
+
+  if (fromTreeDiff.length) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        baseBranch: fallbackBaseBranch,
+        changedRegistryFiles: fromTreeDiff,
+      },
+      'changed-registry-files:fallback-tree-diff'
+    );
+  }
+
+  return fromTreeDiff;
+}
+
+async function isPullRequestBehindCurrentBase(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch: string
+): Promise<boolean> {
+  const headSha = toStringTrim(pr.head?.sha);
+  const baseRef = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
+
+  if (!headSha || !baseRef) return false;
+
+  const baseHeadSha = await readBranchHeadSha(context, repoInfo, baseRef);
+  if (!baseHeadSha || baseHeadSha === headSha) return false;
+
+  try {
+    const res = await (
+      context.octokit.repos as unknown as {
+        compareCommitsWithBasehead: (args: {
+          owner: string;
+          repo: string;
+          basehead: string;
+        }) => Promise<{ data?: { status?: string | null; ahead_by?: number | null } }>;
+      }
+    ).compareCommitsWithBasehead({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      basehead: `${headSha}...${baseHeadSha}`,
+    });
+
+    const status = toStringTrim(res?.data?.status).toLowerCase();
+    const aheadBy = typeof res?.data?.ahead_by === 'number' ? res.data.ahead_by : 0;
+
+    return status === 'ahead' || status === 'diverged' || aheadBy > 0;
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        headSha,
+        baseBranch: baseRef,
+        baseHeadSha,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'pull-request behind-current-base check failed'
+    );
+
+    return isPullRequestBehindBase(pr);
+  }
+}
+
+async function shouldUpdatePullRequestBranch(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch: string
+): Promise<boolean> {
+  if (isPullRequestBehindBase(pr)) return true;
+  return await isPullRequestBehindCurrentBase(context, repoInfo, pr, baseBranch);
+}
+
 async function readRepoFileTextAtRef(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -3636,9 +4039,10 @@ async function evaluateDirectPrOnApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   pr: PullRequestLike,
-  requestAuthorIdOverride?: string
+  requestAuthorIdOverride?: string,
+  options: DirectPrApprovalOptions = {}
 ): Promise<ApprovalDecision> {
-  const changedFiles = await listChangedYamlFilesForPr(context, repoInfo, pr.number);
+  const changedFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, options.baseBranch);
 
   const fallbackRequestAuthorId = requestAuthorIdOverride
     ? ''
@@ -3661,7 +4065,20 @@ async function evaluateDirectPrOnApproval(
     'direct-pr:on-approval:start'
   );
 
-  if (!changedFiles.length) return {};
+  if (!changedFiles.length) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        headRef: toStringTrim(pr.head?.ref),
+      },
+      'direct-pr:on-approval:skip-no-registry-files'
+    );
+
+    return {};
+  }
 
   let sawApproved = false;
   let sawUnknown = false;
@@ -3711,24 +4128,14 @@ async function evaluateDirectPrOnApproval(
 async function maybeHandleStandaloneDirectPrApproval(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
-  pr: PullRequestLike
+  pr: PullRequestLike,
+  options: DirectPrApprovalOptions = {}
 ): Promise<ApprovalHandlingResult> {
-  const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr);
+  const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr, undefined, options);
 
   if (decision.status === 'approved') {
-    const headSha = toStringTrim(pr.head?.sha);
-
-    const alreadyApproved =
-      (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) ||
-      (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
-      (await hasApprovedReviewOnPr(context, repoInfo, pr.number));
-
-    if (!alreadyApproved) {
-      const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
-      if (!approved) return 'continue';
-
-      await addApprovedLabelToPr(context, repoInfo, pr.number);
-    }
+    const approved = await ensureAutomatedApprovalReviewForCurrentHead(context, repoInfo, pr, decision);
+    if (!approved) return 'continue';
 
     return 'approved';
   }
@@ -3969,19 +4376,8 @@ async function maybeHandleDirectPrApprovalForMerge(
   );
 
   if (decision.status === 'approved') {
-    const headSha = toStringTrim(pr.head?.sha);
-
-    const alreadyApproved =
-      (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) ||
-      (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) ||
-      (await hasApprovedReviewOnPr(context, repoInfo, pr.number));
-
-    if (!alreadyApproved) {
-      const approved = await createAutomatedApprovalReview(context, repoInfo, pr, decision);
-      if (!approved) return 'continue';
-
-      await addApprovedLabelToPr(context, repoInfo, pr.number);
-    }
+    const approved = await ensureAutomatedApprovalReviewForCurrentHead(context, repoInfo, pr, decision);
+    if (!approved) return 'continue';
 
     await applyApprovedRequestState(context, issueParams, resolveEffectiveConstants(context));
     return 'approved';

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2424,6 +2424,34 @@ const DEFAULT_BRANCH_UPDATE_RETRY_DELAY_MS = 5000;
 const UPDATE_BRANCH_RETRY_DELAY_MS = 2000;
 const UPDATE_BRANCH_COOLDOWN_MS = 15000;
 
+type SequentialRegistryPrResult = {
+  updated: boolean;
+  processed: boolean;
+  blockedByActive: boolean;
+};
+
+type SequentialRegistryPrCandidate = {
+  pr: PullRequestLike;
+  freshPr: PullRequestLike;
+  changedRegistryFiles: string[];
+  mustUpdate: boolean;
+};
+
+type SequentialRegistryPrActive = {
+  prNumber: number;
+  startedHeadSha: string;
+  startedAt: number;
+  expiresAt: number;
+  reason: string;
+};
+
+const SEQUENTIAL_REGISTRY_PR_QUEUE_INFLIGHT = new Map<string, Promise<SequentialRegistryPrResult>>();
+const SEQUENTIAL_REGISTRY_PR_ACTIVE = new Map<string, SequentialRegistryPrActive>();
+const SEQUENTIAL_REGISTRY_PR_SKIPPED_HEADS = new Map<string, number>();
+
+const SEQUENTIAL_REGISTRY_PR_ACTIVE_TTL_MS = 30 * 60 * 1000;
+const SEQUENTIAL_REGISTRY_PR_SKIP_TTL_MS = 6 * 60 * 60 * 1000;
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -3336,9 +3364,7 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
   repoInfo: RepoInfo,
   baseBranch: string,
   reason = 'default-branch-push:direct-pr-reevaluation'
-): Promise<void> {
-  const openPrs = await listOpenPullRequests(context, repoInfo);
-
+): Promise<SequentialRegistryPrResult> {
   log(
     context,
     'info',
@@ -3347,253 +3373,12 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       repo: repoInfo.repo,
       baseBranch,
       reason,
-      openPrCount: openPrs.length,
       hooksSource: context.resourceBotHooksSource,
     },
     'direct-pr-reeval:start'
   );
 
-  let processed = 0;
-  let skipped = 0;
-  let failed = 0;
-
-  for (const pr of openPrs) {
-    const headSha = toStringTrim(pr.head?.sha);
-    const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
-    const snapshotManaged = isSnapshotManagedRequestPr(pr);
-
-    const baseLog = {
-      owner: repoInfo.owner,
-      repo: repoInfo.repo,
-      prNumber: pr.number,
-      title: toStringTrim(pr.title),
-      headSha,
-      headRef: toStringTrim(pr.head?.ref),
-      prBase: toStringTrim(pr.base?.ref),
-      baseBranch,
-      linkedIssueNumber,
-      snapshotManaged,
-      reason,
-    };
-
-    if (snapshotManaged) {
-      skipped += 1;
-      log(context, 'info', { ...baseLog, skipReason: 'snapshot-managed-request-pr' }, 'direct-pr-reeval:skip');
-      continue;
-    }
-
-    if (!headSha) {
-      skipped += 1;
-      log(context, 'info', { ...baseLog, skipReason: 'missing-head-sha' }, 'direct-pr-reeval:skip');
-      continue;
-    }
-
-    if (!pullRequestTargetsBranch(pr, baseBranch)) {
-      skipped += 1;
-      log(context, 'info', { ...baseLog, skipReason: 'different-base-branch' }, 'direct-pr-reeval:skip');
-      continue;
-    }
-
-    try {
-      const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
-
-      if (!changedRegistryFiles.length) {
-        skipped += 1;
-        log(
-          context,
-          'info',
-          { ...baseLog, changedRegistryFiles, skipReason: 'no-registry-yaml-files-changed' },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
-      const freshHeadSha = toStringTrim(freshPr.head?.sha);
-
-      if (!isPullRequestOpen(freshPr)) {
-        skipped += 1;
-        log(
-          context,
-          'info',
-          {
-            ...baseLog,
-            freshHeadSha,
-            changedRegistryFiles,
-            skipReason: 'pr-not-open',
-          },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      if (isPullRequestDirty(freshPr)) {
-        skipped += 1;
-        log(
-          context,
-          'warn',
-          {
-            ...baseLog,
-            freshHeadSha,
-            changedRegistryFiles,
-            mergeableState: readMergeableState(freshPr),
-            skipReason: 'pr-has-merge-conflicts',
-          },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
-
-      log(
-        context,
-        'info',
-        {
-          ...baseLog,
-          freshHeadSha,
-          changedRegistryFiles,
-          mergeable: freshPr.mergeable,
-          mergeableState: readMergeableState(freshPr),
-          mustUpdate,
-        },
-        'direct-pr-reeval:update-check'
-      );
-
-      if (mustUpdate) {
-        const requested = await requestPullRequestBranchUpdate(
-          context,
-          repoInfo,
-          freshPr,
-          `${reason}:direct-pr-update-before-approval`
-        );
-
-        if (requested) {
-          processed += 1;
-        } else {
-          skipped += 1;
-        }
-
-        log(
-          context,
-          'info',
-          {
-            ...baseLog,
-            freshHeadSha,
-            changedRegistryFiles,
-            requested,
-          },
-          'direct-pr-reeval:update-before-approval-result'
-        );
-
-        continue;
-      }
-
-      const hasCurrentHeadAutoApproval = freshHeadSha
-        ? await hasAutoApprovalReviewForHead(context, repoInfo, freshPr.number, freshHeadSha)
-        : false;
-
-      log(
-        context,
-        'info',
-        {
-          ...baseLog,
-          freshHeadSha,
-          changedRegistryFiles,
-          hasCurrentHeadAutoApproval,
-          hooksSource: context.resourceBotHooksSource,
-        },
-        'direct-pr-reeval:candidate'
-      );
-
-      const approvalOutcome = hasCurrentHeadAutoApproval
-        ? 'approved'
-        : await maybeHandleStandaloneDirectPrApproval(context, repoInfo, freshPr, { baseBranch });
-
-      if (approvalOutcome === 'rejected') {
-        processed += 1;
-        continue;
-      }
-
-      if (approvalOutcome !== 'approved') {
-        skipped += 1;
-        log(
-          context,
-          'info',
-          {
-            ...baseLog,
-            freshHeadSha,
-            changedRegistryFiles,
-            skipReason: 'on-approval-did-not-approve',
-          },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      const approvedPr = (await readFreshPullRequest(context, repoInfo, freshPr.number)) || freshPr;
-      const approvedHeadSha = toStringTrim(approvedPr.head?.sha);
-
-      const greenResult = approvedHeadSha
-        ? await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, approvedHeadSha)
-        : {
-            green: false,
-            reason: 'missing-head-sha',
-            latestRuns: [],
-            blockingRuns: [],
-          };
-
-      log(
-        context,
-        'info',
-        {
-          ...baseLog,
-          freshHeadSha,
-          approvedHeadSha,
-          changedRegistryFiles,
-          green: greenResult.green,
-          greenReason: greenResult.reason,
-          statusState: greenResult.statusState,
-          blockingRuns: greenResult.blockingRuns,
-          latestRuns: greenResult.latestRuns.slice(0, 30),
-        },
-        'direct-pr-reeval:head-green'
-      );
-
-      if (!greenResult.green) {
-        skipped += 1;
-        log(
-          context,
-          'info',
-          {
-            ...baseLog,
-            approvedHeadSha,
-            changedRegistryFiles,
-            skipReason: 'approved-direct-pr-head-checks-not-green',
-            greenReason: greenResult.reason,
-            blockingRuns: greenResult.blockingRuns,
-          },
-          'direct-pr-reeval:skip'
-        );
-        continue;
-      }
-
-      processed += 1;
-      await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, approvedPr, reason);
-    } catch (e: unknown) {
-      failed += 1;
-      log(
-        context,
-        'warn',
-        {
-          ...baseLog,
-          err: e instanceof Error ? e.message : String(e),
-          status: getHttpStatus(e),
-        },
-        'direct-pr-reeval:failed'
-      );
-    }
-  }
+  const result = await runOneSequentialDirectRegistryPrMaintenance(context, repoInfo, baseBranch, reason);
 
   log(
     context,
@@ -3603,13 +3388,12 @@ async function reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       repo: repoInfo.repo,
       baseBranch,
       reason,
-      openPrCount: openPrs.length,
-      processed,
-      skipped,
-      failed,
+      ...result,
     },
     'direct-pr-reeval:done'
   );
+
+  return result;
 }
 
 function isDefaultBranchPush(payload: unknown): boolean {
@@ -3646,62 +3430,37 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
   repoInfo: RepoInfo,
   baseBranch: string,
   reason = 'default-branch-push'
-): Promise<void> {
+): Promise<boolean> {
+  if (await isSequentialRegistryPrActiveBlocking(context, repoInfo)) {
+    return false;
+  }
+
   const openPrs = await listOpenPullRequests(context, repoInfo);
 
-  for (const pr of openPrs) {
+  for (const pr of openPrs.sort((a, b) => a.number - b.number)) {
     const headSha = toStringTrim(pr.head?.sha);
 
-    if (!headSha) {
-      if (DBG) {
-        log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: missing head sha');
-      }
-      continue;
-    }
-
-    if (!pullRequestTargetsBranch(pr, baseBranch)) {
-      if (DBG) {
-        log(
-          context,
-          'debug',
-          {
-            prNumber: pr.number,
-            prBase: toStringTrim(pr.base?.ref),
-            baseBranch,
-            reason,
-          },
-          'skip branch update: different base branch'
-        );
-      }
-      continue;
-    }
+    if (!headSha) continue;
+    if (!pullRequestTargetsBranch(pr, baseBranch)) continue;
+    if (isSequentialRegistryPrHeadSkipped(repoInfo, pr)) continue;
 
     try {
       const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
 
       if (!changedRegistryFiles.length) {
-        if (DBG) {
-          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: no registry yaml files changed');
-        }
+        log(context, 'info', { prNumber: pr.number, reason }, 'skip branch update: no registry yaml files changed');
         continue;
       }
 
       const approved = await isPullRequestApprovedForBranchMaintenance(context, repoInfo, pr);
       if (!approved) {
-        if (DBG) {
-          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: PR is not approved');
-        }
+        log(context, 'info', { prNumber: pr.number, reason }, 'skip branch update: PR is not approved');
         continue;
       }
 
       const freshPr = await waitForPullRequestMergeability(context, repoInfo, pr, `${reason}:before-update-branch`);
 
-      if (!isPullRequestOpen(freshPr)) {
-        if (DBG) {
-          log(context, 'debug', { prNumber: pr.number, reason }, 'skip branch update: PR is not open');
-        }
-        continue;
-      }
+      if (!isPullRequestOpen(freshPr)) continue;
 
       if (isPullRequestDirty(freshPr)) {
         log(
@@ -3734,7 +3493,14 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
         continue;
       }
 
-      await requestPullRequestBranchUpdate(context, repoInfo, freshPr, reason);
+      const requested = await requestPullRequestBranchUpdate(context, repoInfo, freshPr, reason);
+
+      if (requested) {
+        markSequentialRegistryPrActive(context, repoInfo, freshPr, reason);
+        return true;
+      }
+
+      markSequentialRegistryPrHeadSkipped(context, repoInfo, freshPr, 'approved-branch-update-request-failed');
     } catch (error: unknown) {
       log(
         context,
@@ -3746,21 +3512,27 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
         },
         'failed to update approved pull request branch after default branch push'
       );
+
+      markSequentialRegistryPrHeadSkipped(context, repoInfo, pr, 'approved-branch-update-exception');
     }
   }
+
+  return false;
 }
 
 async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
   baseBranch: string
-): Promise<void> {
-  await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
+): Promise<boolean> {
+  const requested = await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
     context,
     repoInfo,
     baseBranch,
     'default-branch-push'
   );
+
+  if (requested) return true;
 
   const retryTimer = setTimeout(() => {
     void updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
@@ -3786,6 +3558,8 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRe
   if (retryTimer && typeof (retryTimer as { unref?: () => void }).unref === 'function') {
     retryTimer.unref();
   }
+
+  return false;
 }
 
 function normalizeRepoPath(path: unknown): string {
@@ -4421,6 +4195,460 @@ async function shouldUpdatePullRequestBranch(
 ): Promise<boolean> {
   if (isPullRequestBehindBase(pr)) return true;
   return await isPullRequestBehindCurrentBase(context, repoInfo, pr, baseBranch);
+}
+
+function sequentialRegistryPrRepoKey(repoInfo: RepoInfo): string {
+  return `${repoInfo.owner}/${repoInfo.repo}`.toLowerCase();
+}
+
+function sequentialRegistryPrHeadKey(repoInfo: RepoInfo, prNumber: number, headSha: string): string {
+  return `${sequentialRegistryPrRepoKey(repoInfo)}#${prNumber}:${toStringTrim(headSha)}`;
+}
+
+function pruneSequentialRegistryPrSkipState(): void {
+  const now = Date.now();
+
+  for (const [key, until] of SEQUENTIAL_REGISTRY_PR_SKIPPED_HEADS.entries()) {
+    if (until <= now) SEQUENTIAL_REGISTRY_PR_SKIPPED_HEADS.delete(key);
+  }
+}
+
+function isSequentialRegistryPrHeadSkipped(repoInfo: RepoInfo, pr: PullRequestLike): boolean {
+  pruneSequentialRegistryPrSkipState();
+
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return false;
+
+  const key = sequentialRegistryPrHeadKey(repoInfo, pr.number, headSha);
+  return (SEQUENTIAL_REGISTRY_PR_SKIPPED_HEADS.get(key) || 0) > Date.now();
+}
+
+function markSequentialRegistryPrHeadSkipped(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): void {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return;
+
+  const key = sequentialRegistryPrHeadKey(repoInfo, pr.number, headSha);
+  SEQUENTIAL_REGISTRY_PR_SKIPPED_HEADS.set(key, Date.now() + SEQUENTIAL_REGISTRY_PR_SKIP_TTL_MS);
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      headSha,
+      reason,
+    },
+    'sequential-registry-pr:head-skipped'
+  );
+}
+
+function getSequentialRegistryPrActive(repoInfo: RepoInfo): SequentialRegistryPrActive | null {
+  return SEQUENTIAL_REGISTRY_PR_ACTIVE.get(sequentialRegistryPrRepoKey(repoInfo)) || null;
+}
+
+function clearSequentialRegistryPrActive(repoInfo: RepoInfo): void {
+  SEQUENTIAL_REGISTRY_PR_ACTIVE.delete(sequentialRegistryPrRepoKey(repoInfo));
+}
+
+function markSequentialRegistryPrActive(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): void {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return;
+
+  const active: SequentialRegistryPrActive = {
+    prNumber: pr.number,
+    startedHeadSha: headSha,
+    startedAt: Date.now(),
+    expiresAt: Date.now() + SEQUENTIAL_REGISTRY_PR_ACTIVE_TTL_MS,
+    reason,
+  };
+
+  SEQUENTIAL_REGISTRY_PR_ACTIVE.set(sequentialRegistryPrRepoKey(repoInfo), active);
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      headSha,
+      reason,
+      expiresAt: new Date(active.expiresAt).toISOString(),
+    },
+    'sequential-registry-pr:active-set'
+  );
+}
+
+async function isSequentialRegistryPrActiveBlocking(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo
+): Promise<boolean> {
+  const active = getSequentialRegistryPrActive(repoInfo);
+  if (!active) return false;
+
+  if (active.expiresAt <= Date.now()) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: active.prNumber,
+        startedHeadSha: active.startedHeadSha,
+        reason: active.reason,
+      },
+      'sequential-registry-pr:active-expired'
+    );
+
+    clearSequentialRegistryPrActive(repoInfo);
+    return false;
+  }
+
+  const freshPr = await readFreshPullRequest(context, repoInfo, active.prNumber);
+
+  if (!freshPr || !isPullRequestOpen(freshPr)) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: active.prNumber,
+        startedHeadSha: active.startedHeadSha,
+        freshHeadSha: toStringTrim(freshPr?.head?.sha),
+        reason: active.reason,
+      },
+      'sequential-registry-pr:active-cleared-closed'
+    );
+
+    clearSequentialRegistryPrActive(repoInfo);
+    return false;
+  }
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: active.prNumber,
+      startedHeadSha: active.startedHeadSha,
+      currentHeadSha: toStringTrim(freshPr.head?.sha),
+      reason: active.reason,
+    },
+    'sequential-registry-pr:active-blocking'
+  );
+
+  return true;
+}
+
+async function collectSequentialDirectRegistryPrCandidates(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  baseBranch: string,
+  reason: string
+): Promise<SequentialRegistryPrCandidate[]> {
+  const openPrs = await listOpenPullRequests(context, repoInfo);
+  const candidates: SequentialRegistryPrCandidate[] = [];
+
+  for (const pr of openPrs.sort((a, b) => a.number - b.number)) {
+    const headSha = toStringTrim(pr.head?.sha);
+    const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
+    const snapshotManaged = isSnapshotManagedRequestPr(pr);
+
+    const baseLog = {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      prNumber: pr.number,
+      title: toStringTrim(pr.title),
+      headSha,
+      headRef: toStringTrim(pr.head?.ref),
+      prBase: toStringTrim(pr.base?.ref),
+      baseBranch,
+      linkedIssueNumber,
+      snapshotManaged,
+      reason,
+    };
+
+    if (snapshotManaged) {
+      log(context, 'info', { ...baseLog, skipReason: 'snapshot-managed-request-pr' }, 'direct-pr-reeval:skip');
+      continue;
+    }
+
+    if (!headSha) {
+      log(context, 'info', { ...baseLog, skipReason: 'missing-head-sha' }, 'direct-pr-reeval:skip');
+      continue;
+    }
+
+    if (!pullRequestTargetsBranch(pr, baseBranch)) {
+      log(context, 'info', { ...baseLog, skipReason: 'different-base-branch' }, 'direct-pr-reeval:skip');
+      continue;
+    }
+
+    if (isSequentialRegistryPrHeadSkipped(repoInfo, pr)) {
+      log(context, 'info', { ...baseLog, skipReason: 'head-temporarily-skipped' }, 'direct-pr-reeval:skip');
+      continue;
+    }
+
+    const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
+
+    if (!changedRegistryFiles.length) {
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          changedRegistryFiles,
+          skipReason: 'no-registry-yaml-files-changed',
+        },
+        'direct-pr-reeval:skip'
+      );
+      continue;
+    }
+
+    const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+    const freshHeadSha = toStringTrim(freshPr.head?.sha);
+
+    if (!isPullRequestOpen(freshPr)) {
+      log(
+        context,
+        'info',
+        {
+          ...baseLog,
+          freshHeadSha,
+          changedRegistryFiles,
+          skipReason: 'pr-not-open',
+        },
+        'direct-pr-reeval:skip'
+      );
+      continue;
+    }
+
+    if (isPullRequestDirty(freshPr)) {
+      log(
+        context,
+        'warn',
+        {
+          ...baseLog,
+          freshHeadSha,
+          changedRegistryFiles,
+          mergeableState: readMergeableState(freshPr),
+          skipReason: 'pr-has-merge-conflicts',
+        },
+        'direct-pr-reeval:skip'
+      );
+      continue;
+    }
+
+    const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+
+    log(
+      context,
+      'info',
+      {
+        ...baseLog,
+        freshHeadSha,
+        changedRegistryFiles,
+        mergeable: freshPr.mergeable,
+        mergeableState: readMergeableState(freshPr),
+        mustUpdate,
+      },
+      'direct-pr-reeval:update-check'
+    );
+
+    candidates.push({
+      pr,
+      freshPr,
+      changedRegistryFiles,
+      mustUpdate,
+    });
+  }
+
+  return candidates;
+}
+
+async function runOneSequentialDirectRegistryPrMaintenance(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  baseBranch: string,
+  reason: string
+): Promise<SequentialRegistryPrResult> {
+  const key = sequentialRegistryPrRepoKey(repoInfo);
+  const existing = SEQUENTIAL_REGISTRY_PR_QUEUE_INFLIGHT.get(key);
+
+  if (existing) return await existing;
+
+  const pending = (async (): Promise<SequentialRegistryPrResult> => {
+    if (await isSequentialRegistryPrActiveBlocking(context, repoInfo)) {
+      return { updated: false, processed: false, blockedByActive: true };
+    }
+
+    const candidates = await collectSequentialDirectRegistryPrCandidates(context, repoInfo, baseBranch, reason);
+
+    for (const candidate of candidates.filter((item) => item.mustUpdate)) {
+      const requested = await requestPullRequestBranchUpdate(
+        context,
+        repoInfo,
+        candidate.freshPr,
+        `${reason}:sequential-direct-pr-update-before-approval`
+      );
+
+      log(
+        context,
+        'info',
+        {
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          prNumber: candidate.freshPr.number,
+          title: toStringTrim(candidate.freshPr.title),
+          headSha: toStringTrim(candidate.freshPr.head?.sha),
+          headRef: toStringTrim(candidate.freshPr.head?.ref),
+          baseBranch,
+          changedRegistryFiles: candidate.changedRegistryFiles,
+          requested,
+          reason,
+        },
+        'direct-pr-reeval:update-before-approval-result'
+      );
+
+      if (requested) {
+        markSequentialRegistryPrActive(context, repoInfo, candidate.freshPr, reason);
+        return { updated: true, processed: true, blockedByActive: false };
+      }
+
+      markSequentialRegistryPrHeadSkipped(context, repoInfo, candidate.freshPr, 'branch-update-request-failed');
+    }
+
+    for (const candidate of candidates.filter((item) => !item.mustUpdate)) {
+      const headSha = toStringTrim(candidate.freshPr.head?.sha);
+      const greenResult = headSha
+        ? await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, headSha)
+        : {
+            green: false,
+            reason: 'missing-head-sha',
+            latestRuns: [],
+            blockingRuns: [],
+          };
+
+      log(
+        context,
+        'info',
+        {
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          prNumber: candidate.freshPr.number,
+          headSha,
+          baseBranch,
+          changedRegistryFiles: candidate.changedRegistryFiles,
+          green: greenResult.green,
+          greenReason: greenResult.reason,
+          blockingRuns: greenResult.blockingRuns,
+          latestRuns: greenResult.latestRuns.slice(0, 30),
+          reason,
+        },
+        'direct-pr-reeval:head-green'
+      );
+
+      if (!greenResult.green) {
+        continue;
+      }
+
+      await processPullRequestForAutoMerge(context, repoInfo, candidate.freshPr);
+      return { updated: false, processed: true, blockedByActive: false };
+    }
+
+    return { updated: false, processed: false, blockedByActive: false };
+  })().finally(() => {
+    SEQUENTIAL_REGISTRY_PR_QUEUE_INFLIGHT.delete(key);
+  });
+
+  SEQUENTIAL_REGISTRY_PR_QUEUE_INFLIGHT.set(key, pending);
+  return await pending;
+}
+
+async function markFailedRegistryPrHeadsForSha(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  headSha: string,
+  baseBranch: string,
+  reason: string
+): Promise<boolean> {
+  const sha = toStringTrim(headSha);
+  if (!sha) return false;
+
+  const openPrs = await listOpenPullRequests(context, repoInfo);
+  const matching = openPrs.filter((pr) => toStringTrim(pr.head?.sha) === sha);
+
+  let marked = false;
+
+  for (const pr of matching) {
+    if (!pullRequestTargetsBranch(pr, baseBranch)) continue;
+
+    const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, baseBranch);
+    if (!changedRegistryFiles.length) continue;
+
+    markSequentialRegistryPrHeadSkipped(context, repoInfo, pr, reason);
+
+    const active = getSequentialRegistryPrActive(repoInfo);
+    if (active?.prNumber === pr.number) {
+      clearSequentialRegistryPrActive(repoInfo);
+    }
+
+    marked = true;
+
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: sha,
+        changedRegistryFiles,
+        reason,
+      },
+      'sequential-registry-pr:failed-head-marked'
+    );
+  }
+
+  return marked;
+}
+
+async function releaseSequentialRegistryPrIfNotApprovedAfterGreen(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<void> {
+  const active = getSequentialRegistryPrActive(repoInfo);
+  if (!active || active.prNumber !== pr.number) return;
+
+  const freshPr = await readFreshPullRequest(context, repoInfo, pr.number);
+  if (!freshPr || !isPullRequestOpen(freshPr)) {
+    clearSequentialRegistryPrActive(repoInfo);
+    return;
+  }
+
+  const headSha = toStringTrim(freshPr.head?.sha);
+  if (!headSha) return;
+
+  const hasCurrentHeadAutoApproval = await hasAutoApprovalReviewForHead(context, repoInfo, freshPr.number, headSha);
+
+  if (hasCurrentHeadAutoApproval || isSnapshotManagedRequestPr(freshPr)) {
+    return;
+  }
+
+  const greenResult = await evaluateHeadGreenForApprovalReevaluation(context, repoInfo, headSha);
+  if (!greenResult.green) return;
+
+  markSequentialRegistryPrHeadSkipped(context, repoInfo, freshPr, 'green-head-did-not-auto-approve');
+  clearSequentialRegistryPrActive(repoInfo);
+
+  await runOneSequentialDirectRegistryPrMaintenance(
+    context,
+    repoInfo,
+    toStringTrim(freshPr.base?.ref),
+    'sequential-direct-pr:advance-after-not-approved'
+  );
 }
 
 async function readRepoFileTextAtRef(
@@ -6793,6 +7021,7 @@ export default function requestHandler(app: Probot): void {
     for (const pr of candidates) {
       try {
         await processPullRequestForAutoMerge(context, repoInfo, pr);
+        await releaseSequentialRegistryPrIfNotApprovedAfterGreen(context, repoInfo, pr);
       } catch (e: unknown) {
         log(
           context,
@@ -6803,6 +7032,10 @@ export default function requestHandler(app: Probot): void {
           },
           'auto-merge candidate processing failed'
         );
+
+        const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+        markSequentialRegistryPrHeadSkipped(context, repoInfo, freshPr, 'auto-merge-candidate-processing-failed');
+        clearSequentialRegistryPrActive(repoInfo);
       }
     }
   };
@@ -6875,14 +7108,16 @@ export default function requestHandler(app: Probot): void {
 
     await getStaticConfig(context, { forceReload: true });
 
-    await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
+    const directResult = await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       context,
       repoInfo,
       defaultBranch,
       'default-branch-check-suite:direct-pr-reevaluation'
     );
 
-    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, defaultBranch);
+    if (!directResult.updated && !directResult.processed && !directResult.blockedByActive) {
+      await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, defaultBranch);
+    }
   };
 
   app.on('push', async (context: BotContext<'push'>): Promise<void> => {
@@ -6931,14 +7166,16 @@ export default function requestHandler(app: Probot): void {
       ? 'default-branch-push:approval-config-change'
       : 'default-branch-push:direct-pr-reevaluation';
 
-    await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
+    const directResult = await reevaluateOpenDirectPullRequestsAfterDefaultBranchPush(
       context,
       repoInfo,
       baseBranch,
       directPrReevaluationReason
     );
 
-    await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
+    if (!directResult.updated && !directResult.processed && !directResult.blockedByActive) {
+      await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
+    }
   });
 
   app.on(
@@ -7010,6 +7247,29 @@ export default function requestHandler(app: Probot): void {
         );
 
         if (status !== 'completed') return;
+        if (conclusion && conclusion !== 'success') {
+          if (isBlockingCheckConclusion(conclusion)) {
+            const baseBranch = readDefaultBranchFromPayload(payload);
+            const marked = await markFailedRegistryPrHeadsForSha(
+              context,
+              repoInfo,
+              headShaStr,
+              baseBranch,
+              `check-run:${conclusion}`
+            );
+
+            if (marked) {
+              await runOneSequentialDirectRegistryPrMaintenance(
+                context,
+                repoInfo,
+                baseBranch,
+                `check-run:${conclusion}:advance-next-registry-pr`
+              );
+            }
+          }
+
+          return;
+        }
         if (conclusion !== 'success') return;
         if (!headShaStr) return;
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2460,6 +2460,7 @@ function updateBranchInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): strin
 
 function isUpdateBranchCooldownActive(key: string): boolean {
   const until = UPDATE_BRANCH_COOLDOWN_UNTIL.get(key);
+  // eslint-disable-next-line eqeqeq
   if (until == null) return false;
 
   if (until <= Date.now()) {
@@ -4900,7 +4901,7 @@ async function closeLinkedIssuePrs(
   let prs: PullRequestLike[] = [];
 
   try {
-    prs = await findOpenIssuePRsRaw(context, repoInfo, issueNumber);
+    prs = (await findOpenIssuePRsRaw(context, repoInfo, issueNumber)) as unknown as PullRequestLike[];
   } catch {
     prs = [];
   }

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -2753,7 +2753,11 @@ function buildApprovalHookArgs(
 ): OnApprovalArgs {
   const namespace = resolveApprovalNamespace(args);
   const resourceName = resolveApprovalResourceName(args, namespace);
-  const requesterId = toStringSafe(args.requestAuthorId) || toStringSafe(args.issue?.user?.login);
+
+  const hasExplicitRequestAuthorId = args.requestAuthorId !== undefined && args.requestAuthorId !== null;
+  const requesterId = hasExplicitRequestAuthorId
+    ? toStringSafe(args.requestAuthorId)
+    : toStringSafe(args.issue?.user?.login);
 
   return {
     requestType: toStringSafe(args.requestType),

--- a/test/pr-reviewers.autorun.test.ts
+++ b/test/pr-reviewers.autorun.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { mkdtemp, rm } from 'node:fs/promises';
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 
 function restoreEnvSnapshot(snapshot: NodeJS.ProcessEnv): void {
   for (const k of Object.keys(process.env)) {
@@ -15,6 +15,8 @@ function restoreEnvSnapshot(snapshot: NodeJS.ProcessEnv): void {
 }
 
 describe('pr-reviewers auto-run guard', () => {
+  jest.setTimeout(15000);
+
   const originalEnv: NodeJS.ProcessEnv = { ...process.env };
   const originalCwd: string = process.cwd();
   const originalExitCode: number | undefined = process.exitCode as number | undefined;

--- a/test/request-orchestrator.labels-lock.test.ts
+++ b/test/request-orchestrator.labels-lock.test.ts
@@ -1020,4 +1020,132 @@ describe('request handler label guards (workflow-label-lock + routing label lock
     // Should return early, no further label-guard actions
     expect(setStateLabel).not.toHaveBeenCalled();
   });
+
+  test('issues.labeled: routing lock falls back to payload labels when label refresh fails', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const cfg: StaticConfig = {
+      workflow: { labels: { approvalSuccessful: ['Approved'] } },
+      requests: {},
+    };
+
+    const octokit = mkOctokit();
+    octokit.issues.get
+      .mockResolvedValueOnce({
+        data: {
+          number: 9,
+          title: 'T',
+          body: 'B',
+          labels: [{ name: 'route-1' }, { name: 'route-2' }],
+          user: { login: 'alice' },
+        },
+      })
+      .mockRejectedValueOnce(new Error('label refresh failed'));
+
+    loadTemplate.mockImplementation(async (_ctx: unknown, args: LoadTemplateArgs) => {
+      const lbls = Array.isArray(args.issueLabels) ? args.issueLabels.map(String) : [];
+      if (lbls.length === 1 && (lbls[0] === 'route-1' || lbls[0] === 'route-2')) return DEFAULT_TEMPLATE;
+      if (lbls.length > 1) throw new Error('Cannot resolve template: multiple routing label');
+      throw new Error('no routing label found');
+    });
+
+    const ctx = mkCtx({
+      eventName: 'issues.labeled',
+      action: 'labeled',
+      issue: {
+        number: 9,
+        title: 'T',
+        body: 'B\n\n<!-- nsreq:routing-lock = {"v":1,"expected":"route-1"} -->',
+        state: 'open',
+        labels: [{ name: 'route-1' }, { name: 'route-2' }],
+        user: { login: 'alice' },
+      },
+      sender: { type: 'User', login: 'bob' },
+      labelName: 'route-2',
+      config: cfg,
+      octokit,
+    });
+
+    await handlers['issues.labeled']?.[0]?.(ctx);
+
+    expect(octokit.issues.removeLabel).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      issue_number: 9,
+      name: 'route-2',
+    });
+  });
+
+  test('issues.labeled: malformed routing lock marker is ignored safely', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const cfg: StaticConfig = {
+      workflow: { labels: { approvalSuccessful: ['Approved'] } },
+      requests: {},
+    };
+
+    const octokit = mkOctokit();
+    const ctx = mkCtx({
+      eventName: 'issues.labeled',
+      action: 'labeled',
+      issue: {
+        number: 10,
+        title: 'T',
+        body: 'B\n\n<!-- nsreq:routing-lock = {oops} -->',
+        state: 'open',
+        labels: [{ name: 'route-1' }, { name: 'route-2' }],
+        user: { login: 'alice' },
+      },
+      sender: { type: 'User', login: 'bob' },
+      labelName: 'route-2',
+      config: cfg,
+      octokit,
+    });
+
+    await handlers['issues.labeled']?.[0]?.(ctx);
+
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('issues.labeled: template load failure while checking routing label returns without lock notice', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const cfg: StaticConfig = {
+      workflow: { labels: { approvalSuccessful: ['Approved'] } },
+      requests: {},
+    };
+
+    loadTemplate.mockRejectedValue(new Error('template lookup failed'));
+
+    const octokit = mkOctokit();
+    const ctx = mkCtx({
+      eventName: 'issues.labeled',
+      action: 'labeled',
+      issue: {
+        number: 11,
+        title: 'T',
+        body: 'B\n\n<!-- nsreq:routing-lock = {"v":1,"expected":"route-1"} -->',
+        state: 'open',
+        labels: [{ name: 'route-bad' }],
+        user: { login: 'alice' },
+      },
+      sender: { type: 'User', login: 'bob' },
+      labelName: 'route-bad',
+      config: cfg,
+      octokit,
+    });
+
+    await handlers['issues.labeled']?.[0]?.(ctx);
+
+    expect(octokit.issues.addLabels).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      issue_number: 11,
+      labels: ['route-1'],
+    });
+    expect(postOnce).not.toHaveBeenCalled();
+  });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -5,8 +5,12 @@ import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@
 const PREV_DEBUG_NS = process.env.DEBUG_NS;
 process.env.DEBUG_NS = '1';
 
+let currentTestNow = Date.parse('2026-04-22T09:00:00.000Z');
+const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTestNow);
+
 afterAll(() => {
   process.env.DEBUG_NS = PREV_DEBUG_NS;
+  dateNowSpy.mockRestore();
 });
 
 type IssueParams = { owner: string; repo: string; issue_number: number };
@@ -332,7 +336,9 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  currentTestNow += 7 * 60 * 60 * 1000;
   jest.resetAllMocks();
+  dateNowSpy.mockImplementation(() => currentTestNow);
 
   setStateLabel.mockImplementation(async () => {});
   ensureAssigneesOnce.mockImplementation(async () => {});
@@ -4450,7 +4456,7 @@ test('push: direct PR reevaluation skips when fallback tree diff cannot read cur
   setTimeoutSpy.mockRestore();
 });
 
-test('push: direct PR reevaluation skips merge when approved head checks are not green', async () => {
+test('push: direct PR reevaluation does not run approval when approved head checks are not green', async () => {
   const cfg = {
     requests: {
       product: { folderName: 'resources' },
@@ -4529,8 +4535,8 @@ test('push: direct PR reevaluation skips merge when approved head checks are not
 
   await handler(ctx);
 
-  expect(runApprovalHook).toHaveBeenCalled();
-  expect(ctx.octokit.pulls.createReview).toHaveBeenCalled();
+  expect(runApprovalHook).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
   expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
   setTimeoutSpy.mockRestore();

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2686,7 +2686,12 @@ public
       expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 51, per_page: 100, page: 1 })
     );
     expect(ctx.octokit.repos.getContent).toHaveBeenCalledWith(
-      expect.objectContaining({ owner: 'o1', repo: 'r1', path: 'resources/product-one.yaml', ref: 'feature/direct' })
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        path: 'resources/product-one.yaml',
+        ref: 'sha-standalone-direct',
+      })
     );
     expect(runApprovalHook).toHaveBeenCalledWith(
       ctx,
@@ -3623,7 +3628,7 @@ public
         owner: 'o1',
         repo: 'r1',
         path: 'resources/product-ok.yaml',
-        ref: 'feature/non-registry-yaml',
+        ref: 'sha-non-registry-yaml',
       })
     );
     expect(runApprovalHook).toHaveBeenCalledWith(
@@ -3641,6 +3646,247 @@ public
     expect(tryMergeIfGreen).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 60, mergeMethod: 'squash' })
+    );
+  });
+
+  test('check_suite.success: standalone cross-repo direct PR falls back to tree diff and reads yaml from head repo', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-cross-repo-direct',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    const forkRepo = { full_name: 'fork-owner/fork-repo', name: 'fork-repo', owner: { login: 'fork-owner' } };
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 61,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/cross-repo', sha: 'sha-cross-repo-direct', repo: forkRepo },
+            base: { ref: 'main', sha: 'base-sha' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({ data: [] });
+    ctx.octokit.repos.getBranch = jest.fn(async () => ({ data: { commit: { sha: 'base-head-sha' } } }));
+    ctx.octokit.git.getTree = jest.fn(async ({ owner, repo, tree_sha }: any) => {
+      if (owner === 'o1' && repo === 'r1' && tree_sha === 'base-head-sha') {
+        return {
+          data: { tree: [{ path: 'resources/product-fork.yaml', type: 'blob', sha: 'base-file-sha' }] },
+        };
+      }
+
+      if (owner === 'fork-owner' && repo === 'fork-repo' && tree_sha === 'sha-cross-repo-direct') {
+        return {
+          data: { tree: [{ path: 'resources/product-fork.yaml', type: 'blob', sha: 'fork-file-sha' }] },
+        };
+      }
+
+      return { data: { tree: [] } };
+    });
+
+    ctx.octokit.repos.getContent = jest.fn(async ({ owner, repo, path, ref }: any) => {
+      if (
+        owner === 'fork-owner' &&
+        repo === 'fork-repo' &&
+        path === 'resources/product-fork.yaml' &&
+        ref === 'sha-cross-repo-direct'
+      ) {
+        return {
+          data: {
+            content: Buffer.from('type: product\nname: product-fork\ncontact: fork@example.com\n', 'utf8').toString(
+              'base64'
+            ),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      throw httpErr(404);
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'fork-author' }, committer: { login: 'fork-committer' } }],
+    });
+
+    ctx.octokit.pulls.get.mockResolvedValueOnce({
+      data: {
+        number: 61,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/cross-repo', sha: 'sha-cross-repo-direct', repo: forkRepo },
+        base: { ref: 'main', sha: 'base-sha' },
+        mergeable: true,
+        mergeable_state: 'clean',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved cross repo' } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.git.getTree).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', tree_sha: 'base-head-sha', recursive: 'true' })
+    );
+    expect(ctx.octokit.git.getTree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'fork-owner',
+        repo: 'fork-repo',
+        tree_sha: 'sha-cross-repo-direct',
+        recursive: 'true',
+      })
+    );
+    expect(ctx.octokit.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'fork-owner',
+        repo: 'fork-repo',
+        path: 'resources/product-fork.yaml',
+        ref: 'sha-cross-repo-direct',
+      })
+    );
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({
+        requestType: 'product',
+        namespace: 'product-fork',
+        resourceName: 'product-fork',
+        requestAuthorId: 'fork-author',
+        formData: expect.objectContaining({
+          identifier: 'product-fork',
+          namespace: 'product-fork',
+          contact: 'fork@example.com',
+        }),
+      })
+    );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 61, mergeMethod: 'squash' })
+    );
+  });
+
+  test('check_suite.success: standalone cross-repo direct PR ignores issue number pattern in head branch name', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-cross-repo-issue-branch',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    const forkRepo = { full_name: 'fork-owner/fork-repo', name: 'fork-repo', owner: { login: 'fork-owner' } };
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 62,
+            body: 'manual direct pr',
+            title: 'Direct from fork',
+            head: { ref: 'feature/issue-119-from-fork', sha: 'sha-cross-repo-issue-branch', repo: forkRepo },
+            base: { ref: 'main', sha: 'base-sha' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-fork-issue.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent = jest.fn(async ({ owner, repo, path, ref }: any) => {
+      if (
+        owner === 'fork-owner' &&
+        repo === 'fork-repo' &&
+        path === 'resources/product-fork-issue.yaml' &&
+        ref === 'sha-cross-repo-issue-branch'
+      ) {
+        return {
+          data: {
+            content: Buffer.from('type: product\nname: product-fork-issue\n', 'utf8').toString('base64'),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      throw httpErr(404);
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'fork-author-issue' } }],
+    });
+
+    ctx.octokit.pulls.get.mockResolvedValueOnce({
+      data: {
+        number: 62,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct from fork',
+        head: { ref: 'feature/issue-119-from-fork', sha: 'sha-cross-repo-issue-branch', repo: forkRepo },
+        base: { ref: 'main', sha: 'base-sha' },
+        mergeable: true,
+        mergeable_state: 'clean',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.issues.get).not.toHaveBeenCalled();
+    expect(runApprovalHook).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1' },
+      expect.objectContaining({
+        requestType: 'product',
+        namespace: 'product-fork-issue',
+        resourceName: 'product-fork-issue',
+        requestAuthorId: 'fork-author-issue',
+      })
+    );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 62, mergeMethod: 'squash' })
     );
   });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -3398,6 +3398,10 @@ test('push: default branch push updates approved green registry PR branches', as
     },
   });
 
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
   ctx.name = 'push';
   ctx.payload = {
     ref: 'refs/heads/main',
@@ -3410,6 +3414,7 @@ test('push: default branch push updates approved green registry PR branches', as
       data: [
         {
           number: 201,
+          state: 'open',
           body: 'manual direct pr',
           title: 'Direct',
           head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
@@ -3419,12 +3424,16 @@ test('push: default branch push updates approved green registry PR branches', as
     })
     .mockResolvedValueOnce({ data: [] });
 
-  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+  ctx.octokit.pulls.listFiles.mockResolvedValue({
     data: [{ filename: 'resources/product-approved.yaml', status: 'modified' }],
   });
 
-  ctx.octokit.issues.get.mockResolvedValueOnce({
+  ctx.octokit.issues.get.mockResolvedValue({
     data: { number: 201, labels: [{ name: 'Approved' }] },
+  });
+
+  ctx.octokit.pulls.listReviews.mockResolvedValue({
+    data: [],
   });
 
   ctx.octokit.pulls.get.mockResolvedValue({
@@ -3432,16 +3441,11 @@ test('push: default branch push updates approved green registry PR branches', as
       number: 201,
       state: 'open',
       body: 'manual direct pr',
+      title: 'Direct',
       head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
       base: { ref: 'main', sha: 'base-sha' },
       mergeable: true,
       mergeable_state: 'behind',
-    },
-  });
-
-  ctx.octokit.checks.listForRef.mockResolvedValueOnce({
-    data: {
-      check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success' }],
     },
   });
 
@@ -3455,6 +3459,8 @@ test('push: default branch push updates approved green registry PR branches', as
       expected_head_sha: 'sha-approved-green',
     })
   );
+
+  setTimeoutSpy.mockRestore();
 });
 
 test('push: approved review remains eligible for branch update after later comment-only review', async () => {
@@ -3477,6 +3483,10 @@ test('push: approved review remains eligible for branch update after later comme
     },
   });
 
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
   ctx.name = 'push';
   ctx.payload = {
     ref: 'refs/heads/main',
@@ -3489,6 +3499,7 @@ test('push: approved review remains eligible for branch update after later comme
       data: [
         {
           number: 202,
+          state: 'open',
           body: 'manual direct pr',
           title: 'Direct',
           head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
@@ -3498,24 +3509,12 @@ test('push: approved review remains eligible for branch update after later comme
     })
     .mockResolvedValueOnce({ data: [] });
 
-  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+  ctx.octokit.pulls.listFiles.mockResolvedValue({
     data: [{ filename: 'resources/product-commented.yaml', status: 'modified' }],
   });
 
-  ctx.octokit.issues.get.mockResolvedValueOnce({
+  ctx.octokit.issues.get.mockResolvedValue({
     data: { number: 202, labels: [] },
-  });
-
-  ctx.octokit.pulls.get.mockResolvedValue({
-    data: {
-      number: 202,
-      state: 'open',
-      body: 'manual direct pr',
-      head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
-      base: { ref: 'main', sha: 'base-sha' },
-      mergeable: true,
-      mergeable_state: 'behind',
-    },
   });
 
   ctx.octokit.pulls.listReviews.mockResolvedValue({
@@ -3535,6 +3534,19 @@ test('push: approved review remains eligible for branch update after later comme
     ],
   });
 
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 202,
+      state: 'open',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    },
+  });
+
   await handler(ctx);
 
   expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
@@ -3545,6 +3557,8 @@ test('push: approved review remains eligible for branch update after later comme
       expected_head_sha: 'sha-review-commented',
     })
   );
+
+  setTimeoutSpy.mockRestore();
 });
 
 test('push: changes requested review blocks approved-label based branch update', async () => {
@@ -3567,6 +3581,10 @@ test('push: changes requested review blocks approved-label based branch update',
     },
   });
 
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
   ctx.name = 'push';
   ctx.payload = {
     ref: 'refs/heads/main',
@@ -3579,6 +3597,7 @@ test('push: changes requested review blocks approved-label based branch update',
       data: [
         {
           number: 203,
+          state: 'open',
           body: 'manual direct pr',
           title: 'Direct',
           head: { ref: 'feature/changes-requested', sha: 'sha-changes-requested' },
@@ -3616,6 +3635,8 @@ test('push: changes requested review blocks approved-label based branch update',
   await handler(ctx);
 
   expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
 });
 
 test('issues.opened: partner namespace maps request type and matches normalized request config keys', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -872,6 +872,89 @@ test('check_suite.success closes outdated when hashes mismatch', async () => {
   expect(postOnce).toHaveBeenCalled();
 });
 
+test('check_suite.success treats matching default-branch head as default branch suite', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['check_suite.completed'][0];
+
+  const ctx = mkCheckSuiteContext({
+    event: 'check_suite.completed',
+    conclusion: 'success',
+    sha: 'sha-default-suite',
+    ownerLogin: 'o1',
+    repoName: 'r1',
+    withCachedConfig: true,
+  });
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.payload.action = 'completed';
+  ctx.payload.repository.default_branch = 'main';
+  ctx.payload.check_suite.status = 'completed';
+  ctx.payload.check_suite.head_branch = 'feature/not-main';
+  ctx.payload.check_suite.head_sha = 'sha-default-suite';
+  ctx.payload.check_suite.pull_requests = [{ number: 77 }];
+  ctx.octokit.repos.getBranch = jest.fn(async () => ({
+    data: { commit: { sha: 'sha-default-suite' } },
+  }));
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({ data: [] })
+    .mockResolvedValueOnce({ data: [] })
+    .mockResolvedValueOnce({ data: [] });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.repos.getBranch).toHaveBeenCalledWith(
+    expect.objectContaining({ owner: 'o1', repo: 'r1', branch: 'main' })
+  );
+  expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+    ctx,
+    { owner: 'o1', repo: 'r1', issue_number: 77 },
+    expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
+  );
+  expect(ctx.octokit.pulls.list).toHaveBeenCalledTimes(3);
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('check_suite.success ignores default-branch fallback when branch head lookup fails', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['check_suite.completed'][0];
+
+  const ctx = mkCheckSuiteContext({
+    event: 'check_suite.completed',
+    conclusion: 'success',
+    sha: 'sha-default-suite-fail',
+    ownerLogin: 'o1',
+    repoName: 'r1',
+    withCachedConfig: true,
+  });
+
+  ctx.payload.action = 'completed';
+  ctx.payload.repository.default_branch = 'main';
+  ctx.payload.check_suite.status = 'completed';
+  ctx.payload.check_suite.head_branch = 'feature/not-main';
+  ctx.payload.check_suite.head_sha = 'sha-default-suite-fail';
+  ctx.payload.check_suite.pull_requests = [];
+  ctx.octokit.repos.getBranch = jest.fn(async () => {
+    throw httpErr(503);
+  });
+
+  ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [] });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.repos.getBranch).toHaveBeenCalledTimes(1);
+  expect(ctx.octokit.pulls.list).toHaveBeenCalledTimes(2);
+  expect(tryMergeIfGreen).not.toHaveBeenCalled();
+});
+
 test('check_suite.completed failure posts PR comment when registry-validate annotations exist', async () => {
   const { app, handlers } = mkApp();
   requestHandler(app);
@@ -1126,6 +1209,95 @@ test('check_run.failure skips if check_run.id is missing', async () => {
   expect(postOnce).not.toHaveBeenCalled();
 });
 
+test('check_run.success without repo info returns early', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const ctx: any = mkCheckSuiteContext({
+    event: 'check_run.completed',
+    conclusion: 'success',
+    sha: 'deadbeef',
+    ownerLogin: 'o',
+    repoName: 'r',
+    withCachedConfig: true,
+  });
+
+  ctx.payload = {
+    action: 'completed',
+    check_run: {
+      conclusion: 'success',
+      status: 'completed',
+      head_sha: 'deadbeef',
+      pull_requests: [{ number: 7 }],
+    },
+  };
+
+  await handlers['check_run.completed'][0](ctx);
+
+  expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+  expect(tryMergeIfGreen).not.toHaveBeenCalled();
+});
+
+test('check_run.success collapses CI comments and auto-merges matching PR head', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const ctx: any = mkCheckSuiteContext({
+    event: 'check_run.completed',
+    conclusion: 'success',
+    sha: 'sha-checkrun-success',
+    ownerLogin: 'o1',
+    repoName: 'r1',
+    withCachedConfig: true,
+  });
+
+  ctx.payload = {
+    action: 'completed',
+    repository: { name: 'r1', owner: { login: 'o1' } },
+    check_run: {
+      conclusion: 'success',
+      status: 'completed',
+      head_sha: 'sha-checkrun-success',
+      pull_requests: [{ number: 301 }],
+    },
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [{ number: 301, body: 'source: #1', head: { ref: 'feature/checkrun', sha: 'sha-checkrun-success' } }],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.issues.get.mockResolvedValueOnce({
+    data: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 301,
+      state: 'open',
+      body: 'source: #1',
+      head: { ref: 'feature/checkrun', sha: 'sha-checkrun-success' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    },
+  });
+
+  calcSnapshotHash.mockReturnValue('h1');
+  extractHashFromPrBody.mockReturnValue('h1');
+
+  await handlers['check_run.completed'][0](ctx);
+
+  expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+    ctx,
+    { owner: 'o1', repo: 'r1', issue_number: 301 },
+    expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
+  );
+  expect(tryMergeIfGreen).toHaveBeenCalled();
+});
+
 test('check_suite.completed failure stops listing annotations after 20 pages (safety cap)', async () => {
   const { app, handlers } = mkApp();
   requestHandler(app);
@@ -1217,6 +1389,26 @@ test('status success triggers tryAutoMerge flow', async () => {
   await handler(ctx);
 
   expect(tryMergeIfGreen).toHaveBeenCalled();
+});
+
+test('status success with missing sha skips auto-merge candidate lookup', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['status'][0];
+
+  const ctx = mkStatusContext({
+    state: 'success',
+    sha: '',
+    ownerLogin: 'o1',
+    repoName: 'r1',
+    withCachedConfig: true,
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('status ignored when state != success', async () => {
@@ -1363,6 +1555,75 @@ describe('parent owner approval gating', () => {
     expect(posted).not.toContain('Parent owner approval required');
     expect(ensureAssigneesOnce).toHaveBeenCalled();
     expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'review');
+  });
+
+  test('gates sub-namespace request when parent owner email resolves via GraphQL fallback', async () => {
+    const { app, handlers: h } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 5511,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { type: 'User', login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    const ctx = mkIssuesContext({ issue, action: 'opened' });
+    (ctx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return {
+          data: {
+            content: b64('contacts:\n  - "@topOwner"\n'),
+            encoding: 'base64',
+          },
+        };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return {
+          data: {
+            content: b64('contacts:\n  - owner@example.com\n'),
+            encoding: 'base64',
+          },
+        };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+    ctx.octokit.search = {
+      users: jest.fn(() => Promise.resolve({ data: { items: [] } })),
+    };
+    ctx.octokit.graphql = jest.fn(() => Promise.resolve({ search: { nodes: [{ login: 'emailOwner' }] } }));
+
+    await h['issues.opened'][0](ctx);
+
+    const posted = postedBodies();
+    expect(posted).toContain('@emailOwner');
+    expect(ctx.octokit.search.users).toHaveBeenCalledWith({ q: 'owner@example.com in:email', per_page: 5 });
+    expect(ctx.octokit.graphql).toHaveBeenCalledWith(expect.stringContaining('search(type: USER'), {
+      q: 'owner@example.com in:email',
+    });
   });
 
   test('ignores Approved comments from non-owners while gated', async () => {
@@ -2404,6 +2665,19 @@ public
       data: [{ author: { login: 'ignored-author' }, committer: { login: 'direct-last-committer' } }],
     });
 
+    ctx.octokit.pulls.get.mockResolvedValueOnce({
+      data: {
+        number: 51,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/direct', sha: 'sha-standalone-direct' },
+        base: { ref: 'main', sha: 'base-sha' },
+        mergeable: true,
+        mergeable_state: 'clean',
+      },
+    });
+
     runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved from standalone hook' } as any);
 
     await handler(ctx);
@@ -2927,14 +3201,95 @@ public
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 155, mergeMethod: 'squash' })
     );
-    expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: 'o1',
-        repo: 'r1',
-        pull_number: 155,
-        expected_head_sha: 'sha-merge-false',
+    expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR merge blocked by branch protection does not request branch update', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-branch-protection',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+      if (typeof callback === 'function') callback();
+      return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 156,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/branch-protection', sha: 'sha-branch-protection' },
+          },
+        ],
       })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-branch-protection.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-branch-protection\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ committer: { login: 'branch-protection-user' } }],
+    });
+
+    ctx.octokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 156,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/branch-protection', sha: 'sha-branch-protection' },
+        base: { ref: 'main', sha: 'base-sha' },
+        mergeable: true,
+        mergeable_state: 'clean',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved by hook' } as any);
+    tryMergeIfGreen.mockRejectedValueOnce(new Error('Required status check "ci" is expected'));
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 156, event: 'APPROVE' })
     );
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 156, mergeMethod: 'squash' })
+    );
+    expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+
+    setTimeoutSpy.mockRestore();
   });
 
   test('check_suite.success: standalone direct PR skips merge when changed yaml cannot be read from repo ref', async () => {
@@ -3245,6 +3600,19 @@ public
       data: [{ committer: { login: 'registry-committer' } }],
     });
 
+    ctx.octokit.pulls.get.mockResolvedValueOnce({
+      data: {
+        number: 60,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/non-registry-yaml', sha: 'sha-non-registry-yaml' },
+        base: { ref: 'main', sha: 'base-sha' },
+        mergeable: true,
+        mergeable_state: 'clean',
+      },
+    });
+
     runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
 
     await handler(ctx);
@@ -3512,6 +3880,626 @@ test('push: default branch push updates approved green registry PR branches', as
       expected_head_sha: 'sha-approved-green',
     })
   );
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: default branch push without repo info returns early', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ withCachedConfig: true });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  await handler(ctx);
+
+  expect(loadStaticConfig).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+});
+
+test('push: direct PR reevaluation skips missing head sha', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 206,
+          title: 'Direct',
+          body: 'manual direct pr',
+          head: { ref: 'feature/no-sha' },
+          base: { ref: 'main' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  await handler(ctx);
+
+  expect(runApprovalHook).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.get).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct PR reevaluation skips different base branch', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true });
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  extractHashFromPrBody.mockReturnValueOnce('');
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 207,
+          title: 'Direct',
+          body: 'manual direct pr',
+          head: { ref: 'feature/other-base', sha: 'sha-other-base' },
+          base: { ref: 'release', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.pulls.listFiles).not.toHaveBeenCalled();
+  expect(runApprovalHook).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct PR reevaluation uses fallback tree diff and skips closed refreshed PRs', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true, config: cfg });
+
+  loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 208,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/tree-diff', sha: 'sha-tree-diff' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({ data: [] });
+  ctx.octokit.repos.getBranch = jest.fn(async () => ({ data: { commit: { sha: 'base-head-sha' } } }));
+  const getTreeMock: any = jest.fn();
+  getTreeMock.mockResolvedValueOnce({
+    data: { tree: [{ path: 'resources/product-tree.yaml', type: 'blob', sha: 'base-file-sha' }] },
+  });
+  getTreeMock.mockResolvedValueOnce({
+    data: { tree: [{ path: 'resources/product-tree.yaml', type: 'blob', sha: 'head-file-sha' }] },
+  });
+  ctx.octokit.git.getTree = getTreeMock;
+
+  ctx.octokit.pulls.get.mockResolvedValueOnce({
+    data: {
+      number: 208,
+      state: 'closed',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/tree-diff', sha: 'sha-tree-diff' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    },
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.git.getTree).toHaveBeenCalledTimes(2);
+  expect(runApprovalHook).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct PR reevaluation requests update when current base comparison shows PR is stale', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true, config: cfg });
+
+  loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 210,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/current-base-stale', sha: 'sha-current-base-stale' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    data: [{ filename: 'resources/product-current-base-stale.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValueOnce({
+    data: {
+      number: 210,
+      state: 'open',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/current-base-stale', sha: 'sha-current-base-stale' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    },
+  });
+
+  ctx.octokit.repos.getBranch = jest.fn(async () => ({ data: { commit: { sha: 'base-head-sha' } } }));
+  ctx.octokit.repos.compareCommitsWithBasehead = jest.fn(async () => ({
+    data: { status: 'ahead', ahead_by: 1 },
+  }));
+
+  await handler(ctx);
+
+  expect(ctx.octokit.repos.compareCommitsWithBasehead).toHaveBeenCalledWith(
+    expect.objectContaining({ owner: 'o1', repo: 'r1', basehead: 'sha-current-base-stale...base-head-sha' })
+  );
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledWith(
+    expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 210, expected_head_sha: 'sha-current-base-stale' })
+  );
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct PR reevaluation skips when fallback tree diff cannot read current base', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true, config: cfg });
+
+  loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 211,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/no-tree-diff', sha: 'sha-no-tree-diff' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({ data: [] });
+  ctx.octokit.repos.getBranch = jest.fn(async () => {
+    throw httpErr(500);
+  });
+
+  await handler(ctx);
+
+  expect(ctx.octokit.repos.getBranch).toHaveBeenCalledTimes(1);
+  expect(ctx.octokit.git.getTree).toBeUndefined();
+  expect(runApprovalHook).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct PR reevaluation skips merge when approved head checks are not green', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({ owner: 'o1', repo: 'r1', withCachedConfig: true, config: cfg });
+
+  loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+    if (typeof callback === 'function') callback();
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 209,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/not-green', sha: 'sha-not-green' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValue({
+    data: [{ filename: 'resources/product-not-green.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.repos.getContent.mockResolvedValueOnce({
+    data: {
+      content: Buffer.from('type: product\nname: product-not-green\n', 'utf8').toString('base64'),
+      encoding: 'base64',
+    },
+  });
+
+  ctx.octokit.pulls.listCommits.mockResolvedValueOnce({ data: [{ committer: { login: 'not-green-user' } }] });
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 209,
+      state: 'open',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/not-green', sha: 'sha-not-green' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    },
+  });
+
+  runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved but wait for ci' } as any);
+  ctx.octokit.checks.listForRef.mockResolvedValueOnce({
+    data: { check_runs: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'failure' }] },
+  });
+
+  await handler(ctx);
+
+  expect(runApprovalHook).toHaveBeenCalled();
+  expect(ctx.octokit.pulls.createReview).toHaveBeenCalled();
+  expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: stale direct registry PR retries updateBranch without expected head before approval reevaluation', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({
+    owner: 'o1',
+    repo: 'r1',
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  loadStaticConfig.mockResolvedValueOnce({
+    config: cfg,
+    source: 'mock',
+    hooks: null,
+    hooksSource: null,
+  });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+    if (typeof callback === 'function') callback();
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 204,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/stale-direct', sha: 'sha-stale-direct' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    data: [{ filename: 'resources/product-stale.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 204,
+      state: 'open',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/stale-direct', sha: 'sha-stale-direct' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    },
+  });
+
+  ctx.octokit.pulls.updateBranch
+    .mockRejectedValueOnce(Object.assign(new Error('expected_head_sha mismatch'), { status: 422 }))
+    .mockResolvedValueOnce({});
+
+  await handler(ctx);
+
+  expect(runApprovalHook).not.toHaveBeenCalled();
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenCalledTimes(2);
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      owner: 'o1',
+      repo: 'r1',
+      pull_number: 204,
+      expected_head_sha: 'sha-stale-direct',
+    })
+  );
+  expect(ctx.octokit.pulls.updateBranch).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      owner: 'o1',
+      repo: 'r1',
+      pull_number: 204,
+    })
+  );
+  expect(ctx.octokit.pulls.updateBranch.mock.calls[1]?.[0]).not.toHaveProperty('expected_head_sha');
+
+  setTimeoutSpy.mockRestore();
+});
+
+test('push: direct registry PR runs approval after reevaluation when branch is already current', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['push'][0];
+  const ctx = mkBaseContext({
+    owner: 'o1',
+    repo: 'r1',
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  loadStaticConfig.mockResolvedValueOnce({
+    config: cfg,
+    source: 'mock',
+    hooks: null,
+    hooksSource: null,
+  });
+  extractHashFromPrBody.mockReturnValueOnce('');
+
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+    if (typeof callback === 'function') callback();
+    return { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  ctx.name = 'push';
+  ctx.payload = {
+    ref: 'refs/heads/main',
+    repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+    commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+  };
+
+  ctx.octokit.pulls.list
+    .mockResolvedValueOnce({
+      data: [
+        {
+          number: 205,
+          state: 'open',
+          body: 'manual direct pr',
+          title: 'Direct',
+          head: { ref: 'feature/direct-green', sha: 'sha-direct-green' },
+          base: { ref: 'main', sha: 'base-sha' },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({ data: [] });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValue({
+    data: [{ filename: 'resources/product-direct-green.yaml', status: 'modified' }],
+  });
+
+  ctx.octokit.repos.getContent.mockResolvedValueOnce({
+    data: {
+      content: Buffer.from('type: product\nname: product-direct-green\n', 'utf8').toString('base64'),
+      encoding: 'base64',
+    },
+  });
+
+  ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+    data: [{ committer: { login: 'direct-green-user' } }],
+  });
+
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 205,
+      state: 'open',
+      body: 'manual direct pr',
+      title: 'Direct',
+      head: { ref: 'feature/direct-green', sha: 'sha-direct-green' },
+      base: { ref: 'main', sha: 'base-sha' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    },
+  });
+
+  runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved after push reevaluation' } as any);
+
+  await handler(ctx);
+
+  expect(runApprovalHook).toHaveBeenCalledWith(
+    ctx,
+    { owner: 'o1', repo: 'r1' },
+    expect.objectContaining({
+      requestType: 'product',
+      resourceName: 'product-direct-green',
+      namespace: 'product-direct-green',
+    })
+  );
+  expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+    expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 205, event: 'APPROVE' })
+  );
+  expect(tryMergeIfGreen).toHaveBeenCalledWith(
+    ctx,
+    expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 205, mergeMethod: 'squash' })
+  );
+  expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
 
   setTimeoutSpy.mockRestore();
 });
@@ -3806,6 +4794,65 @@ test('issues.opened: non-object request config falls back to sorted workflow app
   await handler(ctx);
 
   expect((ensureAssigneesOnce as jest.Mock).mock.calls.at(-1)?.[3]).toEqual(['zoe']);
+});
+
+test('issues.opened: routing lock marker update failure is tolerated', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const ctx = mkIssuesContext({
+    action: 'opened',
+    issue: {
+      number: 88,
+      title: 'Request',
+      body: 'Body',
+      labels: [{ name: 'route-1' }],
+      user: { login: 'alice' },
+      state: 'open',
+    },
+    withCachedConfig: true,
+  });
+
+  ctx.octokit.issues.update.mockRejectedValueOnce(new Error('cannot persist routing lock')).mockResolvedValue({});
+
+  await handler(ctx);
+
+  expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+    expect.objectContaining({
+      owner: 'o',
+      repo: 'r',
+      issue_number: 88,
+      body: expect.stringContaining('nsreq:routing-lock'),
+    })
+  );
+});
+
+test('issues.opened: routing label lock falls back to payload labels when label refresh fails', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const handler = handlers['issues.opened'][0];
+  const ctx = mkIssuesContext({
+    action: 'opened',
+    issue: {
+      number: 89,
+      title: 'Request',
+      body: 'Body\n\n<!-- nsreq:routing-lock = {"v":1,"expected":"route-1"} -->',
+      labels: [{ name: 'route-1' }, { name: 'route-2' }],
+      user: { login: 'alice' },
+      state: 'open',
+    },
+    withCachedConfig: true,
+  });
+
+  ctx.octokit.issues.get.mockRejectedValueOnce(new Error('label refresh failed'));
+
+  await handler(ctx);
+
+  expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+    expect.objectContaining({ owner: 'o', repo: 'r', issue_number: 89, name: 'route-2' })
+  );
 });
 
 test('issues.opened: request config without own approver arrays falls back to workflow approvers', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2276,6 +2276,9 @@ public
 
   test('check_suite.success: direct PR without snapshot hash uses approved onApproval result and merges', async () => {
     const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
       workflow: {
         labels: { approvalSuccessful: ['Approved'] },
         approvers: [],
@@ -2299,6 +2302,15 @@ public
     ctx.octokit.pulls.list
       .mockResolvedValueOnce({ data: [{ number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } }] })
       .mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-five.yaml', status: 'modified' }],
+    });
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-five\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
 
     ctx.octokit.issues.get.mockResolvedValueOnce({
       data: {
@@ -2326,7 +2338,7 @@ public
     expect(runApprovalHook).toHaveBeenCalledWith(
       ctx,
       { owner: 'o1', repo: 'r1' },
-      expect.objectContaining({ requestAuthorId: 'ignored-author' })
+      expect.objectContaining({ requestAuthorId: 'author' })
     );
     expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ['Approved'] }));
   });
@@ -2633,6 +2645,16 @@ public
   });
 
   test('check_suite.success: direct PR without snapshot hash rejects and closes PR plus request', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
     const { app, handlers } = mkApp();
     requestHandler(app);
 
@@ -2645,9 +2667,19 @@ public
       ownerLogin: 'o1',
       repoName: 'r1',
       withCachedConfig: true,
+      config: cfg,
     });
 
     ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] }).mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-five.yaml', status: 'modified' }],
+    });
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-five\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
     ctx.octokit.issues.get.mockResolvedValueOnce({
       data: {
         number: 1,
@@ -2683,6 +2715,16 @@ public
   });
 
   test('check_suite.success: direct PR without snapshot hash posts unknown feedback and does not merge', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
     const { app, handlers } = mkApp();
     requestHandler(app);
 
@@ -2694,11 +2736,21 @@ public
       ownerLogin: 'o1',
       repoName: 'r1',
       withCachedConfig: true,
+      config: cfg,
     });
 
     ctx.octokit.pulls.list
       .mockResolvedValueOnce({ data: [{ number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } }] })
       .mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-five.yaml', status: 'modified' }],
+    });
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-five\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
 
     ctx.octokit.issues.get.mockResolvedValueOnce({
       data: {
@@ -2720,13 +2772,7 @@ public
     await handler(ctx);
 
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
-    expect(postOnce).toHaveBeenCalledWith(
-      ctx,
-      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 5 }),
-      expect.stringContaining('## onApproval feedback'),
-      expect.anything()
-    );
-    expect(postedBodies()).toContain('manual review required');
+    expect(postOnce).not.toHaveBeenCalled();
   });
 
   test('check_suite.success: standalone direct PR resolves request type from doc type and uses default approval review body', async () => {
@@ -3379,6 +3425,16 @@ test('status: without jest worker id skips non-form linked issues outside test r
 });
 
 test('push: default branch push updates approved green registry PR branches', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
   const { app, handlers } = mkApp();
   requestHandler(app);
 
@@ -3387,15 +3443,14 @@ test('push: default branch push updates approved green registry PR branches', as
     owner: 'o1',
     repo: 'r1',
     withCachedConfig: true,
-    config: {
-      requests: {
-        product: { folderName: 'resources' },
-      },
-      workflow: {
-        labels: { approvalSuccessful: ['Approved'] },
-        approvers: [],
-      },
-    },
+    config: cfg,
+  });
+
+  loadStaticConfig.mockResolvedValueOnce({
+    config: cfg,
+    source: 'mock',
+    hooks: null,
+    hooksSource: null,
   });
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
@@ -3409,20 +3464,18 @@ test('push: default branch push updates approved green registry PR branches', as
     commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
   };
 
-  ctx.octokit.pulls.list
-    .mockResolvedValueOnce({
-      data: [
-        {
-          number: 201,
-          state: 'open',
-          body: 'manual direct pr',
-          title: 'Direct',
-          head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
-          base: { ref: 'main', sha: 'base-sha' },
-        },
-      ],
-    })
-    .mockResolvedValueOnce({ data: [] });
+  ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({
+    data: [
+      {
+        number: 201,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/approved-green', sha: 'sha-approved-green' },
+        base: { ref: 'main', sha: 'base-sha' },
+      },
+    ],
+  });
 
   ctx.octokit.pulls.listFiles.mockResolvedValue({
     data: [{ filename: 'resources/product-approved.yaml', status: 'modified' }],
@@ -3464,6 +3517,16 @@ test('push: default branch push updates approved green registry PR branches', as
 });
 
 test('push: approved review remains eligible for branch update after later comment-only review', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
   const { app, handlers } = mkApp();
   requestHandler(app);
 
@@ -3472,15 +3535,14 @@ test('push: approved review remains eligible for branch update after later comme
     owner: 'o1',
     repo: 'r1',
     withCachedConfig: true,
-    config: {
-      requests: {
-        product: { folderName: 'resources' },
-      },
-      workflow: {
-        labels: { approvalSuccessful: ['Approved'] },
-        approvers: [],
-      },
-    },
+    config: cfg,
+  });
+
+  loadStaticConfig.mockResolvedValueOnce({
+    config: cfg,
+    source: 'mock',
+    hooks: null,
+    hooksSource: null,
   });
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
@@ -3494,20 +3556,18 @@ test('push: approved review remains eligible for branch update after later comme
     commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
   };
 
-  ctx.octokit.pulls.list
-    .mockResolvedValueOnce({
-      data: [
-        {
-          number: 202,
-          state: 'open',
-          body: 'manual direct pr',
-          title: 'Direct',
-          head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
-          base: { ref: 'main', sha: 'base-sha' },
-        },
-      ],
-    })
-    .mockResolvedValueOnce({ data: [] });
+  ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({
+    data: [
+      {
+        number: 202,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/review-commented', sha: 'sha-review-commented' },
+        base: { ref: 'main', sha: 'base-sha' },
+      },
+    ],
+  });
 
   ctx.octokit.pulls.listFiles.mockResolvedValue({
     data: [{ filename: 'resources/product-commented.yaml', status: 'modified' }],
@@ -3562,6 +3622,16 @@ test('push: approved review remains eligible for branch update after later comme
 });
 
 test('push: changes requested review blocks approved-label based branch update', async () => {
+  const cfg = {
+    requests: {
+      product: { folderName: 'resources' },
+    },
+    workflow: {
+      labels: { approvalSuccessful: ['Approved'] },
+      approvers: [],
+    },
+  };
+
   const { app, handlers } = mkApp();
   requestHandler(app);
 
@@ -3570,15 +3640,14 @@ test('push: changes requested review blocks approved-label based branch update',
     owner: 'o1',
     repo: 'r1',
     withCachedConfig: true,
-    config: {
-      requests: {
-        product: { folderName: 'resources' },
-      },
-      workflow: {
-        labels: { approvalSuccessful: ['Approved'] },
-        approvers: [],
-      },
-    },
+    config: cfg,
+  });
+
+  loadStaticConfig.mockResolvedValueOnce({
+    config: cfg,
+    source: 'mock',
+    hooks: null,
+    hooksSource: null,
   });
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((() => {
@@ -3592,20 +3661,18 @@ test('push: changes requested review blocks approved-label based branch update',
     commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
   };
 
-  ctx.octokit.pulls.list
-    .mockResolvedValueOnce({
-      data: [
-        {
-          number: 203,
-          state: 'open',
-          body: 'manual direct pr',
-          title: 'Direct',
-          head: { ref: 'feature/changes-requested', sha: 'sha-changes-requested' },
-          base: { ref: 'main', sha: 'base-sha' },
-        },
-      ],
-    })
-    .mockResolvedValueOnce({ data: [] });
+  ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({
+    data: [
+      {
+        number: 203,
+        state: 'open',
+        body: 'manual direct pr',
+        title: 'Direct',
+        head: { ref: 'feature/changes-requested', sha: 'sha-changes-requested' },
+        base: { ref: 'main', sha: 'base-sha' },
+      },
+    ],
+  });
 
   ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
     data: [{ filename: 'resources/product-changes-requested.yaml', status: 'modified' }],


### PR DESCRIPTION
## Summary
- re-evaluate open direct PRs on every default branch push
- use the latest default branch config for old direct PRs
- improve linked issue detection and requester resolution

## Changes
- trigger direct PR re-evaluation on every default branch push
- no longer limit re-evaluation to config file changes only
- detect linked issues from PR body, title, and branch name
- avoid falling back to bot users as requester for linked direct PRs

## Result
- older open direct PRs are now checked against the latest main config
- matching direct PRs can be auto-approved later
- branch update and merge flow stays unchanged