### PR TITLE
fix: update approved registry PRs sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Changed
+
+- Approved registry PR branch updates now run sequentially.
+- Only approved registry PRs are considered for branch updates.
+- Registry PRs are processed from newest to oldest.
+- The bot now prevents multiple registry PR update pipelines from running at once.
+
+### Added
+
+- Approval detection from auto-approval reviews.
+- Approval detection from manual PR reviews.
+- Approval detection from the approved label.
+- Queue continuation after the current PR finishes.
+
+### Fixed
+
+- Prevented parallel CI runs caused by multiple registry PR branch updates.
+- Reduced unnecessary updateBranch calls.
+- Improved controlled processing of registry PR maintenance.
+
 ## [[0.1.2](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.2)] - 2026-04-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.0",
+  "version": "0.1.3-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "global-registry-bot",
-      "version": "0.1.0",
+      "version": "0.1.3-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.18.0",
@@ -5024,9 +5024,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5041,9 +5038,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5058,9 +5052,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5075,9 +5066,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5092,9 +5080,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5109,9 +5094,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5126,9 +5108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5143,9 +5122,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3",
+  "version": "0.1.3-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.3-dev.1",
+  "version": "0.1.3",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2183,6 +2183,28 @@ async function hasApprovedReviewOnPr(
   }
 }
 
