### PR TITLE
fix: release registry PR queue on blocking checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.5",
+  "version": "0.1.5-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.5-dev.1",
+  "version": "0.1.5",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",
@@ -25,8 +25,7 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged",
-    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.5-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
+    "lint:staged": "lint-staged"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "prettier": "prettier --write \"**/*.{js,ts,json,yml,yaml,md}\"",
     "prettier:ci": "prettier --check \"**/*.{js,ts,json,yml,yaml,md}\"",
-    "lint:staged": "lint-staged"
+    "lint:staged": "lint-staged",
+    "deploy": "cf login -a https://api.cf.sap.hana.ondemand.com -o CORE_CF -s dev && cf push github-bot-docker --docker-image ghcr-remote.common.repositories.cloud.sap/open-resource-discovery/global-registry-bot:0.1.5-dev.1 --docker-username C5388932 --random-route -m 256M -k 512M"
   },
   "dependencies": {
     "ajv": "8.18.0",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -5060,10 +5060,40 @@ async function handleBlockingRegistryHeadConclusion(
   if (!sha) return false;
 
   const marked = await markFailedRegistryPrHeadsForSha(context, repoInfo, sha, baseBranch, reason);
-  if (!marked) return false;
+  if (!marked) {
+    log(
+      context,
+      'info',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        headSha: sha,
+        baseBranch: toStringTrim(baseBranch),
+        reason,
+      },
+      'sequential-registry-pr:blocking-head-not-marked'
+    );
+
+    return false;
+  }
 
   const advanceBaseBranch = await resolveSequentialRegistryQueueBaseBranchForHead(context, repoInfo, sha, baseBranch);
-  if (!advanceBaseBranch) return true;
+
+  if (!advanceBaseBranch) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        headSha: sha,
+        reason,
+      },
+      'sequential-registry-pr:advance-skipped-missing-base-branch'
+    );
+
+    return true;
+  }
 
   await runOneSequentialDirectRegistryPrMaintenance(
     context,
@@ -8031,6 +8061,8 @@ export default function requestHandler(app: Probot): void {
         if (status !== 'completed') return;
         if (conclusion && conclusion !== 'success') {
           if (isBlockingCheckConclusion(conclusion)) {
+            await getStaticConfig(context);
+
             await handleBlockingRegistryHeadConclusion(
               context,
               repoInfo,
@@ -8111,6 +8143,8 @@ export default function requestHandler(app: Probot): void {
       }
 
       if (isBlockingCheckConclusion(conclusion)) {
+        await getStaticConfig(context);
+
         await handleBlockingRegistryHeadConclusion(
           context,
           { owner: ownerLogin, repo: repoName },

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -5024,6 +5024,57 @@ async function markFailedRegistryPrHeadsForSha(
   return marked;
 }
 
+async function resolveSequentialRegistryQueueBaseBranchForHead(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  headSha: string,
+  fallbackBaseBranch: string
+): Promise<string> {
+  const fallback = toStringTrim(fallbackBaseBranch);
+  if (fallback) return fallback;
+
+  const sha = toStringTrim(headSha);
+  if (!sha) return '';
+
+  try {
+    const openPrs = await listOpenPullRequests(context, repoInfo);
+    const matchingPr = openPrs.find((pr) => toStringTrim(pr.head?.sha) === sha);
+    const baseBranch = toStringTrim(matchingPr?.base?.ref);
+
+    if (baseBranch) return baseBranch;
+  } catch {
+    return '';
+  }
+
+  return '';
+}
+
+async function handleBlockingRegistryHeadConclusion(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  headSha: string,
+  baseBranch: string,
+  reason: string
+): Promise<boolean> {
+  const sha = toStringTrim(headSha);
+  if (!sha) return false;
+
+  const marked = await markFailedRegistryPrHeadsForSha(context, repoInfo, sha, baseBranch, reason);
+  if (!marked) return false;
+
+  const advanceBaseBranch = await resolveSequentialRegistryQueueBaseBranchForHead(context, repoInfo, sha, baseBranch);
+  if (!advanceBaseBranch) return true;
+
+  await runOneSequentialDirectRegistryPrMaintenance(
+    context,
+    repoInfo,
+    advanceBaseBranch,
+    `${reason}:advance-next-registry-pr`
+  );
+
+  return true;
+}
+
 async function releaseSequentialRegistryPrIfNotApprovedAfterGreen(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -7980,23 +8031,13 @@ export default function requestHandler(app: Probot): void {
         if (status !== 'completed') return;
         if (conclusion && conclusion !== 'success') {
           if (isBlockingCheckConclusion(conclusion)) {
-            const baseBranch = readDefaultBranchFromPayload(payload);
-            const marked = await markFailedRegistryPrHeadsForSha(
+            await handleBlockingRegistryHeadConclusion(
               context,
               repoInfo,
               headShaStr,
-              baseBranch,
+              readDefaultBranchFromPayload(payload),
               `check-run:${conclusion}`
             );
-
-            if (marked) {
-              await runOneSequentialDirectRegistryPrMaintenance(
-                context,
-                repoInfo,
-                baseBranch,
-                `check-run:${conclusion}:advance-next-registry-pr`
-              );
-            }
           }
 
           return;
@@ -8067,6 +8108,16 @@ export default function requestHandler(app: Probot): void {
         if (!headShaStr) return;
         await tryAutoMerge(context, { owner: ownerLogin, repo: repoName }, headShaStr);
         return;
+      }
+
+      if (isBlockingCheckConclusion(conclusion)) {
+        await handleBlockingRegistryHeadConclusion(
+          context,
+          { owner: ownerLogin, repo: repoName },
+          headShaStr,
+          readDefaultBranchFromPayload(payload),
+          `check-suite:${conclusion}`
+        );
       }
 
       // failure -> comment on PR if registry-validate annotations exist


### PR DESCRIPTION
## Summary
- Release the active sequential registry PR lock on blocking `check_run` and `check_suite` results
- Load the latest config before detecting affected registry PR heads
- Mark failed/action-required registry PR heads as skipped
- Continue the queue with the next eligible registry PR

## Result
- Agent/direct PRs no longer wait behind a blocked active PR
- Sequential registry processing stays intact
- Failed or action-required PRs no longer stop the registry PR pipeline