### PR TITLE
fix: support hook approvers for standalone PR and issue approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Added
+
+- Approval comments are now supported directly on standalone direct PRs.
+- Standalone PR approval checks now include hook-provided approvers.
+- Request issue approval checks also include hook-provided approvers.
+
+### Changed
+
+- onApproval approvers are preserved and reused in PR and issue approval flows.
+- Standalone PRs with manual hook approvers can now be approved properly.
+- Existing auto-approval logic remains unchanged.
+
+### Fixed
+
+- Fixed standalone PRs getting stuck when onApproval returned manual approvers.
+- Fixed issue approval comments ignoring hook-provided approvers.
+- Fixed missing manual approval path for standalone direct PRs.
+
 ## [[0.1.4](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.4)] - 2026-04-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.0",
+  "version": "0.1.3-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "global-registry-bot",
-      "version": "0.1.0",
+      "version": "0.1.3-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.18.0",
@@ -5024,9 +5024,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5041,9 +5038,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5058,9 +5052,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5075,9 +5066,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5092,9 +5080,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5109,9 +5094,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5126,9 +5108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5143,9 +5122,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.4-dev.1",
+  "version": "0.1.5",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.4",
+  "version": "0.1.4-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1569,6 +1569,97 @@ async function fetchIssueLabels(
   return toLabelNames(issue.labels);
 }
 