+async function hasApprovedLabelOnPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<boolean> {
+  const eff = resolveEffectiveConstants(context);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+  if (!approvedLabel) return false;
+
+  try {
+    const labels = await fetchIssueLabels(context, {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      issue_number: prNumber,
+    });
+
+    return labelsMatching(labels, approvedLabel).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 async function isPullRequestApprovedForBranchMaintenance(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -2201,6 +2223,10 @@ async function isPullRequestApprovedForBranchMaintenance(
   }
 
   if (await hasApprovedReviewOnPr(context, repoInfo, pr.number)) {
+    return true;
+  }
+
+  if (await hasApprovedLabelOnPr(context, repoInfo, pr.number)) {
     return true;
   }
 
@@ -2435,6 +2461,7 @@ type SequentialRegistryPrCandidate = {
   freshPr: PullRequestLike;
   changedRegistryFiles: string[];
   mustUpdate: boolean;
+  approvedForUpdate: boolean;
 };
 
 type SequentialRegistryPrActive = {
@@ -2912,7 +2939,13 @@ async function runMergeApprovedPrOrUpdateBranch(
   }
 
   if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
-    await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-before-merge`);
+    await requestPullRequestBranchUpdateRespectingSequentialRegistryQueue(
+      context,
+      repoInfo,
+      currentPr,
+      baseBranch,
+      `${reason}:behind-before-merge`
+    );
     return;
   }
 
@@ -3037,7 +3070,13 @@ async function runMergeApprovedPrOrUpdateBranch(
       }
 
       if (await shouldUpdatePullRequestBranch(context, repoInfo, currentPr, baseBranch)) {
-        await requestPullRequestBranchUpdate(context, repoInfo, currentPr, `${reason}:behind-after-merge-attempt`);
+        await requestPullRequestBranchUpdateRespectingSequentialRegistryQueue(
+          context,
+          repoInfo,
+          currentPr,
+          baseBranch,
+          `${reason}:behind-after-merge-attempt`
+        );
         return;
       }
 
@@ -3080,7 +3119,13 @@ async function runMergeApprovedPrOrUpdateBranch(
         const freshPr = (await readFreshPullRequest(context, repoInfo, currentPr.number)) || currentPr;
 
         if (await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch)) {
-          await requestPullRequestBranchUpdate(context, repoInfo, freshPr, `${reason}:merge-failed-outdated`);
+          await requestPullRequestBranchUpdateRespectingSequentialRegistryQueue(
+            context,
+            repoInfo,
+            freshPr,
+            baseBranch,
+            `${reason}:merge-failed-outdated`
+          );
         } else {
           log(
             context,
@@ -3190,6 +3235,14 @@ async function processPullRequestForAutoMerge(
   repoInfo: RepoInfo,
   pr: PullRequestLike
 ): Promise<void> {
+  const prBaseBranch = toStringTrim(pr.base?.ref);
+
+  if (await isSequentialDirectRegistryPr(context, repoInfo, pr, prBaseBranch)) {
+    if (await shouldDeferSequentialDirectRegistryPrProcessing(context, repoInfo, pr)) {
+      return;
+    }
+  }
+
   const issueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
 
   if (issueNumber === null) {
@@ -3437,7 +3490,7 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
 
   const openPrs = await listOpenPullRequests(context, repoInfo);
 
-  for (const pr of openPrs.sort((a, b) => a.number - b.number)) {
+  for (const pr of openPrs.sort((a, b) => b.number - a.number)) {
     const headSha = toStringTrim(pr.head?.sha);
 
     if (!headSha) continue;
@@ -3449,6 +3502,19 @@ async function updateApprovedOpenPullRequestBranchesAfterDefaultBranchPush(
 
       if (!changedRegistryFiles.length) {
         log(context, 'info', { prNumber: pr.number, reason }, 'skip branch update: no registry yaml files changed');
+        continue;
+      }
+
+      if (!isSnapshotManagedRequestPr(pr)) {
+        log(
+          context,
+          'info',
+          {
+            prNumber: pr.number,
+            reason,
+          },
+          'skip branch update: direct registry PR handled by sequential queue'
+        );
         continue;
       }
 
@@ -4344,6 +4410,104 @@ async function isSequentialRegistryPrActiveBlocking(
   return true;
 }
 
+async function isSequentialDirectRegistryPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch?: string
+): Promise<boolean> {
+  const targetBaseBranch = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
+  if (!targetBaseBranch) return false;
+  if (isSnapshotManagedRequestPr(pr)) return false;
+  if (!pullRequestTargetsBranch(pr, targetBaseBranch)) return false;
+
+  const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, targetBaseBranch);
+  return changedRegistryFiles.length > 0;
+}
+
+async function shouldDeferSequentialDirectRegistryPrProcessing(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<boolean> {
+  const active = getSequentialRegistryPrActive(repoInfo);
+  if (!active || active.prNumber === pr.number) return false;
+
+  if (!(await isSequentialRegistryPrActiveBlocking(context, repoInfo))) {
+    return false;
+  }
+
+  const currentActive = getSequentialRegistryPrActive(repoInfo);
+  if (!currentActive || currentActive.prNumber === pr.number) {
+    return false;
+  }
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      activePrNumber: currentActive.prNumber,
+      activeHeadSha: currentActive.startedHeadSha,
+    },
+    'sequential-registry-pr:auto-merge-deferred'
+  );
+
+  return true;
+}
+
+async function requestPullRequestBranchUpdateRespectingSequentialRegistryQueue(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch: string,
+  reason: string
+): Promise<boolean> {
+  const targetBaseBranch = toStringTrim(baseBranch) || toStringTrim(pr.base?.ref);
+
+  if (!(await isSequentialDirectRegistryPr(context, repoInfo, pr, targetBaseBranch))) {
+    return await requestPullRequestBranchUpdate(context, repoInfo, pr, reason);
+  }
+
+  const active = getSequentialRegistryPrActive(repoInfo);
+
+  if (active && active.prNumber === pr.number) {
+    const requested = await requestPullRequestBranchUpdate(context, repoInfo, pr, reason);
+
+    if (requested) {
+      markSequentialRegistryPrActive(context, repoInfo, pr, reason);
+    }
+
+    return requested;
+  }
+
+  const result = await runOneSequentialDirectRegistryPrMaintenance(context, repoInfo, targetBaseBranch, reason);
+  return result.updated;
+}
+
+async function advanceSequentialRegistryPrQueueAfterTerminalState(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<void> {
+  const active = getSequentialRegistryPrActive(repoInfo);
+  if (!active || active.prNumber !== pr.number) return;
+
+  const freshPr = await readFreshPullRequest(context, repoInfo, pr.number);
+
+  if (freshPr && isPullRequestOpen(freshPr)) {
+    return;
+  }
+
+  clearSequentialRegistryPrActive(repoInfo);
+
+  const baseBranch = toStringTrim(freshPr?.base?.ref) || toStringTrim(pr.base?.ref);
+  if (!baseBranch) return;
+
+  await runOneSequentialDirectRegistryPrMaintenance(context, repoInfo, baseBranch, reason);
+}
+
 async function collectSequentialDirectRegistryPrCandidates(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -4353,7 +4517,7 @@ async function collectSequentialDirectRegistryPrCandidates(
   const openPrs = await listOpenPullRequests(context, repoInfo);
   const candidates: SequentialRegistryPrCandidate[] = [];
 
-  for (const pr of openPrs.sort((a, b) => a.number - b.number)) {
+  for (const pr of openPrs.sort((a, b) => b.number - a.number)) {
     const headSha = toStringTrim(pr.head?.sha);
     const linkedIssueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
     const snapshotManaged = isSnapshotManagedRequestPr(pr);
@@ -4443,6 +4607,9 @@ async function collectSequentialDirectRegistryPrCandidates(
     }
 
     const mustUpdate = await shouldUpdatePullRequestBranch(context, repoInfo, freshPr, baseBranch);
+    const approvedForUpdate = mustUpdate
+      ? await isPullRequestApprovedForBranchMaintenance(context, repoInfo, freshPr)
+      : false;
 
     log(
       context,
@@ -4454,6 +4621,7 @@ async function collectSequentialDirectRegistryPrCandidates(
         mergeable: freshPr.mergeable,
         mergeableState: readMergeableState(freshPr),
         mustUpdate,
+        approvedForUpdate,
       },
       'direct-pr-reeval:update-check'
     );
@@ -4463,6 +4631,7 @@ async function collectSequentialDirectRegistryPrCandidates(
       freshPr,
       changedRegistryFiles,
       mustUpdate,
+      approvedForUpdate,
     });
   }
 
@@ -4487,7 +4656,7 @@ async function runOneSequentialDirectRegistryPrMaintenance(
 
     const candidates = await collectSequentialDirectRegistryPrCandidates(context, repoInfo, baseBranch, reason);
 
-    for (const candidate of candidates.filter((item) => item.mustUpdate)) {
+    for (const candidate of candidates.filter((item) => item.mustUpdate && item.approvedForUpdate)) {
       const requested = await requestPullRequestBranchUpdate(
         context,
         repoInfo,
@@ -7022,6 +7191,12 @@ export default function requestHandler(app: Probot): void {
       try {
         await processPullRequestForAutoMerge(context, repoInfo, pr);
         await releaseSequentialRegistryPrIfNotApprovedAfterGreen(context, repoInfo, pr);
+        await advanceSequentialRegistryPrQueueAfterTerminalState(
+          context,
+          repoInfo,
+          pr,
+          'sequential-direct-pr:advance-after-terminal-state'
+        );
       } catch (e: unknown) {
         log(
           context,
@@ -7034,8 +7209,32 @@ export default function requestHandler(app: Probot): void {
         );
 
         const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+        const baseBranch = toStringTrim(freshPr.base?.ref) || toStringTrim(pr.base?.ref);
+        const isSequentialDirectRegistry = baseBranch
+          ? await isSequentialDirectRegistryPr(context, repoInfo, freshPr, baseBranch)
+          : false;
+
+        if (!isSequentialDirectRegistry) {
+          continue;
+        }
+
+        const active = getSequentialRegistryPrActive(repoInfo);
+        const wasActiveSequentialPr = active?.prNumber === freshPr.number || active?.prNumber === pr.number;
+
         markSequentialRegistryPrHeadSkipped(context, repoInfo, freshPr, 'auto-merge-candidate-processing-failed');
-        clearSequentialRegistryPrActive(repoInfo);
+
+        if (wasActiveSequentialPr) {
+          clearSequentialRegistryPrActive(repoInfo);
+
+          if (baseBranch) {
+            await runOneSequentialDirectRegistryPrMaintenance(
+              context,
+              repoInfo,
+              baseBranch,
+              'sequential-direct-pr:advance-after-processing-failure'
+            );
+          }
+        }
       }
     }
   };

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2208,19 +2208,36 @@ async function isPullRequestApprovedForBranchMaintenance(
   repoInfo: RepoInfo,
   pr: PullRequestLike
 ): Promise<boolean> {
-  if (await hasBlockingChangesRequestedReviewOnPr(context, repoInfo, pr.number)) {
+  let reviews: PullRequestReviewLike[];
+  try {
+    reviews = await listPullRequestReviews(context, repoInfo, pr.number);
+  } catch {
+    reviews = [];
+  }
+
+  const latestStates = getLatestActionableReviewStates(reviews);
+  const latestStateValues = new Set(latestStates.values());
+
+  if (latestStateValues.has('CHANGES_REQUESTED')) {
     return false;
   }
 
   if (isSnapshotManagedRequestPr(pr)) return true;
 
   const headSha = toStringTrim(pr.head?.sha);
+  const marker = headSha ? buildAutoApprovalReviewMarker(headSha) : null;
 
-  if (headSha && (await hasAutoApprovalReviewForHead(context, repoInfo, pr.number, headSha))) {
+  if (
+    marker &&
+    reviews.some(
+      (review) =>
+        toStringTrim(review?.state).toUpperCase() === 'APPROVED' && toStringTrim(review?.body).includes(marker)
+    )
+  ) {
     return true;
   }
 
-  if (await hasApprovedReviewOnPr(context, repoInfo, pr.number)) {
+  if (latestStateValues.has('APPROVED')) {
     return true;
   }
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2148,39 +2148,6 @@ function getLatestActionableReviewStates(reviews: PullRequestReviewLike[]): Map<
   return latestByReviewer;
 }
 
-async function hasBlockingChangesRequestedReviewOnPr(
-  context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo,
-  prNumber: number
-): Promise<boolean> {
-  try {
-    const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
-    const latestStates = new Set(getLatestActionableReviewStates(reviews).values());
-
-    return latestStates.has('CHANGES_REQUESTED');
-  } catch {
-    return false;
-  }
-}
-
-async function hasApprovedReviewOnPr(
-  context: BotContext<RequestEvents>,
-  repoInfo: RepoInfo,
-  prNumber: number
-): Promise<boolean> {
-  try {
-    const reviews = await listPullRequestReviews(context, repoInfo, prNumber);
-
-    const latestStates = new Set(getLatestActionableReviewStates(reviews).values());
-
-    if (latestStates.has('CHANGES_REQUESTED')) return false;
-
-    return latestStates.has('APPROVED');
-  } catch {
-    return false;
-  }
-}
-
 async function hasApprovedLabelOnPr(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -4427,8 +4427,23 @@ async function isSequentialDirectRegistryPr(
   if (isSnapshotManagedRequestPr(pr)) return false;
   if (!pullRequestTargetsBranch(pr, targetBaseBranch)) return false;
 
-  const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, targetBaseBranch);
-  return changedRegistryFiles.length > 0;
+  try {
+    const changedRegistryFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, targetBaseBranch);
+    return changedRegistryFiles.length > 0;
+  } catch (error) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        baseBranch: targetBaseBranch,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'sequential-registry-pr:changed-files-lookup-failed'
+    );
+
+    return false;
+  }
 }
 
 async function shouldDeferSequentialDirectRegistryPrProcessing(


### PR DESCRIPTION
## Summary

This change fixes the sequential registry PR update flow.

## What changed

- only approved registry PRs are considered for branch updates
- accept approval from auto-approval, manual review, or approved label
- process registry PRs one by one instead of in parallel
- handle PRs from newest to oldest
- prevent multiple registry PR pipelines from starting at the same time
- continue with the next PR after the current one finishes

## Result

Registry PR updates now run in a controlled sequence and avoid unnecessary parallel CI runs.