+const ENSURE_LABELS_INFLIGHT = new Map<string, Promise<void>>();
+const ON_APPROVAL_UNKNOWN_POST_INFLIGHT = new Map<string, Promise<void>>();
+
+function issueScopedKey(params: IssueParams, suffix: string): string {
+  return `${params.owner}/${params.repo}#${params.issue_number}:${suffix}`.toLowerCase();
+}
+
+async function ensureLabelsPresentOnce(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  labels: string[]
+): Promise<void> {
+  const targetLabels = Array.from(new Set((labels || []).map(toStringTrim).filter(Boolean)));
+  if (!targetLabels.length) return;
+
+  const key = issueScopedKey(params, `labels:${targetLabels.map(normalizeKey).sort().join('|')}`);
+  const existing = ENSURE_LABELS_INFLIGHT.get(key);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const pending = (async (): Promise<void> => {
+    let currentLabels: string[] = [];
+
+    try {
+      currentLabels = await fetchIssueLabels(context, params);
+    } catch {
+      currentLabels = [];
+    }
+
+    const currentKeys = new Set(currentLabels.map(normalizeKey).filter(Boolean));
+    const missing = targetLabels.filter((label) => {
+      const key = normalizeKey(label);
+      return key && !currentKeys.has(key);
+    });
+
+    if (!missing.length) return;
+
+    try {
+      await context.octokit.issues.addLabels({
+        ...params,
+        labels: missing,
+      });
+    } catch (error: unknown) {
+      const status = getHttpStatus(error);
+      if (status !== 404) {
+        log(
+          context,
+          'warn',
+          {
+            err: getErrorMessage(error),
+            labels: missing,
+            issueNumber: params.issue_number,
+          },
+          'failed to ensure labels'
+        );
+      }
+    }
+  })().finally(() => {
+    ENSURE_LABELS_INFLIGHT.delete(key);
+  });
+
+  ENSURE_LABELS_INFLIGHT.set(key, pending);
+  await pending;
+}
+
+async function postApprovalUnknownOnce(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  decision: ApprovalDecision
+): Promise<void> {
+  const key = issueScopedKey(params, 'on-approval-unknown');
+  const existing = ON_APPROVAL_UNKNOWN_POST_INFLIGHT.get(key);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const pending = (async (): Promise<void> => {
+    await postOnce(context, params, buildApprovalUnknownBody(decision), {
+      minimizeTag: 'nsreq:on-approval:unknown',
+    });
+  })().finally(() => {
+    ON_APPROVAL_UNKNOWN_POST_INFLIGHT.delete(key);
+  });
+
+  ON_APPROVAL_UNKNOWN_POST_INFLIGHT.set(key, pending);
+  await pending;
+}
+
 async function ensureAssigneesPresent(
   context: BotContext<RequestEvents>,
   params: IssueParams,
@@ -1643,16 +1734,7 @@ async function handoverToCpa(
 
   const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
 
-  if (labelsToAdd.length) {
-    try {
-      await context.octokit.issues.addLabels({
-        ...params,
-        labels: labelsToAdd,
-      });
-    } catch {
-      /* empty */
-    }
-  }
+  await ensureLabelsPresentOnce(context, params, labelsToAdd);
 
   if (eff.labelOnApproved) {
     try {
@@ -5221,20 +5303,8 @@ async function handoverStandaloneDirectPrToReview(
 
   const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
 
-  if (labelsToAdd.length) {
-    try {
-      await context.octokit.issues.addLabels({
-        ...params,
-        labels: labelsToAdd,
-      });
-    } catch {
-      // ignore
-    }
-  }
-
-  await postOnce(context, params, buildApprovalUnknownBody(decision), {
-    minimizeTag: 'nsreq:on-approval:unknown',
-  });
+  await ensureLabelsPresentOnce(context, params, labelsToAdd);
+  await postApprovalUnknownOnce(context, params, decision);
 }
 
 async function handleDirectPrApprovalComment(
@@ -5526,9 +5596,7 @@ async function maybeHandleApprovalDecision(
   }
 
   if (decision.status === 'unknown') {
-    await postOnce(context, params, buildApprovalUnknownBody(decision), {
-      minimizeTag: 'nsreq:on-approval:unknown',
-    });
+    await postApprovalUnknownOnce(context, params, decision);
   }
 
   return 'continue';
@@ -5600,11 +5668,10 @@ async function maybeHandleDirectPrApprovalForMerge(
   }
 
   if (decision.status === 'unknown') {
-    await postOnce(
+    await postApprovalUnknownOnce(
       context,
       { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
-      buildApprovalUnknownBody(decision),
-      { minimizeTag: 'nsreq:on-approval:unknown' }
+      decision
     );
   }
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -5297,7 +5297,6 @@ async function handoverStandaloneDirectPrToReview(
   const assignees = uniqLogins([...hookApprovers, ...configuredApprovers]);
 
   if (assignees.length) {
-    await ensureAssigneesOnce(context, params, pr as unknown as IssueLike, assignees);
     await ensureAssigneesPresent(context, params, assignees);
   }
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -6789,13 +6789,15 @@ async function postRoutingLockNoticeOnce(
     return;
   }
 
-  const p = (async (): Promise<void> => {
-    await postOnce(context, params, `Routing label is locked to "${expected}". Manual changes were reverted.`, {
-      minimizeTag: 'nsreq:routing-label-lock',
+  const p = Promise.resolve()
+    .then(async (): Promise<void> => {
+      await postOnce(context, params, `Routing label is locked to "${expected}". Manual changes were reverted.`, {
+        minimizeTag: 'nsreq:routing-label-lock',
+      });
+    })
+    .finally(() => {
+      ROUTING_LOCK_NOTICE_INFLIGHT.delete(key);
     });
-  })().finally(() => {
-    ROUTING_LOCK_NOTICE_INFLIGHT.delete(key);
-  });
 
   ROUTING_LOCK_NOTICE_INFLIGHT.set(key, p);
   await p;

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1612,49 +1612,6 @@ async function ensureAssigneesPresent(
   }
 }
 
-async function resolveAdditionalIssueApproversFromApprovalHook(
-  context: BotContext<RequestEvents>,
-  params: IssueParams,
-  issue: IssueLike,
-  template: TemplateLike,
-  parsedFormData: FormData,
-  requestType: string
-): Promise<string[]> {
-  try {
-    const resourceName = extractResourceNameFromForm(parsedFormData, template);
-    const namespace = toStringTrim((parsedFormData as Record<string, unknown>)['namespace']) || resourceName;
-
-    const decision = normalizeApprovalDecision(
-      await runApprovalHook(
-        context,
-        { owner: params.owner, repo: params.repo },
-        {
-          requestType,
-          namespace,
-          resourceName,
-          formData: parsedFormData,
-          issue,
-        }
-      )
-    );
-
-    if (decision.status !== 'unknown') return [];
-    return uniqLogins(decision.approvers || []);
-  } catch (e: unknown) {
-    log(
-      context,
-      'warn',
-      {
-        err: e instanceof Error ? e.message : String(e),
-        issueNumber: issue.number,
-      },
-      'failed to resolve additional issue approvers from onApproval hook'
-    );
-
-    return [];
-  }
-}
-
 async function handoverToCpa(
   context: BotContext<RequestEvents>,
   params: IssueParams,
@@ -1907,14 +1864,16 @@ function buildApprovalDecisionJson(decision: ApprovalDecision): string {
 function normalizeApprovalDecision(decision: ApprovalDecision | boolean): ApprovalDecision {
   if (decision === true) return { status: 'approved' };
   if (decision === false) return {};
+  if (!decision) return {};
 
-  const normalized = decision || {};
-  const approvers = uniqLogins(
-    Array.isArray(normalized.approvers) ? normalized.approvers.map((x) => toStringTrim(x)).filter(Boolean) : []
-  );
+  const rawApprovers = Array.isArray((decision as { approvers?: unknown }).approvers)
+    ? ((decision as { approvers?: unknown[] }).approvers ?? [])
+    : [];
+
+  const approvers = uniqLogins(rawApprovers.map((value) => normalizeLogin(value)).filter(Boolean));
 
   return {
-    ...normalized,
+    ...decision,
     ...(approvers.length ? { approvers } : {}),
   };
 }
@@ -5128,8 +5087,9 @@ async function evaluateDirectPrOnApproval(
   }
 
   let sawApproved = false;
-  let sawUnknown = false;
+  let sawNonApproved = false;
   let approvedComment = '';
+  let firstUnknownDecision: ApprovalDecision | null = null;
 
   for (const filePath of changedFiles) {
     const decision = await evaluateChangedResourceApproval(context, repoInfo, pr, filePath, requestAuthorId);
@@ -5159,17 +5119,100 @@ async function evaluateDirectPrOnApproval(
       continue;
     }
 
-    sawUnknown = true;
+    sawNonApproved = true;
+    if (decision.status === 'unknown' && !firstUnknownDecision) {
+      firstUnknownDecision = decision;
+    }
   }
 
-  if (sawApproved && !sawUnknown) {
+  if (sawApproved && !sawNonApproved) {
     return {
       status: 'approved',
       ...(approvedComment ? { comment: approvedComment } : {}),
     };
   }
 
+  if (firstUnknownDecision) {
+    return firstUnknownDecision;
+  }
+
   return {};
+}
+
+async function resolveDirectPrRequestTypes(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  options: DirectPrApprovalOptions = {}
+): Promise<string[]> {
+  const changedFiles = await listChangedYamlFilesForPrWithFallback(context, repoInfo, pr, options.baseBranch);
+  const requestTypes: string[] = [];
+
+  for (const filePath of changedFiles) {
+    const parsed = await readRegistryDocForApproval(context, repoInfo, pr, filePath);
+    if (!parsed) continue;
+
+    const requestType = pickRequestTypeForChangedResource(context, filePath, parsed);
+    if (!requestType) continue;
+
+    requestTypes.push(requestType);
+  }
+
+  return Array.from(new Set(requestTypes));
+}
+
+async function handleDirectPrApprovalComment(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  commenter: string
+): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+
+  const requestTypes = await resolveDirectPrRequestTypes(context, repoInfo, pr, {
+    baseBranch: toStringTrim(pr.base?.ref),
+  });
+
+  const configuredApprovers = uniqLogins(
+    requestTypes.flatMap((requestType) =>
+      resolveApproversForRequestType(context, requestType, eff.approverUsernames, eff.approverPoolUsernames)
+    )
+  );
+
+  const approvalDecision = await evaluateDirectPrOnApproval(context, repoInfo, pr, undefined, {
+    baseBranch: toStringTrim(pr.base?.ref),
+  });
+
+  if (approvalDecision.status === 'rejected') {
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      buildApprovalRejectedBody(approvalDecision),
+      { minimizeTag: 'nsreq:on-approval:rejected' }
+    );
+    return;
+  }
+
+  const allowedApprovers = uniqLogins([...(configuredApprovers || []), ...(approvalDecision.approvers || [])]);
+  const okApprover = isAuthorizedApprover(commenter, pr.user?.login, allowedApprovers);
+  if (!okApprover) {
+    await postOnce(
+      context,
+      { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+      `Approval ignored: commenter ${commenter} is not an allowed approver for this direct PR.`,
+      { minimizeTag: 'nsreq:approval-info' }
+    );
+    return;
+  }
+
+  const approved = await ensureAutomatedApprovalReviewForCurrentHead(context, repoInfo, pr, {
+    status: 'approved',
+    comment: `Approved by @${commenter}`,
+  });
+
+  if (!approved) return;
+
+  await tryMergeApprovedPrOrUpdateBranch(context, repoInfo, pr, 'direct-pr-manual-approval');
 }
 
 async function maybeHandleStandaloneDirectPrApproval(
@@ -5911,6 +5954,41 @@ async function processIssueEvent(
     requestType: effectiveRequestType,
     extraApprovers: hookApprovers,
   });
+}
+
+async function resolveAdditionalIssueApproversFromApprovalHook(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  issue: IssueLike,
+  template: TemplateLike,
+  parsedFormData: FormData,
+  requestType?: string
+): Promise<string[]> {
+  const effectiveRequestType = requestType || resolveEffectiveRequestType(template, parsedFormData);
+  const resourceName = extractResourceNameFromForm(parsedFormData, template);
+
+  if (!effectiveRequestType) return [];
+
+  try {
+    const decision = normalizeApprovalDecision(
+      await runApprovalHook(
+        context,
+        { owner: params.owner, repo: params.repo },
+        {
+          requestType: effectiveRequestType,
+          namespace: resourceName,
+          resourceName,
+          formData: parsedFormData,
+          issue,
+          requestAuthorId: normalizeLogin(issue.user?.login),
+        }
+      )
+    );
+
+    return uniqLogins((decision.approvers || []).filter(Boolean));
+  } catch {
+    return [];
+  }
 }
 
 async function handleApprovalComment(
@@ -7312,9 +7390,6 @@ export default function requestHandler(app: Probot): void {
       await getStaticConfig(context);
 
       const issue = context.payload.issue as unknown as IssueLike;
-      if (!process.env.JEST_WORKER_ID) {
-        if (!hasIssueFormInputs(issue)) return;
-      }
       const comment = context.payload.comment as unknown as CommentLike;
       const sender = context.payload.sender as unknown as SenderLike;
 
@@ -7338,6 +7413,23 @@ export default function requestHandler(app: Probot): void {
 
       const { owner, repo, issue_number: issueNumber } = context.issue() as IssueParams;
       const params: IssueParams = { owner, repo, issue_number: issueNumber };
+      const repoInfo: RepoInfo = { owner, repo };
+
+      const stripped = stripQuoteAndCode(comment.body || '');
+      const isApproval = isApprovalComment(context, stripped);
+
+      if (!process.env.JEST_WORKER_ID && !hasIssueFormInputs(issue)) {
+        const isPullRequestConversation = isPlainObject((issue as Record<string, unknown>)['pull_request']);
+
+        if (isPullRequestConversation && isApproval) {
+          const pr = await readFreshPullRequest(context, repoInfo, issueNumber);
+          if (pr && parseLinkedIssueNumberFromPr(pr, repoInfo) === null) {
+            await handleDirectPrApprovalComment(context, repoInfo, pr, commenter);
+          }
+        }
+
+        return;
+      }
 
       let template: TemplateLike;
       try {
@@ -7365,8 +7457,6 @@ export default function requestHandler(app: Probot): void {
         return;
       }
 
-      const stripped = stripQuoteAndCode(comment.body || '');
-      const isApproval = isApprovalComment(context, stripped);
       if (isApproval) {
         const handled = await handleParentOwnerApprovalIfNeeded(
           context,

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -2686,7 +2686,11 @@ function updateBranchInflightKey(repoInfo: RepoInfo, pr: PullRequestLike): strin
 
 function isUpdateBranchCooldownActive(key: string): boolean {
   const until = UPDATE_BRANCH_COOLDOWN_UNTIL.get(key) || 0;
-  return until > Date.now();
+  if (until <= Date.now()) {
+    UPDATE_BRANCH_COOLDOWN_UNTIL.delete(key);
+    return false;
+  }
+  return true;
 }
 
 function markUpdateBranchCooldown(key: string): void {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1878,6 +1878,30 @@ function normalizeApprovalDecision(decision: ApprovalDecision | boolean): Approv
   };
 }
 
+function isManualApprovalRequiredText(value: unknown): boolean {
+  return /\bmanual approval required\b/i.test(toStringTrim(value));
+}
+
+function getVisibleApprovalText(decision: ApprovalDecision): string {
+  const comment = toStringTrim(decision.comment);
+  if (comment && !isManualApprovalRequiredText(comment)) return comment;
+
+  const message = toStringTrim(decision.message);
+  if (message && !isManualApprovalRequiredText(message)) return message;
+
+  const reason = toStringTrim(decision.reason);
+  if (reason && !isManualApprovalRequiredText(reason)) return reason;
+
+  return '';
+}
+
+function buildAutoApprovalReviewBody(decision: ApprovalDecision, headSha: string): string {
+  const visible = getVisibleApprovalText(decision);
+  const marker = buildAutoApprovalReviewMarker(headSha);
+
+  return visible ? `${visible}\n\n${marker}` : marker;
+}
+
 function isApprovalDecisionAuthorizedByHookApprovers(
   decision: ApprovalDecision,
   requesterId: string | undefined | null
@@ -1901,10 +1925,9 @@ function promoteUnknownApprovalDecisionForDirectPrRequester(
   return {
     ...normalized,
     status: 'approved',
-    comment:
-      toStringTrim(normalized.comment) ||
-      toStringTrim(normalized.message) ||
-      `Approved automatically because the PR requester is an allowed hook approver.`,
+    comment: getVisibleApprovalText(normalized),
+    message: '',
+    reason: '',
   };
 }
 
@@ -1912,11 +1935,13 @@ function buildApprovalUnknownBody(decision: ApprovalDecision): string {
   const lead = toStringTrim(decision.message) || toStringTrim(decision.comment) || toStringTrim(decision.reason);
   const leadBlock = lead ? `${lead}\n\n` : '';
 
-  return `## onApproval feedback
+  return `${leadBlock}<details>
+<summary>Decision details</summary>
 
-${leadBlock}\`\`\`json
+\`\`\`json
 ${buildApprovalDecisionJson({ status: 'unknown', ...decision })}
 \`\`\`
+</details>
 
 Continuing with the standard review flow.`;
 }
@@ -1968,9 +1993,9 @@ async function createAutomatedApprovalReview(
   pr: PullRequestLike,
   decision: ApprovalDecision
 ): Promise<boolean> {
-  const body =
-    toStringTrim(decision.comment) || toStringTrim(decision.message) || 'Approved automatically by onApproval hook.';
-  const reviewBody = `${body}\n\n${buildAutoApprovalReviewMarker(pr.head?.sha || '')}`;
+  const headSha = toStringTrim(pr.head?.sha);
+  const reviewBody = buildAutoApprovalReviewBody(decision, headSha);
+  const failureText = getVisibleApprovalText(decision) || 'The onApproval hook matched this PR.';
 
   try {
     await (
@@ -1996,7 +2021,7 @@ async function createAutomatedApprovalReview(
       'info',
       {
         prNumber: pr.number,
-        headSha: toStringTrim(pr.head?.sha),
+        headSha,
       },
       'automated PR approval review created'
     );
@@ -2030,11 +2055,11 @@ async function createAutomatedApprovalReview(
       { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
       `## onApproval matched, but automatic PR approval failed
 
-  ${body}
+${failureText}
 
-  Approval API error: ${message}${status ? ` (HTTP ${status})` : ''}
+Approval API error: ${message}${status ? ` (HTTP ${status})` : ''}
 
-  The PR could not be approved automatically, so merge remains blocked until a review is added manually.`,
+The PR could not be approved automatically, so merge remains blocked until a review is added manually.`,
       { minimizeTag: 'nsreq:on-approval:approve-failed' }
     );
 
@@ -5136,6 +5161,13 @@ async function evaluateDirectPrOnApproval(
     return firstUnknownDecision;
   }
 
+  if (sawNonApproved) {
+    return {
+      status: 'unknown',
+      reason: 'Manual review required because onApproval did not approve all changed registry files.',
+    };
+  }
+
   return {};
 }
 
@@ -5159,6 +5191,50 @@ async function resolveDirectPrRequestTypes(
   }
 
   return Array.from(new Set(requestTypes));
+}
+
+async function handoverStandaloneDirectPrToReview(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  decision: ApprovalDecision,
+  options: DirectPrApprovalOptions = {}
+): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+  const params: IssueParams = { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number };
+
+  const requestTypes = await resolveDirectPrRequestTypes(context, repoInfo, pr, options);
+
+  const configuredApprovers = uniqLogins(
+    requestTypes.flatMap((requestType) =>
+      resolveApproversForRequestType(context, requestType, eff.approverUsernames, eff.approverPoolUsernames)
+    )
+  );
+
+  const hookApprovers = uniqLogins(decision.approvers || []);
+  const assignees = uniqLogins([...hookApprovers, ...configuredApprovers]);
+
+  if (assignees.length) {
+    await ensureAssigneesOnce(context, params, pr as unknown as IssueLike, assignees);
+    await ensureAssigneesPresent(context, params, assignees);
+  }
+
+  const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
+
+  if (labelsToAdd.length) {
+    try {
+      await context.octokit.issues.addLabels({
+        ...params,
+        labels: labelsToAdd,
+      });
+    } catch {
+      // ignore
+    }
+  }
+
+  await postOnce(context, params, buildApprovalUnknownBody(decision), {
+    minimizeTag: 'nsreq:on-approval:unknown',
+  });
 }
 
 async function handleDirectPrApprovalComment(
@@ -5250,6 +5326,11 @@ async function maybeHandleStandaloneDirectPrApproval(
     }
 
     return 'rejected';
+  }
+
+  if (decision.status === 'unknown') {
+    await handoverStandaloneDirectPrToReview(context, repoInfo, pr, decision, options);
+    return 'continue';
   }
 
   return 'continue';

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -474,6 +474,8 @@ function normalizeApprovalHookResult(value: unknown): ApprovalHookDecision {
 
   if (!isPlainObject(value)) return {};
 
+  const approvers = toLoginArray(value['approvers']);
+
   if (value['approved'] === true) {
     const comment = toStringSafe(value['comment']);
     const message = toStringSafe(value['message']);
@@ -482,6 +484,7 @@ function normalizeApprovalHookResult(value: unknown): ApprovalHookDecision {
       status: 'approved',
       ...(comment ? { comment } : {}),
       ...(message ? { message } : {}),
+      ...(approvers.length ? { approvers } : {}),
     };
   }
 
@@ -490,7 +493,6 @@ function normalizeApprovalHookResult(value: unknown): ApprovalHookDecision {
   const reason = toStringSafe(value['reason']);
   const comment = toStringSafe(value['comment']);
   const message = toStringSafe(value['message']);
-  const approvers = toLoginArray(value['approvers']);
   const errors = normalizeApprovalHookErrors(value['errors'] ?? value['error']);
 
   if (status === 'approved' || status === 'rejected' || status === 'unknown') {

--- a/test/request-orchestrator.coverage.test.ts
+++ b/test/request-orchestrator.coverage.test.ts
@@ -1118,6 +1118,46 @@ describe('request-orchestrator additional coverage', () => {
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
   });
 
+  test('status: ignores non-success state before auto-merge evaluation', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const octokit = mkOctokit();
+    const repository: Repository = { name: 'r', owner: { login: 'o' } };
+
+    const ctx = mkCtx({
+      name: 'status',
+      config: DEFAULT_CONFIG_MOCK,
+      octokit,
+      payload: { state: 'failure', repository, sha: 'head-sha' },
+    });
+
+    await expect(handlers['status']?.(ctx)).resolves.toBeUndefined();
+
+    expect(octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('status: ignores success payload without sha', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const octokit = mkOctokit();
+    const repository: Repository = { name: 'r', owner: { login: 'o' } };
+
+    const ctx = mkCtx({
+      name: 'status',
+      config: DEFAULT_CONFIG_MOCK,
+      octokit,
+      payload: { state: 'success', repository },
+    });
+
+    await expect(handlers['status']?.(ctx)).resolves.toBeUndefined();
+
+    expect(octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
   test('issues.opened: routing error is silently ignored for non-form issues', async () => {
     const { app, handlers } = mkApp();
     requestHandler(app as unknown as Probot);
@@ -1305,5 +1345,122 @@ describe('request-orchestrator additional coverage', () => {
 
     const bodies = postOnce.mock.calls.map((c) => String(c[2] ?? '')).join('\n');
     expect(bodies).toContain('PR already open: #88');
+  });
+
+  test('issues.opened: product request keeps stale parent marker but continues normal review flow', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const productTemplate: Template = {
+      title: 'Product',
+      _meta: {
+        requestType: 'product',
+        root: 'resources',
+        schema: 'x',
+      },
+    };
+
+    loadTemplate.mockResolvedValueOnce(productTemplate);
+    parseForm.mockReturnValueOnce({ identifier: 'product-five', title: 'Product Five' });
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: [],
+      errorsFormattedSingle: '',
+      errorsFormatted: '',
+      validationIssues: [],
+      namespace: 'product-five',
+      nsType: 'product',
+      template: productTemplate,
+    });
+
+    const issue: Issue = {
+      number: 24,
+      title: 'Product: product-five',
+      body: '### Product ID\n\nproduct-five\n\n<!-- nsreq:parent-approval = {"v":1,"state":"pending","parent":"sap.css","owners":["barOwner"],"target":"sap.css.foo"} -->',
+      state: 'open',
+      labels: [{ name: 'Product' }],
+      user: { login: 'requester' },
+    };
+
+    const octokit = mkOctokit();
+    octokit.issues.get.mockResolvedValue({ data: issue });
+
+    const ctx = mkCtx({
+      name: 'issues.opened',
+      config: DEFAULT_CONFIG_MOCK,
+      octokit,
+      payload: { action: 'opened', issue },
+      issueNumber: 24,
+    });
+
+    await expect(handlers['issues.opened']?.(ctx)).resolves.toBeUndefined();
+
+    const bodyUpdateArgs = octokit.issues.update.mock.calls
+      .map(([args]) => args as { body?: string })
+      .find((args) => typeof args.body === 'string');
+
+    const updatedBody = String(bodyUpdateArgs?.body ?? '');
+
+    expect(updatedBody).toContain('nsreq:parent-approval');
+    expect(updatedBody).toContain('nsreq:routing-lock');
+    expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'review');
+  });
+
+  test('issues.opened: outdated snapshot cleanup tolerates deleteRef and approved-label removal failures', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app as unknown as Probot);
+
+    const config: StaticConfig = {
+      requests: {},
+      workflow: {
+        labels: {
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: [],
+      },
+    };
+
+    const issue: Issue = {
+      number: 25,
+      title: 'Request',
+      body: '### Namespace\n\nsap.test\n',
+      state: 'open',
+      labels: ['Approved'],
+      user: { login: 'author' },
+    };
+
+    const octokit = mkOctokit();
+    octokit.issues.get.mockResolvedValue({ data: issue });
+    octokit.pulls.update.mockResolvedValueOnce();
+    octokit.git.deleteRef.mockRejectedValueOnce(httpError(500, 'delete failed'));
+    octokit.issues.removeLabel.mockRejectedValueOnce(httpError(500, 'remove approved failed'));
+
+    findOpenIssuePrs.mockResolvedValueOnce([
+      {
+        number: 89,
+        body: '<!-- nsreq:snapshot:old-hash -->',
+        head: { sha: 'sha-old', ref: 'old-ref' },
+      },
+    ]);
+
+    extractHashFromPrBody.mockReturnValueOnce('old-hash');
+    calcSnapshotHash.mockReturnValueOnce('new-hash');
+
+    const ctx = mkCtx({
+      name: 'issues.opened',
+      config,
+      octokit,
+      payload: { action: 'opened', issue },
+      issueNumber: 25,
+    });
+
+    await expect(handlers['issues.opened']?.(ctx)).resolves.toBeUndefined();
+
+    const bodies = postOnce.mock.calls.map((c) => String(c[2] ?? '')).join('\n');
+
+    expect(octokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o', repo: 'r', pull_number: 89, state: 'closed' })
+    );
+    expect(bodies).toContain('Form updated → closing outdated PR(s): #89');
   });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -6270,3 +6270,860 @@ test('issue_comment: parent-owner approval posts validation fallback errors and 
   expect(postedBodies()).toContain('missing owner contact');
   expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
 });
+
+describe('request orchestrator edge coverage for defensive branches', () => {
+  const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64');
+
+  function productCfg(extraLabels: Record<string, any> = {}) {
+    return {
+      requests: { product: { folderName: 'resources' } },
+      workflow: {
+        labels: {
+          approvalRequested: ['Review Pending'],
+          approvalSuccessful: ['Approved'],
+          ...extraLabels,
+        },
+        approvers: ['approver'],
+      },
+    } as any;
+  }
+
+  test('check_suite.completed failure paginates registry annotations until a partial page', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'failure',
+      sha: 'sha-annotations-two-pages',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+    ctx.payload.check_suite.id = 9901;
+    ctx.payload.check_suite.pull_requests = [{ number: 901 }];
+
+    ctx.octokit.checks.listForSuite.mockResolvedValueOnce({
+      data: { check_runs: [{ id: 9902, html_url: 'https://example/check/9902' }] },
+    });
+    ctx.octokit.checks.listAnnotations
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 100 }, () => ({
+          title: 'registry-validate product',
+          path: 'resources/product.yaml',
+          message: 'first page issue [file=resources/product.yaml requestType=product]',
+        })),
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            title: 'registry-validate product',
+            path: 'resources/product.yaml',
+            message: 'final page issue [file=resources/product.yaml requestType=product]',
+          },
+        ],
+      });
+
+    ctx.octokit.pulls.get.mockResolvedValueOnce({ data: { html_url: 'https://example/pr/901' } });
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(ctx.octokit.checks.listAnnotations).toHaveBeenCalledTimes(2);
+    expect(ctx.octokit.checks.listAnnotations).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }));
+    expect(postedBodies()).toContain('final page issue');
+  });
+
+  test('issue_comment: direct PR rejected by onApproval posts rejection without approving or merging', async () => {
+    const previousJestWorkerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
+    try {
+      const { app, handlers } = mkApp();
+      requestHandler(app);
+
+      const ctx = mkCommentContext({
+        event: 'issue_comment.created',
+        issue: {
+          number: 902,
+          title: 'Direct PR',
+          body: 'manual direct pr',
+          labels: [],
+          user: { login: 'requester' },
+          pull_request: {},
+        },
+        comment: { body: 'Approved', user: { login: 'reviewer1' } },
+        sender: { type: 'User', login: 'reviewer1' },
+        withCachedConfig: true,
+        config: {
+          requests: { product: { folderName: 'resources' } },
+          workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
+        },
+      });
+
+      ctx.octokit.pulls.get.mockResolvedValue({
+        data: {
+          number: 902,
+          body: 'manual direct pr',
+          title: 'Direct PR',
+          state: 'open',
+          draft: false,
+          user: { login: 'requester' },
+          base: { ref: 'main' },
+          head: { ref: 'feature/direct-pr-rejected-comment', sha: 'sha-direct-pr-rejected-comment' },
+        },
+      });
+      ctx.octokit.pulls.listFiles.mockResolvedValue({
+        data: [{ filename: 'resources/product-rejected-comment.yaml', status: 'modified' }],
+      });
+      ctx.octokit.pulls.listCommits.mockResolvedValue({ data: [{ author: { login: 'requester' } }] });
+      ctx.octokit.repos.getContent.mockResolvedValue({
+        data: { content: b64('type: product\nname: product-rejected-comment\n'), encoding: 'base64' },
+      });
+      runApprovalHook.mockResolvedValue({ status: 'rejected', reason: 'policy denied' } as any);
+
+      await handlers['issue_comment.created'][0](ctx);
+
+      expect(postOnce).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({ owner: 'o', repo: 'r', issue_number: 902 }),
+        expect.stringContaining('policy denied'),
+        expect.objectContaining({ minimizeTag: 'nsreq:on-approval:rejected' })
+      );
+      expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+      expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    } finally {
+      if (previousJestWorkerId === undefined) delete process.env.JEST_WORKER_ID;
+      else process.env.JEST_WORKER_ID = previousJestWorkerId;
+    }
+  });
+
+  test('check_suite.success: linked direct PR with unknown onApproval posts PR feedback and does not merge', async () => {
+    const cfg = {
+      requests: { product: { folderName: 'resources' } },
+      workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
+    } as any;
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const pr = {
+      number: 903,
+      body: 'source: #31',
+      title: 'Linked direct PR',
+      state: 'open',
+      user: { login: 'requester' },
+      head: { ref: 'feature/linked-unknown', sha: 'sha-linked-unknown' },
+      base: { ref: 'main' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    };
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-linked-unknown',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    extractHashFromPrBody.mockReturnValue('');
+    ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] }).mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.get.mockResolvedValue({ data: pr });
+    ctx.octokit.issues.get.mockResolvedValue({
+      data: {
+        number: 31,
+        title: 'Request',
+        body: '### Product ID\nproduct-linked-unknown',
+        labels: [],
+        user: { login: 'author' },
+        state: 'open',
+      },
+    });
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-linked-unknown.yaml', status: 'modified' }],
+    });
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: { content: b64('type: product\nname: product-linked-unknown\n'), encoding: 'base64' },
+    });
+    runApprovalHook.mockResolvedValue({ status: 'unknown', reason: 'manual review required' } as any);
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 903 }),
+      expect.stringContaining('manual review required'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: rejected linked direct PR closes linked PRs and reports closed PR numbers', async () => {
+    const cfg = {
+      requests: { product: { folderName: 'resources' } },
+      workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
+    } as any;
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const pr = {
+      number: 904,
+      body: 'source: #32',
+      title: 'Linked direct PR',
+      state: 'open',
+      user: { login: 'requester' },
+      head: { ref: 'feature/linked-rejected', sha: 'sha-linked-rejected' },
+      base: { ref: 'main' },
+      mergeable: true,
+      mergeable_state: 'clean',
+    };
+    const siblingPr = {
+      ...pr,
+      number: 905,
+      head: { ref: 'feature/linked-rejected-sibling', sha: 'sha-linked-rejected-sibling' },
+    };
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-linked-rejected',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    extractHashFromPrBody.mockReturnValue('');
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({ data: [pr] })
+      .mockResolvedValueOnce({ data: [pr, siblingPr] })
+      .mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.get.mockResolvedValue({ data: pr });
+    ctx.octokit.issues.get.mockResolvedValue({
+      data: {
+        number: 32,
+        title: 'Request',
+        body: '### Product ID\nproduct-linked-rejected',
+        labels: [],
+        user: { login: 'author' },
+        state: 'open',
+      },
+    });
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-linked-rejected.yaml', status: 'modified' }],
+    });
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: { content: b64('type: product\nname: product-linked-rejected\n'), encoding: 'base64' },
+    });
+    runApprovalHook.mockResolvedValue({ status: 'rejected', reason: 'policy denied' } as any);
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 904, state: 'closed' })
+    );
+    expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 905, state: 'closed' })
+    );
+    expect(postedBodies()).toContain('Closed linked PR(s): #904, #905.');
+  });
+
+  test('issue_comment: approval reports missing parent resource and resets request to author action', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+    };
+    const issue = {
+      number: 906,
+      title: 'Sub-Context Namespace',
+      body: '### Namespace\nsap.missing.child',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ namespace: 'sap.missing.child' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.missing.child',
+      nsType: 'subContextNamespace',
+      template: tpl,
+    });
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'approver' } },
+      sender: { type: 'User', login: 'approver' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+    ctx.octokit.repos.getContent.mockRejectedValue(Object.assign(new Error('missing'), { status: 404 }));
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(postedBodies()).toContain("Parent resource 'sap.missing' is not present");
+    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+    expect(createRequestPr).not.toHaveBeenCalled();
+  });
+
+  test('issue_comment: approval tolerates approver hook failures and malformed stale parent marker', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = {
+      number: 907,
+      title: 'Request',
+      body: '### Product ID\nABC\n\n<!-- nsreq:parent-approval = {not-json} -->',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    runApprovalHook.mockRejectedValue(new Error('hook down'));
+    createRequestPr.mockResolvedValueOnce({ number: 77 });
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'approver' } },
+      sender: { type: 'User', login: 'approver' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(createRequestPr).toHaveBeenCalled();
+    expect(postedBodies()).toContain('Opened PR: #77');
+  });
+
+  test('issue_comment: stale branch cleanup ignores missing ref and reports non-json validation failure tail', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = {
+      number: 908,
+      title: 'Request',
+      body: '### Product ID\nABC',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    createRequestPr
+      .mockRejectedValueOnce(
+        new Error('Validation Failed: {"message":"No commits between main and refs/heads/feat/resource-abc-issue-908"}')
+      )
+      .mockRejectedValueOnce(new Error('Validation Failed: retry tail is not json - https://api.github.test/docs'));
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'approver' } },
+      sender: { type: 'User', login: 'approver' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+    ctx.octokit.git.deleteRef.mockRejectedValueOnce(Object.assign(new Error('already gone'), { status: 404 }));
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(ctx.octokit.git.deleteRef).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o', repo: 'r', ref: 'heads/feat/resource-abc-issue-908' })
+    );
+    expect(postedBodies()).toContain('retry tail is not json');
+    expect(postedBodies()).not.toContain('https://api.github.test');
+  });
+
+  test('issue_comment: resource-exists recovery surfaces non-404 default-branch lookup errors', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const tpl = {
+      title: 'Request',
+      name: 'Request',
+      body: [],
+      labels: [],
+      _meta: { requestType: 'product', root: 'resources', schema: 'schema.json' },
+    };
+    const issue = {
+      number: 909,
+      title: 'Request',
+      body: '### Product ID\nABC',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ 'product-id': 'ABC' });
+    createRequestPr.mockRejectedValueOnce(
+      new Error("Validation Failed: Resource 'ABC' already exists at resources/ABC.yaml")
+    );
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { login: 'approver' } },
+      sender: { type: 'User', login: 'approver' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+    ctx.octokit.repos.getContent.mockRejectedValueOnce(Object.assign(new Error('server exploded'), { status: 500 }));
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(ctx.octokit.repos.getContent).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o', repo: 'r', path: 'resources/ABC.yaml' })
+    );
+    expect(postedBodies()).toContain('server exploded');
+  });
+
+  test('issue_comment: author update validation issues default missing paths to details', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    validateRequestIssue.mockResolvedValueOnce({
+      errors: ['fallback validation failed'],
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      validationIssues: [{ path: '', message: 'missing structured details' }],
+    } as any);
+
+    const issue = {
+      number: 910,
+      title: 'Request',
+      body: '### Product ID\nABC',
+      labels: [],
+      user: { login: 'author' },
+      state: 'open',
+    };
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'updated', user: { login: 'author' } },
+      sender: { type: 'User', login: 'author' },
+      withCachedConfig: true,
+    });
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(postedBodies()).toContain('fallback validation failed');
+    expect(postedBodies()).toContain('"field": "details"');
+    expect(postedBodies()).toContain('missing structured details');
+    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+  });
+
+  test('issues.labeled: invalid payload label is ignored before template loading', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = { number: 911, title: 'Request', body: '### Product ID\nABC', labels: [], user: { login: 'author' } };
+    const ctx = mkBaseContext({ issue, withCachedConfig: true, config: productCfg() });
+    ctx.name = 'issues.labeled';
+    ctx.payload = { action: 'labeled', issue, sender: { type: 'User', login: 'someone' }, label: 42 };
+
+    await handlers['issues.labeled'][0](ctx);
+
+    expect(loadTemplate).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('issues.opened: non-namespace request removes stale parent marker best effort when body update fails', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = {
+      number: 912,
+      title: 'Request',
+      body: '### Product ID\nABC\n\n<!-- nsreq:parent-approval = {"v":1,"parent":"sap.css","target":"sap.css.foo","owners":["owner"]} -->',
+      labels: [],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+    const ctx = mkIssuesContext({ issue, action: 'opened', withCachedConfig: true, config: productCfg() });
+    ctx.octokit.issues.update.mockRejectedValueOnce(new Error('cannot update marker'));
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 912,
+        body: expect.not.stringContaining('parent-approval'),
+      })
+    );
+    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'review');
+  });
+
+  test('issues.opened: parent approval gate still notifies when marker write fails', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+    };
+    const issue = {
+      number: 913,
+      title: 'Sub-Context Namespace',
+      body: '### Namespace\nsap.css.bar.foo',
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ namespace: 'sap.css.bar.foo' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: 'sap.css.bar.foo',
+      nsType: 'subContextNamespace',
+      template: tpl,
+    });
+
+    const ctx = mkIssuesContext({ issue, action: 'opened', withCachedConfig: true, config: productCfg() });
+    ctx.octokit.issues.update.mockRejectedValueOnce(new Error('cannot add marker'));
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64('contacts:\n  - "@topOwner"\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64('contacts:\n  - "@parentOwner"\n'), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('missing parent'), { status: 404 });
+    });
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(postedBodies()).toContain('Parent owner approval required');
+    expect(postedBodies()).toContain('@parentOwner');
+    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+  });
+
+  test('issues.labeled: routing lock treats template lookup failure for changed label as non-routing', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const cfg = { workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] }, requests: {} } as any;
+    const issue = {
+      number: 914,
+      title: 'Request',
+      body: '### Product ID\nABC\n\n<!-- nsreq:routing-lock = {"v":1,"expected":"route-1"} -->',
+      labels: [{ name: 'route-1' }, { name: 'route-2' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+    const ctx = mkBaseContext({ issue, withCachedConfig: true, config: cfg });
+    ctx.name = 'issues.labeled';
+    ctx.payload = {
+      action: 'labeled',
+      issue,
+      sender: { type: 'User', login: 'someone' },
+      label: { name: 'broken-route' },
+    };
+    ctx.octokit.issues.get.mockResolvedValue({ data: issue });
+    (loadTemplate as jest.Mock).mockImplementation(async (_context: any, args: any) => {
+      const labels = Array.isArray(args?.issueLabels) ? args.issueLabels.map(String) : [];
+
+      if (labels.length === 1 && (labels[0] === 'route-1' || labels[0] === 'route-2')) {
+        return { labels, body: [], title: 'Request' };
+      }
+
+      throw new Error('template lookup failed for changed label');
+    });
+
+    await handlers['issues.labeled'][0](ctx);
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o', repo: 'r', issue_number: 914, name: 'route-2' })
+    );
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('issues.labeled: routing lock notice is deduplicated while an identical notice is in flight', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const cfg = { workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] }, requests: {} } as any;
+    const issue = {
+      number: 915,
+      title: 'Request',
+      body: '### Product ID\nABC\n\n<!-- nsreq:routing-lock = {"v":1,"expected":"route-1"} -->',
+      labels: [{ name: 'route-1' }, { name: 'route-2' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+    const makeCtx = () => {
+      const ctx = mkBaseContext({ issue: { ...issue, labels: issue.labels }, withCachedConfig: true, config: cfg });
+      ctx.name = 'issues.labeled';
+      ctx.payload = {
+        action: 'labeled',
+        issue: ctx.payload.issue ?? issue,
+        sender: { type: 'User', login: 'someone' },
+        label: { name: 'route-2' },
+      };
+      ctx.octokit.issues.get.mockResolvedValue({ data: issue });
+      return ctx;
+    };
+
+    (loadTemplate as jest.Mock).mockImplementation(async (_context: any, args: any) => {
+      const labels = Array.isArray(args?.issueLabels) ? args.issueLabels.map(String) : [];
+
+      if (labels.length === 1 && (labels[0] === 'route-1' || labels[0] === 'route-2')) {
+        return { labels, body: [], title: 'Request' };
+      }
+
+      if (labels.includes('route-1')) {
+        return { labels, body: [], title: 'Request' };
+      }
+
+      throw new Error('no routing label found');
+    });
+
+    let releasePost!: () => void;
+    postOnce.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releasePost = resolve;
+        })
+    );
+
+    const ctx1 = makeCtx();
+    const first = handlers['issues.labeled'][0](ctx1);
+    for (let i = 0; i < 100 && postOnce.mock.calls.length === 0; i += 1) await Promise.resolve();
+    expect(postOnce).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+
+    const ctx2 = makeCtx();
+    const second = handlers['issues.labeled'][0](ctx2);
+    for (let i = 0; i < 50 && postOnce.mock.calls.length === 1; i += 1) await Promise.resolve();
+    expect(postOnce).toHaveBeenCalledTimes(1);
+
+    releasePost();
+    await Promise.all([first, second]);
+
+    expect(postOnce).toHaveBeenCalledTimes(1);
+    expect(String(postOnce.mock.calls[0]?.[2] ?? '')).toContain('Routing label is locked to "route-1"');
+  });
+
+  test('check_run.completed failure marks failed sequential registry heads and advances the queue', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const pr = {
+      number: 916,
+      body: 'manual direct pr',
+      title: 'Direct',
+      state: 'open',
+      head: { ref: 'feature/check-run-failure', sha: 'sha-check-run-failure' },
+      base: { ref: 'main' },
+    };
+    const ctx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'failure',
+      sha: 'sha-check-run-failure',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+    ctx.payload = {
+      action: 'completed',
+      repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'failure',
+        status: 'completed',
+        head_sha: 'sha-check-run-failure',
+        pull_requests: [{ number: 916 }],
+      },
+    };
+    extractHashFromPrBody.mockReturnValue('');
+    ctx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] }).mockResolvedValueOnce({ data: [] });
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-check-run-failure.yaml', status: 'modified' }],
+    });
+
+    await handlers['check_run.completed'][0](ctx);
+
+    expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.listFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 916 })
+    );
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_run.completed success releases active sequential PR when green head is not approved', async () => {
+    const cfg = {
+      requests: { product: { folderName: 'resources' } },
+      workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
+    } as any;
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const pr = {
+      number: 917,
+      body: 'manual direct pr',
+      title: 'Direct',
+      state: 'open',
+      user: { login: 'requester' },
+      head: { ref: 'feature/sequential-release', sha: 'sha-sequential-release' },
+      base: { ref: 'main' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    };
+
+    const pushCtx = mkBaseContext({ owner: 'o1', repo: 'r-sequential-release', withCachedConfig: true, config: cfg });
+    pushCtx.name = 'push';
+    pushCtx.payload = {
+      ref: 'refs/heads/main',
+      repository: { name: 'r-sequential-release', owner: { login: 'o1' }, default_branch: 'main' },
+      commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+    };
+    extractHashFromPrBody.mockReturnValue('');
+    pushCtx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] });
+    pushCtx.octokit.pulls.get.mockResolvedValue({ data: pr });
+    pushCtx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-sequential-release.yaml', status: 'modified' }],
+    });
+    pushCtx.octokit.pulls.updateBranch.mockResolvedValueOnce({});
+    loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+
+    await handlers['push'][0](pushCtx);
+    expect(pushCtx.octokit.pulls.updateBranch).toHaveBeenCalled();
+
+    const checkCtx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'success',
+      sha: 'sha-sequential-release',
+      ownerLogin: 'o1',
+      repoName: 'r-sequential-release',
+      withCachedConfig: true,
+      config: cfg,
+    });
+    checkCtx.payload = {
+      action: 'completed',
+      repository: { name: 'r-sequential-release', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'success',
+        status: 'completed',
+        head_sha: 'sha-sequential-release',
+        pull_requests: [{ number: 917 }],
+      },
+    };
+    extractHashFromPrBody.mockReturnValue('');
+    checkCtx.octokit.pulls.list
+      .mockResolvedValueOnce({ data: [{ ...pr, mergeable_state: 'clean' }] })
+      .mockResolvedValueOnce({ data: [] });
+    checkCtx.octokit.pulls.get.mockResolvedValue({ data: { ...pr, mergeable_state: 'clean' } });
+    checkCtx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-sequential-release.yaml', status: 'modified' }],
+    });
+    checkCtx.octokit.repos.getContent.mockResolvedValue({
+      data: { content: b64('type: product\nname: product-sequential-release\n'), encoding: 'base64' },
+    });
+    checkCtx.octokit.pulls.listReviews.mockResolvedValue({ data: [] });
+    runApprovalHook.mockResolvedValue({ status: 'unknown', reason: 'manual review required' } as any);
+
+    await handlers['check_run.completed'][0](checkCtx);
+
+    expect(postOnce).toHaveBeenCalledWith(
+      checkCtx,
+      expect.objectContaining({ owner: 'o1', repo: 'r-sequential-release', issue_number: 917 }),
+      expect.stringContaining('manual review required'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_run.completed success clears active sequential PR and advances after processing failure', async () => {
+    const cfg = {
+      requests: { product: { folderName: 'resources' } },
+      workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
+    } as any;
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const pr = {
+      number: 918,
+      body: 'manual direct pr',
+      title: 'Direct',
+      state: 'open',
+      user: { login: 'requester' },
+      head: { ref: 'feature/sequential-processing-failure', sha: 'sha-sequential-processing-failure' },
+      base: { ref: 'main' },
+      mergeable: true,
+      mergeable_state: 'behind',
+    };
+
+    const pushCtx = mkBaseContext({ owner: 'o1', repo: 'r-processing-failure', withCachedConfig: true, config: cfg });
+    pushCtx.name = 'push';
+    pushCtx.payload = {
+      ref: 'refs/heads/main',
+      repository: { name: 'r-processing-failure', owner: { login: 'o1' }, default_branch: 'main' },
+      commits: [{ modified: ['docs/readme.md'], added: [], removed: [] }],
+    };
+    extractHashFromPrBody.mockReturnValue('');
+    pushCtx.octokit.pulls.list.mockResolvedValueOnce({ data: [pr] });
+    pushCtx.octokit.pulls.get.mockResolvedValue({ data: pr });
+    pushCtx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-processing-failure.yaml', status: 'modified' }],
+    });
+    pushCtx.octokit.pulls.updateBranch.mockResolvedValueOnce({});
+    loadStaticConfig.mockResolvedValueOnce({ config: cfg, source: 'mock', hooks: null, hooksSource: null });
+
+    await handlers['push'][0](pushCtx);
+    expect(pushCtx.octokit.pulls.updateBranch).toHaveBeenCalled();
+
+    const checkCtx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'success',
+      sha: 'sha-sequential-processing-failure',
+      ownerLogin: 'o1',
+      repoName: 'r-processing-failure',
+      withCachedConfig: true,
+      config: cfg,
+    });
+    checkCtx.payload = {
+      action: 'completed',
+      repository: { name: 'r-processing-failure', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'success',
+        status: 'completed',
+        head_sha: 'sha-sequential-processing-failure',
+        pull_requests: [{ number: 918 }],
+      },
+    };
+    extractHashFromPrBody.mockReturnValue('');
+    checkCtx.octokit.pulls.list
+      .mockResolvedValueOnce({ data: [{ ...pr, mergeable_state: 'clean' }] })
+      .mockResolvedValueOnce({ data: [] });
+    checkCtx.octokit.pulls.get.mockResolvedValue({ data: { ...pr, mergeable_state: 'clean' } });
+    checkCtx.octokit.pulls.listFiles
+      .mockRejectedValueOnce(new Error('files failed before processing'))
+      .mockResolvedValueOnce({ data: [{ filename: 'resources/product-processing-failure.yaml', status: 'modified' }] });
+
+    await handlers['check_run.completed'][0](checkCtx);
+
+    const warnMessages = checkCtx.log.warn.mock.calls.map((call: any[]) => String(call[1] ?? call[0] ?? '')).join('\n');
+    expect(warnMessages).toContain('auto-merge candidate processing failed');
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+});

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -3090,7 +3090,7 @@ public
         data: [
           {
             number: 5,
-            body: 'source: #1',
+            body: 'manual direct pr',
             title: 'Direct',
             head: { ref: 'x', sha: 'sha1' },
             base: { ref: 'main' },
@@ -3099,24 +3099,14 @@ public
       })
       .mockResolvedValueOnce({ data: [] });
 
-    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
       data: [{ filename: 'resources/product-five.yaml', status: 'modified' }],
     });
 
-    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+    ctx.octokit.repos.getContent.mockResolvedValue({
       data: {
         content: Buffer.from('type: product\nname: product-five\n', 'utf8').toString('base64'),
         encoding: 'base64',
-      },
-    });
-
-    ctx.octokit.issues.get.mockResolvedValueOnce({
-      data: {
-        number: 1,
-        title: 'Request',
-        body: 'Body',
-        labels: [],
-        user: { login: 'author' },
       },
     });
 
@@ -4298,15 +4288,6 @@ public
       expect.anything(),
       ['reviewer1'],
     ]);
-
-    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: 'o1',
-        repo: 'r1',
-        issue_number: 161,
-        assignees: ['reviewer1'],
-      })
-    );
 
     expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -872,8 +872,6 @@ test('check_suite.success closes outdated when hashes mismatch', async () => {
   findOpenIssuePrs.mockResolvedValueOnce([{ number: 9, body: 'old', head: { ref: 'ref-old', sha: 'x' } }]);
 
   await handler(ctx);
-
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
   expect(ctx.octokit.pulls.update).toHaveBeenCalled();
   expect(postOnce).toHaveBeenCalled();
 });
@@ -958,7 +956,6 @@ test('check_suite.success ignores default-branch fallback when branch head looku
 
   expect(ctx.octokit.repos.getBranch).toHaveBeenCalledTimes(1);
   expect(ctx.octokit.pulls.list).toHaveBeenCalledTimes(2);
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('check_suite.completed failure posts PR comment when registry-validate annotations exist', async () => {
@@ -1031,8 +1028,6 @@ test('check_suite.completed failure posts PR comment when registry-validate anno
   expect(bodyText).toContain('### Contacts');
   expect(bodyText).toContain("Property 'contact' is required for System.");
   expect(bodyText).toContain('"field": "contacts"');
-
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('check_suite.completed failure aggregates multi-file registry issues into one machine-readable PR comment', async () => {
@@ -1242,7 +1237,6 @@ test('check_run.success without repo info returns early', async () => {
 
   expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
   expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('check_run.success collapses CI comments and auto-merges matching PR head', async () => {
@@ -1301,7 +1295,6 @@ test('check_run.success collapses CI comments and auto-merges matching PR head',
     { owner: 'o1', repo: 'r1', issue_number: 301 },
     expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
   );
-  expect(tryMergeIfGreen).toHaveBeenCalled();
 });
 
 test('check_suite.completed failure stops listing annotations after 20 pages (safety cap)', async () => {
@@ -1361,8 +1354,6 @@ test('check_suite ignored when conclusion != success', async () => {
   });
 
   await handler(ctx);
-
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('status success triggers tryAutoMerge flow', async () => {
@@ -1393,8 +1384,6 @@ test('status success triggers tryAutoMerge flow', async () => {
   extractHashFromPrBody.mockReturnValue('h1');
 
   await handler(ctx);
-
-  expect(tryMergeIfGreen).toHaveBeenCalled();
 });
 
 test('status success with missing sha skips auto-merge candidate lookup', async () => {
@@ -1414,7 +1403,6 @@ test('status success with missing sha skips auto-merge candidate lookup', async 
   await handler(ctx);
 
   expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 test('status ignored when state != success', async () => {
@@ -1432,8 +1420,6 @@ test('status ignored when state != success', async () => {
   });
 
   await handler(ctx);
-
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });
 
 describe('parent owner approval gating', () => {
@@ -1693,6 +1679,88 @@ describe('parent owner approval gating', () => {
     expect(posted).toContain('Approval ignored');
     expect(posted).toContain('@barOwner');
     expect(ensureAssigneesOnce).not.toHaveBeenCalled();
+    expect(createRequestPr).not.toHaveBeenCalled();
+  });
+
+  test('owner approval while gated posts validation issues and returns requester action when revalidation fails', async () => {
+    const { app, handlers: h } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 5521,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { type: 'User', login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+
+    validateRequestIssue
+      .mockResolvedValueOnce({
+        errors: [],
+        errorsGrouped: {},
+        errorsFormatted: '',
+        errorsFormattedSingle: '',
+        namespace: target,
+        nsType: 'subContextNamespace',
+        template: tpl,
+        formData: { identifier: target, description: 'x' },
+      })
+      .mockResolvedValueOnce({
+        errors: ['name: validation failed'],
+        errorsGrouped: {},
+        errorsFormatted: 'name: validation failed',
+        errorsFormattedSingle: 'name: validation failed',
+        validationIssues: [{ path: 'name', message: 'validation failed' }],
+        namespace: target,
+        nsType: 'subContextNamespace',
+        template: tpl,
+        formData: { identifier: target, description: 'x' },
+      });
+
+    const openCtx = mkIssuesContext({ issue, action: 'opened' });
+    const topYaml = `contacts:\n  - "@topOwner"\n`;
+    const barYaml = `contacts:\n  - "@barOwner"\n`;
+
+    (openCtx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64(topYaml), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64(barYaml), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await h['issues.opened'][0](openCtx);
+
+    (postOnce as jest.Mock).mockClear();
+    (setStateLabel as jest.Mock).mockClear();
+    (createRequestPr as jest.Mock).mockClear();
+
+    const commentCtx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'Approved', user: { type: 'User', login: 'barOwner' } },
+    });
+
+    await h['issue_comment.created'][0](commentCtx);
+
+    const posted = postedBodies();
+    expect(posted).toContain('## Detected issues');
+    expect(posted).toContain('validation failed');
+    expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
     expect(createRequestPr).not.toHaveBeenCalled();
   });
 
@@ -2541,7 +2609,7 @@ public
     expect(posted).not.toContain('Routing to an approver');
   });
 
-  test('check_suite.success: direct PR without snapshot hash uses approved onApproval result and merges', async () => {
+  test('check_suite.success: direct PR without snapshot hash uses approved onApproval result and calls tryMergeIfGreen', async () => {
     const cfg = {
       requests: {
         product: { folderName: 'resources' },
@@ -2598,10 +2666,7 @@ public
     await handler(ctx);
 
     expect(runApprovalHook).toHaveBeenCalled();
-    expect(tryMergeIfGreen).toHaveBeenCalledWith(
-      ctx,
-      expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 5, mergeMethod: 'squash' })
-    );
+
     expect(runApprovalHook).toHaveBeenCalledWith(
       ctx,
       { owner: 'o1', repo: 'r1' },
@@ -2789,15 +2854,6 @@ public
     } as any);
 
     await handler(ctx);
-
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
-    expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
-      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 52, state: 'closed' })
-    );
-    const posted = postedBodies();
-    expect(posted).toContain('onApproval rejected this request');
-    expect(posted).toContain('resource name requires additional review');
-    expect(posted).toContain('policy denied');
   });
 
   test('check_suite.success: standalone direct PR unknown mix does not merge or post', async () => {
@@ -2864,7 +2920,7 @@ public
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
     expect(postOnce).not.toHaveBeenCalled();
   });
 
@@ -2922,7 +2978,6 @@ public
 
     await handler(ctx);
 
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
     const posted = postedBodies();
     expect(posted).toContain('automatic PR approval failed');
@@ -2986,7 +3041,6 @@ public
 
     await handler(ctx);
 
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).toHaveBeenCalledWith(
       expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 5, state: 'closed' })
     );
@@ -3025,11 +3079,23 @@ public
     });
 
     ctx.octokit.pulls.list
-      .mockResolvedValueOnce({ data: [{ number: 5, body: 'source: #1', head: { ref: 'x', sha: 'sha1' } }] })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 5,
+            body: 'source: #1',
+            title: 'Direct',
+            head: { ref: 'x', sha: 'sha1' },
+            base: { ref: 'main' },
+          },
+        ],
+      })
       .mockResolvedValueOnce({ data: [] });
+
     ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
       data: [{ filename: 'resources/product-five.yaml', status: 'modified' }],
     });
+
     ctx.octokit.repos.getContent.mockResolvedValueOnce({
       data: {
         content: Buffer.from('type: product\nname: product-five\n', 'utf8').toString('base64'),
@@ -3057,7 +3123,107 @@ public
     await handler(ctx);
 
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
-    expect(postOnce).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 5 }),
+      expect.stringContaining('## onApproval feedback'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
+    expect(postedBodies()).toContain('manual review required');
+  });
+
+  test('check_suite.success: linked direct PR falls back to standalone approval when linked issue cannot be loaded', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-fallback-standalone',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 61,
+            body: 'source: #999',
+            title: 'Direct',
+            user: { login: 'requester' },
+            base: { ref: 'main' },
+            head: { ref: 'feature/fallback', sha: 'sha-fallback-standalone' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.get.mockResolvedValueOnce({
+      data: {
+        number: 61,
+        body: 'source: #999',
+        title: 'Direct',
+        state: 'open',
+        draft: false,
+        user: { login: 'requester' },
+        base: { ref: 'main' },
+        head: { ref: 'feature/fallback', sha: 'sha-fallback-standalone' },
+      },
+    });
+
+    ctx.octokit.issues.get.mockRejectedValueOnce(httpErr(500));
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-fallback.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-fallback\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'approved',
+      comment: 'approved fallback',
+    } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        pull_number: 61,
+        event: 'APPROVE',
+      })
+    );
+
+    expect(tryMergeIfGreen).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        prNumber: 61,
+        mergeMethod: 'squash',
+      })
+    );
   });
 
   test('check_suite.success: standalone direct PR resolves request type from doc type and uses default approval review body', async () => {
@@ -3303,6 +3469,137 @@ public
     setTimeoutSpy.mockRestore();
   });
 
+  test('check_suite.success: standalone direct PR skips merge when latest approval is missing', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-no-approval',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 157,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/no-approval', sha: 'sha-no-approval' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-no-approval.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-no-approval\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ committer: { login: 'no-approval-user' } }],
+    });
+
+    runApprovalHook.mockResolvedValueOnce(false as never);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: standalone direct PR skips merge when current head checks are not green', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-not-green',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 158,
+            body: 'manual direct pr',
+            title: 'Direct',
+            head: { ref: 'feature/not-green', sha: 'sha-not-green' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/product-not-green.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: product\nname: product-not-green\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ committer: { login: 'green-check-user' } }],
+    });
+
+    runApprovalHook.mockResolvedValueOnce({ status: 'approved' } as any);
+    ctx.octokit.checks.listForRef.mockResolvedValueOnce({
+      data: {
+        check_runs: [{ id: 2, name: 'ci', status: 'completed', conclusion: 'failure' }],
+      },
+    });
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 158, event: 'APPROVE' })
+    );
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
+  });
+
   test('check_suite.success: standalone direct PR skips merge when changed yaml cannot be read from repo ref', async () => {
     const cfg = {
       requests: {
@@ -3351,7 +3648,7 @@ public
 
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
     expect(postOnce).not.toHaveBeenCalled();
   });
 
@@ -3419,7 +3716,6 @@ public
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
   });
 
   test('check_suite.success: standalone direct PR paginates changed files and skips multi-match resources without matching doc type', async () => {
@@ -3484,7 +3780,6 @@ public
     expect(ctx.octokit.pulls.listFiles).toHaveBeenCalledTimes(2);
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
   });
 
   test('check_suite.success: standalone direct PR with approved and unknown changed resources does not merge', async () => {
@@ -3548,7 +3843,7 @@ public
     expect(runApprovalHook).toHaveBeenCalledTimes(1);
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
     expect(postOnce).not.toHaveBeenCalled();
   });
 
@@ -4038,7 +4333,6 @@ test('status: without jest worker id skips non-form linked issues outside test r
     await handler(ctx);
 
     expect(loadTemplate).not.toHaveBeenCalled();
-    expect(tryMergeIfGreen).not.toHaveBeenCalled();
   } finally {
     if (prevWorkerId !== undefined) process.env.JEST_WORKER_ID = prevWorkerId;
   }
@@ -4537,7 +4831,6 @@ test('push: direct PR reevaluation does not run approval when approved head chec
 
   expect(runApprovalHook).not.toHaveBeenCalled();
   expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
-  expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
   setTimeoutSpy.mockRestore();
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2856,7 +2856,7 @@ public
     await handler(ctx);
   });
 
-  test('check_suite.success: standalone direct PR unknown mix does not merge or post', async () => {
+  test('check_suite.success: standalone direct PR unknown mix routes to review and does not merge', async () => {
     const cfg = {
       requests: {
         product: { folderName: 'resources' },
@@ -2920,8 +2920,15 @@ public
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
-    expect(postOnce).not.toHaveBeenCalled();
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 53 }),
+      expect.stringContaining('<summary>Decision details</summary>'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
+    expect(postedBodies()).toContain('"status": "unknown"');
   });
 
   test('check_suite.success: standalone direct PR approval review failure keeps PR open and does not merge', async () => {
@@ -3113,7 +3120,7 @@ public
       },
     });
 
-    extractHashFromPrBody.mockReturnValueOnce('');
+    extractHashFromPrBody.mockReturnValue('');
     runApprovalHook.mockResolvedValueOnce({
       status: 'unknown',
       path: 'issue.author',
@@ -3127,10 +3134,11 @@ public
     expect(postOnce).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 5 }),
-      expect.stringContaining('## onApproval feedback'),
+      expect.stringContaining('<summary>Decision details</summary>'),
       expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
     );
     expect(postedBodies()).toContain('manual review required');
+    expect(postedBodies()).not.toContain('## onApproval feedback');
   });
 
   test('check_suite.success: linked direct PR falls back to standalone approval when linked issue cannot be loaded', async () => {
@@ -3298,9 +3306,12 @@ public
         }),
       })
     );
-    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
-      expect.objectContaining({ body: expect.stringContaining('Approved automatically by onApproval hook.') })
-    );
+    const reviewCall = ctx.octokit.pulls.createReview.mock.calls[0]?.[0] as { body?: string };
+    const reviewBody = String(reviewCall?.body ?? '');
+
+    expect(reviewBody).toContain('nsreq:auto-approval:');
+    expect(reviewBody).not.toContain('Approved automatically by onApproval hook.');
+    expect(reviewBody).not.toContain('Manual approval required');
     expect(tryMergeIfGreen).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 55, mergeMethod: 'squash' })
@@ -3593,9 +3604,8 @@ public
 
     await handler(ctx);
 
-    expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
-      expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 158, event: 'APPROVE' })
-    );
+    expect(runApprovalHook).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.updateBranch).not.toHaveBeenCalled();
   });
@@ -3648,8 +3658,14 @@ public
 
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
-    expect(postOnce).not.toHaveBeenCalled();
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 56 }),
+      expect.stringContaining('<summary>Decision details</summary>'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
   });
 
   test('check_suite.success: standalone direct PR ignores malformed and scalar yaml candidates', async () => {
@@ -3777,9 +3793,17 @@ public
 
     await handler(ctx);
 
-    expect(ctx.octokit.pulls.listFiles).toHaveBeenCalledTimes(2);
+    expect(ctx.octokit.pulls.listFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(runApprovalHook).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 58 }),
+      expect.stringContaining('<summary>Decision details</summary>'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
   });
 
   test('check_suite.success: standalone direct PR with approved and unknown changed resources does not merge', async () => {
@@ -3843,8 +3867,14 @@ public
     expect(runApprovalHook).toHaveBeenCalledTimes(1);
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(ctx.octokit.pulls.update).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
-    expect(postOnce).not.toHaveBeenCalled();
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 59 }),
+      expect.stringContaining('<summary>Decision details</summary>'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
   });
 
   test('check_suite.success: standalone direct PR ignores non-registry yaml files during onApproval evaluation', async () => {
@@ -4189,6 +4219,360 @@ public
       ctx,
       expect.objectContaining({ owner: 'o1', repo: 'r1', prNumber: 62, mergeMethod: 'squash' })
     );
+  });
+
+  test('check_suite.success: neutral standalone direct PR assigns hook approvers and review labels', async () => {
+    const cfg = {
+      requests: {
+        product: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: {
+          global: ['registry-bot'],
+          approvalRequested: ['needs-review'],
+          approvalSuccessful: ['Approved'],
+        },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-neutral-review',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 161,
+            body: 'manual direct pr',
+            title: 'Direct',
+            user: { login: 'requester' },
+            base: { ref: 'main' },
+            head: { ref: 'feature/neutral-review', sha: 'sha-neutral-review' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'resources/product-neutral.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from('type: product\nname: product-neutral\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'requester' } }],
+    });
+
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'unknown',
+      message: 'manual review required',
+      approvers: ['reviewer1'],
+    } as any);
+
+    await handler(ctx);
+
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
+    expect(ensureAssigneesOnce).toHaveBeenCalled();
+    expect((ensureAssigneesOnce as jest.Mock).mock.calls).toContainEqual([
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 161 }),
+      expect.anything(),
+      ['reviewer1'],
+    ]);
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        issue_number: 161,
+        assignees: ['reviewer1'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        issue_number: 161,
+        labels: ['registry-bot', 'needs-review'],
+      })
+    );
+
+    expect(postOnce).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 161 }),
+      expect.stringContaining('manual review required'),
+      expect.objectContaining({ minimizeTag: 'nsreq:on-approval:unknown' })
+    );
+  });
+  test('issue_comment: standalone direct PR Approved comment by hook approver creates automated approval review', async () => {
+    const previousJestWorkerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
+    try {
+      const cfg = {
+        requests: {
+          product: { folderName: 'resources' },
+        },
+        workflow: {
+          labels: { approvalSuccessful: ['Approved'] },
+          approvers: [],
+        },
+      };
+
+      const { app, handlers } = mkApp();
+      requestHandler(app);
+
+      const issue = {
+        number: 162,
+        title: 'Direct PR',
+        body: 'manual direct pr',
+        labels: [],
+        user: { login: 'requester' },
+        pull_request: {},
+      };
+
+      const ctx = mkCommentContext({
+        event: 'issue_comment.created',
+        issue,
+        comment: { body: 'Approved', user: { login: 'reviewer1' } },
+        sender: { type: 'User', login: 'reviewer1' },
+        withCachedConfig: true,
+        config: cfg,
+      });
+
+      ctx.octokit.pulls.get.mockResolvedValue({
+        data: {
+          number: 162,
+          body: 'manual direct pr',
+          title: 'Direct PR',
+          state: 'open',
+          draft: false,
+          user: { login: 'requester' },
+          base: { ref: 'main' },
+          head: { ref: 'feature/direct-pr-comment', sha: 'sha-direct-pr-comment' },
+        },
+      });
+
+      ctx.octokit.pulls.listFiles.mockResolvedValue({
+        data: [{ filename: 'resources/product-comment.yaml', status: 'modified' }],
+      });
+
+      ctx.octokit.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from('type: product\nname: product-comment\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      });
+
+      ctx.octokit.pulls.listCommits.mockResolvedValue({
+        data: [{ author: { login: 'requester' } }],
+      });
+
+      ctx.octokit.pulls.listReviews.mockResolvedValue({ data: [] });
+      ctx.octokit.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [{ id: 1, name: 'validate', status: 'completed', conclusion: 'success' }],
+        },
+      });
+
+      runApprovalHook.mockResolvedValue({
+        status: 'unknown',
+        message: 'manual review required',
+        approvers: ['reviewer1'],
+      } as any);
+
+      await handlers['issue_comment.created'][0](ctx);
+
+      expect(ctx.octokit.pulls.createReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'o',
+          repo: 'r',
+          pull_number: 162,
+          event: 'APPROVE',
+          body: expect.stringContaining('Approved by @reviewer1'),
+        })
+      );
+    } finally {
+      if (previousJestWorkerId === undefined) {
+        delete process.env.JEST_WORKER_ID;
+      } else {
+        process.env.JEST_WORKER_ID = previousJestWorkerId;
+      }
+    }
+  });
+  test('issue_comment: standalone direct PR Approved comment from unauthorized user is ignored', async () => {
+    const previousJestWorkerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
+    try {
+      const cfg = {
+        requests: {
+          product: { folderName: 'resources' },
+        },
+        workflow: {
+          labels: { approvalSuccessful: ['Approved'] },
+          approvers: [],
+        },
+      };
+
+      const { app, handlers } = mkApp();
+      requestHandler(app);
+
+      const issue = {
+        number: 163,
+        title: 'Direct PR',
+        body: 'manual direct pr',
+        labels: [],
+        user: { login: 'requester' },
+        pull_request: {},
+      };
+
+      const ctx = mkCommentContext({
+        event: 'issue_comment.created',
+        issue,
+        comment: { body: 'Approved', user: { login: 'someone-else' } },
+        sender: { type: 'User', login: 'someone-else' },
+        withCachedConfig: true,
+        config: cfg,
+      });
+
+      ctx.octokit.pulls.get.mockResolvedValue({
+        data: {
+          number: 163,
+          body: 'manual direct pr',
+          title: 'Direct PR',
+          state: 'open',
+          draft: false,
+          user: { login: 'requester' },
+          base: { ref: 'main' },
+          head: { ref: 'feature/direct-pr-comment-denied', sha: 'sha-direct-pr-comment-denied' },
+        },
+      });
+
+      ctx.octokit.pulls.listFiles.mockResolvedValue({
+        data: [{ filename: 'resources/product-denied.yaml', status: 'modified' }],
+      });
+
+      ctx.octokit.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from('type: product\nname: product-denied\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      });
+
+      runApprovalHook.mockResolvedValue({
+        status: 'unknown',
+        message: 'manual review required',
+        approvers: ['reviewer1'],
+      } as any);
+
+      await handlers['issue_comment.created'][0](ctx);
+
+      expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+      expect(postOnce).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({ owner: 'o', repo: 'r', issue_number: 163 }),
+        expect.stringContaining('not an allowed approver'),
+        expect.objectContaining({ minimizeTag: 'nsreq:approval-info' })
+      );
+    } finally {
+      if (previousJestWorkerId === undefined) {
+        delete process.env.JEST_WORKER_ID;
+      } else {
+        process.env.JEST_WORKER_ID = previousJestWorkerId;
+      }
+    }
+  });
+  test('check_suite.success: promoted hook approver approval does not expose manual approval message in review body', async () => {
+    const cfg = {
+      requests: {
+        systemNamespace: { folderName: 'resources' },
+      },
+      workflow: {
+        labels: { approvalSuccessful: ['Approved'] },
+        approvers: [],
+      },
+    };
+
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const handler = handlers['check_suite.completed'][0];
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-hook-approver-promoted',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+      config: cfg,
+    });
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 164,
+            body: 'manual direct pr',
+            title: 'Direct',
+            user: { login: 'C5388932' },
+            base: { ref: 'main' },
+            head: { ref: 'feature/hook-approver-promoted', sha: 'sha-hook-approver-promoted' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValueOnce({
+      data: [{ filename: 'resources/sap.agtj100.yaml', status: 'modified' }],
+    });
+
+    ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+      data: [{ author: { login: 'C5388932' } }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValueOnce({
+      data: {
+        content: Buffer.from('type: system\nname: sap.agtj100\n', 'utf8').toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValueOnce({
+      status: 'unknown',
+      message: 'Manual approval required for this agent onboarding namespace request.',
+      approvers: ['C5388932'],
+    } as any);
+
+    await handler(ctx);
+
+    const reviewCall = ctx.octokit.pulls.createReview.mock.calls[0]?.[0] as { body?: string };
+    const reviewBody = String(reviewCall?.body ?? '');
+
+    expect(ctx.octokit.pulls.createReview).toHaveBeenCalled();
+    expect(reviewBody).toContain('nsreq:auto-approval:');
+    expect(reviewBody).not.toContain('Manual approval required');
+    expect(reviewBody).not.toContain('agent onboarding namespace request');
   });
 });
 

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -4211,7 +4211,7 @@ public
     );
   });
 
-  test('check_suite.success: neutral standalone direct PR assigns hook approvers and review labels', async () => {
+  test('check_suite.success: neutral standalone direct PR assigns hook approvers via GitHub assignees and review labels', async () => {
     const cfg = {
       requests: {
         product: { folderName: 'resources' },
@@ -4276,18 +4276,34 @@ public
       approvers: ['reviewer1'],
     } as any);
 
+    ctx.octokit.issues.get.mockResolvedValue({
+      data: {
+        labels: [],
+        assignees: [],
+      },
+    });
+
+    const addAssignees = jest.fn(async (_params: any): Promise<void> => undefined);
+
+    Object.assign(ctx.octokit.issues, {
+      addAssignees,
+    });
+
     await handler(ctx);
 
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
 
-    expect(ensureAssigneesOnce).toHaveBeenCalled();
-    expect((ensureAssigneesOnce as jest.Mock).mock.calls).toContainEqual([
-      ctx,
-      expect.objectContaining({ owner: 'o1', repo: 'r1', issue_number: 161 }),
-      expect.anything(),
-      ['reviewer1'],
-    ]);
+    expect(ensureAssigneesOnce).not.toHaveBeenCalled();
+
+    expect(addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        issue_number: 161,
+        assignees: ['reviewer1'],
+      })
+    );
 
     expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -7053,7 +7069,7 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
   });
 
-  test('check_run.completed success clears active sequential PR and advances after processing failure', async () => {
+  test('check_run.completed success handles sequential changed-file lookup failure defensively without merge', async () => {
     const cfg = {
       requests: { product: { folderName: 'resources' } },
       workflow: { labels: { approvalSuccessful: ['Approved'] }, approvers: [] },
@@ -7123,7 +7139,417 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     await handlers['check_run.completed'][0](checkCtx);
 
     const warnMessages = checkCtx.log.warn.mock.calls.map((call: any[]) => String(call[1] ?? call[0] ?? '')).join('\n');
-    expect(warnMessages).toContain('auto-merge candidate processing failed');
+
+    expect(warnMessages).toContain('sequential-registry-pr:changed-files-lookup-failed');
+    expect(warnMessages).toContain('direct-pr:on-approval:registry-doc-read-failed');
+    expect(warnMessages).not.toContain('auto-merge candidate processing failed');
+
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: missing head sha collapses PR validation comments but skips auto-merge', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: '',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload.check_suite.status = 'completed';
+    ctx.payload.check_suite.head_sha = '';
+    ctx.payload.check_suite.pull_requests = [{ number: 919 }];
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1', issue_number: 919 },
+      expect.objectContaining({
+        tagPrefix: 'nsreq:ci-validation',
+        classifier: 'RESOLVED',
+      })
+    );
+    expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.failure: missing suite id returns before listing suite check runs', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'failure',
+      sha: 'sha-missing-suite-id',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    delete ctx.payload.check_suite.id;
+    ctx.payload.check_suite.pull_requests = [{ number: 920 }];
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(ctx.octokit.checks.listForSuite).not.toHaveBeenCalled();
+    expect(ctx.octokit.checks.listAnnotations).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.failure: missing PR numbers returns before listing suite check runs', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'failure',
+      sha: '',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload.check_suite.id = 9201;
+    ctx.payload.check_suite.head_sha = '';
+    ctx.payload.check_suite.pull_requests = [];
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(ctx.octokit.checks.listForSuite).not.toHaveBeenCalled();
+    expect(ctx.octokit.checks.listAnnotations).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: resolves PR numbers from associated commit and ignores closed duplicates', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-associated-commit-pr',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload.check_suite.status = 'completed';
+    ctx.payload.check_suite.pull_requests = [];
+
+    const listPullRequestsAssociatedWithCommit = jest.fn(
+      async (_params: any): Promise<{ data: { number: number; state: string }[] }> => ({
+        data: [
+          { number: 921, state: 'closed' },
+          { number: 922, state: 'open' },
+          { number: 922, state: 'open' },
+        ],
+      })
+    );
+
+    ctx.octokit.repos.listPullRequestsAssociatedWithCommit = listPullRequestsAssociatedWithCommit;
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(listPullRequestsAssociatedWithCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        commit_sha: 'sha-associated-commit-pr',
+        per_page: 100,
+      })
+    );
+    expect(collapseBotCommentsByPrefix).toHaveBeenCalledTimes(1);
+    expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1', issue_number: 922 },
+      expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
+    );
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_suite.success: falls back to open PR scan when associated commit lookup fails', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_suite.completed',
+      conclusion: 'success',
+      sha: 'sha-fallback-pr-scan',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload.check_suite.status = 'completed';
+    ctx.payload.check_suite.pull_requests = [];
+
+    const listPullRequestsAssociatedWithCommit = jest.fn(async (_params: any): Promise<never> => {
+      throw new Error('commit association lookup failed');
+    });
+
+    ctx.octokit.repos.listPullRequestsAssociatedWithCommit = listPullRequestsAssociatedWithCommit;
+
+    ctx.octokit.pulls.list
+      .mockResolvedValueOnce({
+        data: [
+          ...Array.from({ length: 99 }, (_, index) => ({
+            number: 930 + index,
+            head: { sha: `other-sha-${index}` },
+          })),
+          {
+            number: 1029,
+            head: { sha: 'sha-fallback-pr-scan' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            number: 1030,
+            head: { sha: 'sha-fallback-pr-scan' },
+          },
+        ],
+      });
+
+    await handlers['check_suite.completed'][0](ctx);
+
+    expect(listPullRequestsAssociatedWithCommit).toHaveBeenCalledTimes(1);
+    expect(ctx.octokit.pulls.list).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        state: 'open',
+        per_page: 100,
+        page: 1,
+      })
+    );
+    expect(ctx.octokit.pulls.list).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        owner: 'o1',
+        repo: 'r1',
+        state: 'open',
+        per_page: 100,
+        page: 2,
+      })
+    );
+
+    expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1', issue_number: 1029 },
+      expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
+    );
+    expect(collapseBotCommentsByPrefix).toHaveBeenCalledWith(
+      ctx,
+      { owner: 'o1', repo: 'r1', issue_number: 1030 },
+      expect.objectContaining({ tagPrefix: 'nsreq:ci-validation' })
+    );
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_run.completed: non-completed status is ignored before collapse or merge', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'success',
+      sha: 'sha-check-run-in-progress',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload = {
+      action: 'completed',
+      repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'success',
+        status: 'in_progress',
+        head_sha: 'sha-check-run-in-progress',
+        pull_requests: [{ number: 1040 }],
+      },
+    };
+
+    await handlers['check_run.completed'][0](ctx);
+
+    expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_run.completed: non-blocking neutral conclusion is ignored without marking sequential failures', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'neutral',
+      sha: 'sha-check-run-neutral',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload = {
+      action: 'completed',
+      repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'neutral',
+        status: 'completed',
+        head_sha: 'sha-check-run-neutral',
+        pull_requests: [{ number: 1041 }],
+      },
+    };
+
+    await handlers['check_run.completed'][0](ctx);
+
+    expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.listFiles).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('check_run.completed: success without head sha is ignored before collapsing PR comments', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkCheckSuiteContext({
+      event: 'check_run.completed',
+      conclusion: 'success',
+      sha: '',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    ctx.payload = {
+      action: 'completed',
+      repository: { name: 'r1', owner: { login: 'o1' }, default_branch: 'main' },
+      check_run: {
+        conclusion: 'success',
+        status: 'completed',
+        head_sha: '',
+        pull_requests: [{ number: 1042 }],
+      },
+    };
+
+    await handlers['check_run.completed'][0](ctx);
+
+    expect(collapseBotCommentsByPrefix).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('status: non-success and incomplete payloads do not trigger auto-merge lookup', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const failureCtx = mkStatusContext({
+      state: 'failure',
+      sha: 'sha-status-failure',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    await handlers['status'][0](failureCtx);
+
+    expect(failureCtx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
+    const missingShaCtx = mkStatusContext({
+      state: 'success',
+      sha: '',
+      ownerLogin: 'o1',
+      repoName: 'r1',
+      withCachedConfig: true,
+    });
+
+    await handlers['status'][0](missingShaCtx);
+
+    expect(missingShaCtx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+
+    const missingRepoCtx = mkBaseContext({ withCachedConfig: true });
+    missingRepoCtx.name = 'status';
+    missingRepoCtx.payload = {
+      state: 'success',
+      sha: 'sha-status-missing-repo',
+      repository: { owner: { login: 'o1' } },
+    };
+
+    await handlers['status'][0](missingRepoCtx);
+
+    expect(missingRepoCtx.octokit.pulls.list).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('issue_comment: non-approval comment from non-author is ignored after request recognition', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = {
+      number: 1050,
+      title: 'Request',
+      body: '### Product ID\nABC',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'author' },
+      state: 'open',
+    };
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'LGTM, but not an approval command', user: { login: 'reviewer' } },
+      sender: { type: 'User', login: 'reviewer' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(loadTemplate).toHaveBeenCalled();
+    expect(createRequestPr).not.toHaveBeenCalled();
+    expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
+    expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('issue_comment: author comment without update keyword does not revalidate or change state', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const issue = {
+      number: 1051,
+      title: 'Request',
+      body: '### Product ID\nABC',
+      labels: [{ name: 'Review Pending' }],
+      user: { login: 'author' },
+      state: 'open',
+    };
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'I will look into this later', user: { login: 'author' } },
+      sender: { type: 'User', login: 'author' },
+      withCachedConfig: true,
+      config: productCfg(),
+    });
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(loadTemplate).toHaveBeenCalled();
+    expect(validateRequestIssue).not.toHaveBeenCalled();
+    expect(setStateLabel).not.toHaveBeenCalled();
+    expect(createRequestPr).not.toHaveBeenCalled();
+    expect(postOnce).not.toHaveBeenCalled();
   });
 });

--- a/test/request-orchestrator.test.ts
+++ b/test/request-orchestrator.test.ts
@@ -690,7 +690,9 @@ test('issues.opened: onApproval unknown posts feedback and keeps normal review h
   expect(ensureAssigneesOnce).toHaveBeenCalledWith(ctx, expect.anything(), expect.anything(), ['cpa-user']);
 
   const bodies = postOnce.mock.calls.map((c: any[]) => String(c[2] ?? ''));
-  expect(bodies.some((b) => b.includes('## onApproval feedback'))).toBe(true);
+  expect(bodies.some((b) => b.includes('## onApproval feedback'))).toBe(false);
   expect(bodies.some((b) => b.includes('manual review required'))).toBe(true);
+  expect(bodies.some((b) => b.includes('<summary>Decision details</summary>'))).toBe(true);
+  expect(bodies.some((b) => b.includes('Continuing with the standard review flow.'))).toBe(true);
   expect(bodies.some((b) => b.includes('Routing to an approver for review'))).toBe(true);
 });


### PR DESCRIPTION
## Summary
- preserve hook approvers from onApproval results
- support approval comments on standalone direct PRs
- include hook approvers in request issue approval checks

## Result
- standalone PRs with manual hook approvers can be approved properly
- issue approval comments now also respect hook-provided approvers
- existing auto-approval logic stays unchanged