### PR TITLE
Expose generic hook secrets to validation hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Registry Bot Release: Hook Secrets and Parent Owner Approval State
+
+### Added
+
+- Generic hook secret support for validation hooks
+  - Loads only CF environment variables prefixed with `HOOK_SECRET_`
+  - Strips the `HOOK_SECRET_` prefix before exposing values to hooks
+  - Provides hook access via `config.getSecret('<NAME>')`
+  - Example: `HOOK_SECRET_STC_URL` becomes `config.getSecret('STC_URL')`
+
+- Dedicated parent owner approval state
+  - Adds `Parent Owner Action` as workflow state while waiting for parent owner approval
+  - Tries to assign parent owners best-effort
+  - Keeps `@mentions` as fallback if GitHub assignment is not possible
+
+### Changed
+
+- Hook secret handling is now generic
+  - Registry hooks can call external services without hardcoded URLs or credentials
+  - Secrets stay scoped to hook execution
+
+- Parent owner approval flow is clearer
+  - `Parent Owner Action` replaces generic requester/review state while waiting for parent owners
+  - The request flow continues automatically after valid parent owner approval
+
+### Result
+
+- Registry hooks are more flexible and production-ready for external service validation.
+- Parent owner approval is easier to track, safer, and less confusing in the GitHub UI.
+
 ## [[0.1.6](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.6)] - 2026-04-29
 
 ## Enhance approval flow with subcontext direct PR, system contact gate and full parent chain validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.6-dev.1",
+  "version": "0.1.7-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.7-dev.1",
+  "version": "0.1.7",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.6",
+  "version": "0.1.6-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/constants.ts
+++ b/src/handlers/request/constants.ts
@@ -21,6 +21,7 @@ export type WorkflowReadableConfig = {
     labels?: {
       authorAction?: unknown;
       approverAction?: unknown;
+      parentOwnerAction?: unknown;
       [k: string]: unknown;
     } | null;
     approvers?: unknown;
@@ -56,6 +57,7 @@ export interface WorkflowLabelsConfig {
 
   authorAction: string | null;
   approverAction: string | null;
+  parentOwnerAction: string | null;
 
   approvalRequested: string[] | null;
   approvalSuccessful: string[] | null;
@@ -145,6 +147,7 @@ export const DEFAULT_CONFIG: StaticRegistryBotConfig = {
       // state labels (author vs review)
       authorAction: null,
       approverAction: null,
+      parentOwnerAction: null,
 
       // request/approval flow
       approvalRequested: null,
@@ -375,6 +378,15 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
                 minLength: 'workflow.labels.approverAction must not be empty when provided.',
               },
             },
+            parentOwnerAction: {
+              type: ['string', 'null'],
+              minLength: 1,
+              description: 'Optional workflow state label used while waiting for parent owner approval.',
+              errorMessage: {
+                type: 'workflow.labels.parentOwnerAction must be a string.',
+                minLength: 'workflow.labels.parentOwnerAction must not be empty when provided.',
+              },
+            },
             approvalRequested: {
               type: ['array', 'null'],
               items: { type: 'string' },
@@ -421,7 +433,8 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
               approvalRejected: 'workflow.labels.approvalRejected is required when workflow.labels is configured.',
               autoMergeCandidate: 'workflow.labels.autoMergeCandidate is required when workflow.labels is configured.',
             },
-            additionalProperties: 'Only known label keys are allowed inside workflow.labels.',
+            additionalProperties:
+              'Only known label keys are allowed inside workflow.labels, including parentOwnerAction.',
           },
         },
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1894,7 +1894,31 @@ async function removeReviewPendingLabelsAfterApproval(
 // Request lifecycle status labels
 const REQUEST_STATUS_LABEL_REQUESTER_ACTION = 'Requester Action';
 const REQUEST_STATUS_LABEL_REVIEW_PENDING = 'Review Pending';
+const REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION = 'Parent Owner Action';
 const REQUEST_STATUS_LABEL_REJECTED = 'Rejected';
+
+function resolveWorkflowLabel(context: BotContext<RequestEvents>, key: string, fallback: string): string {
+  const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
+  const wf = cfg?.workflow ?? {};
+
+  if (!isPlainObject(wf)) return fallback;
+
+  const labelsCfg = isPlainObject((wf as Record<string, unknown>)['labels'])
+    ? ((wf as Record<string, unknown>)['labels'] as Record<string, unknown>)
+    : {};
+
+  const raw = labelsCfg[key];
+
+  if (Array.isArray(raw)) {
+    return toStringTrim(raw[0]) || fallback;
+  }
+
+  return toStringTrim(raw) || fallback;
+}
+
+function resolveParentOwnerActionLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'parentOwnerAction', REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION);
+}
 
 const labelsMatching = (labels: string[], expected: string): string[] => {
   const expectedKey = normalizeKey(expected);
@@ -1905,6 +1929,80 @@ const labelsMatching = (labels: string[], expected: string): string[] => {
     return k === expectedKey || k.includes(expectedKey) || expectedKey.includes(k);
   });
 };
+
+async function clearParentOwnerActionState(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  currentLabels?: string[]
+): Promise<void> {
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+
+  let labels = (currentLabels || []).slice();
+  if (!labels.length) {
+    try {
+      labels = await fetchIssueLabels(context, params);
+    } catch {
+      return;
+    }
+  }
+
+  const toRemove = labelsMatching(labels, parentOwnerActionLabel);
+  if (!toRemove.length) return;
+
+  await removeExactLabelsFromIssue(context, params, toRemove);
+}
+
+async function setParentOwnerActionState(context: BotContext<RequestEvents>, params: IssueParams): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
+  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+
+  let labels: string[] = [];
+  try {
+    labels = await fetchIssueLabels(context, params);
+  } catch {
+    labels = [];
+  }
+
+  const toRemove = new Set<string>();
+
+  for (const label of [
+    authorActionLabel,
+    approverActionLabel,
+    approvedLabel,
+    REQUEST_STATUS_LABEL_REJECTED,
+    ...(eff.reviewRequestedLabels || []),
+  ]) {
+    for (const match of labelsMatching(labels, label)) {
+      if (normalizeKey(match) !== normalizeKey(parentOwnerActionLabel)) {
+        toRemove.add(match);
+      }
+    }
+  }
+
+  if (toRemove.size) {
+    await removeExactLabelsFromIssue(context, params, Array.from(toRemove));
+  }
+
+  await ensureLabelsPresentOnce(context, params, [parentOwnerActionLabel]);
+}
+
+async function assignParentOwnersForApproval(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  owners: string[]
+): Promise<void> {
+  const assignees = uniqLogins((owners || []).map(toStringTrim).filter(Boolean));
+  if (!assignees.length) return;
+
+  // Best effort only.
+  // If GitHub does not allow assignment, ensureAssigneesPresent logs and continues.
+  // The parent owners are still mentioned in the comment as fallback.
+  await ensureAssigneesPresent(context, params, assignees);
+}
 
 async function removeExactLabelsFromIssue(
   context: BotContext<RequestEvents>,
@@ -1944,9 +2042,14 @@ async function removeProgressStatusLabels(
     }
   }
 
+  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
+  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+
   const toRemove = new Set<string>([
-    ...labelsMatching(labels, REQUEST_STATUS_LABEL_REQUESTER_ACTION),
-    ...labelsMatching(labels, REQUEST_STATUS_LABEL_REVIEW_PENDING),
+    ...labelsMatching(labels, authorActionLabel),
+    ...labelsMatching(labels, approverActionLabel),
+    ...labelsMatching(labels, parentOwnerActionLabel),
   ]);
 
   if (!toRemove.size) return;
@@ -7746,6 +7849,7 @@ async function maybeRequireParentOwnerApproval(
   const rt = toStringTrim(requestType).toLowerCase();
   if (!rt.includes('namespace')) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7757,6 +7861,7 @@ async function maybeRequireParentOwnerApproval(
 
   if (parts.length <= 2) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7766,6 +7871,7 @@ async function maybeRequireParentOwnerApproval(
 
   if (!parent || owners.length === 0) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7779,6 +7885,7 @@ async function maybeRequireParentOwnerApproval(
       );
     }
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7789,9 +7896,15 @@ async function maybeRequireParentOwnerApproval(
     normalizeKey(current.target) === normalizeKey(target) &&
     Boolean(normalizeLogin(current.approvedBy));
 
-  if (alreadyApproved) return false;
+  if (alreadyApproved) {
+    await clearParentOwnerActionState(context, params);
+    return false;
+  }
 
   await ensureParentApprovalMarker(context, params, issue, { v: 1, parent, target, owners });
+
+  await setParentOwnerActionState(context, params);
+  await assignParentOwnersForApproval(context, params, owners);
 
   const mentions = owners.map((o) => `@${o}`).join(' ');
   const tag = `nsreq:parent-approval:${normalizeKey(parent)}:${normalizeKey(target)}`;
@@ -7809,7 +7922,6 @@ Please confirm by commenting \`Approved\`. After that, the bot will continue wit
     { minimizeTag: tag }
   );
 
-  await setStateLabel(context, params, issue, 'author');
   return true;
 }
 
@@ -7832,6 +7944,9 @@ async function handleParentOwnerApprovalIfNeeded(
   const tagBase = `nsreq:parent-approval:${normalizeKey(meta.parent)}:${normalizeKey(meta.target)}`;
 
   if (!isOwner) {
+    await setParentOwnerActionState(context, params);
+    await assignParentOwnersForApproval(context, params, owners);
+
     const mentions = owners.map((o) => `@${o}`).join(' ');
     await postOnce(
       context,
@@ -7868,6 +7983,7 @@ ${mentions}`,
         minimizeTag: 'nsreq:validation',
       }
     );
+    await clearParentOwnerActionState(context, params);
     await setStateLabel(context, params, issue, 'author');
     return true;
   }
@@ -7886,6 +8002,8 @@ ${mentions}`,
     approvedBy: commenterLogin,
     approvedAt: new Date().toISOString(),
   });
+
+  await clearParentOwnerActionState(context, params);
 
   const approvalOutcome = await maybeHandleApprovalDecision(
     context,
@@ -8550,6 +8668,9 @@ export default function requestHandler(app: Probot): void {
       const authorActionLabel = toStringTrim(labelsCfg['authorAction']) || REQUEST_STATUS_LABEL_REQUESTER_ACTION;
       const approverActionLabel = toStringTrim(labelsCfg['approverAction']) || REQUEST_STATUS_LABEL_REVIEW_PENDING;
 
+      const parentOwnerActionLabel =
+        toStringTrim(labelsCfg['parentOwnerAction']) || REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION;
+
       const authorActionKey = normalizeKey(authorActionLabel);
       const approverActionKey = normalizeKey(approverActionLabel);
       const isProgressStateLabel = (k: string): boolean => k === authorActionKey || k === approverActionKey;
@@ -8558,6 +8679,9 @@ export default function requestHandler(app: Probot): void {
 
       const lockedKeys = resolveLockedWorkflowLabelKeys(context);
       const changedKey = normalizeKey(changedLabel);
+
+      const parentOwnerActionKey = normalizeKey(parentOwnerActionLabel);
+      if (parentOwnerActionKey) lockedKeys.add(parentOwnerActionKey);
 
       const effectiveRequestType = template ? resolveEffectiveRequestType(template, parsedFormData) : '';
       const approverRouting = effectiveRequestType
@@ -8575,7 +8699,13 @@ export default function requestHandler(app: Probot): void {
       const senderIsConfiguredApprover = isConfiguredApprover(sender?.login, approverRouting.approvalUsernames);
 
       const managedWorkflowKeys = new Set<string>(Array.from(lockedKeys));
-      for (const label of [authorActionLabel, approverActionLabel, approvedLabel, REQUEST_STATUS_LABEL_REJECTED]) {
+      for (const label of [
+        authorActionLabel,
+        approverActionLabel,
+        parentOwnerActionLabel,
+        approvedLabel,
+        REQUEST_STATUS_LABEL_REJECTED,
+      ]) {
         const key = normalizeKey(label);
         if (key) managedWorkflowKeys.add(key);
       }

--- a/src/handlers/request/validation/hook-worker.ts
+++ b/src/handlers/request/validation/hook-worker.ts
@@ -92,6 +92,51 @@ function installSafeFetch(allowedHosts: string[], secrets: Record<string, string
   return api;
 }
 
+function normalizeHookSecretName(value: unknown): string {
+  return String(value ?? '')
+    .replace(/^HOOK_SECRET_/i, '')
+    .trim();
+}
+
+function collectHookConfigValues(configValue: unknown, secrets: Record<string, string>): Record<string, string> {
+  const values: Record<string, string> = {};
+
+  const add = (key: unknown, value: unknown): void => {
+    const normalizedKey = normalizeHookSecretName(key);
+    const normalizedValue = typeof value === 'string' ? value.trim() : '';
+
+    if (!normalizedKey || !normalizedValue) return;
+
+    values[normalizedKey] = normalizedValue;
+  };
+
+  for (const [key, value] of Object.entries(secrets || {})) {
+    add(key, value);
+  }
+
+  if (isPlainObject(configValue)) {
+    for (const [key, value] of Object.entries(configValue)) {
+      add(key, value);
+    }
+  }
+
+  return values;
+}
+
+function withHookGetSecret(configValue: unknown, secrets: Record<string, string>): Record<string, unknown> {
+  const config: Record<string, unknown> = isPlainObject(configValue) ? { ...configValue } : {};
+  const values = collectHookConfigValues(config, secrets);
+
+  Object.defineProperty(config, 'getSecret', {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: (key: string): string => values[normalizeHookSecretName(key)] || '',
+  });
+
+  return config;
+}
+
 async function loadModule(task: Task): Promise<Record<string, unknown>> {
   const key = `${task.owner}/${task.repo}:${task.path}#${task.hash}`;
   const cached = MODULE_CACHE.get(key);
@@ -148,6 +193,8 @@ export default async function hookWorker(task: Task): Promise<HookWorkerResult> 
     const argsObj: Record<string, unknown> = isPlainObject(task.args)
       ? { ...task.args, api, log }
       : { value: task.args, api, log };
+
+    argsObj.config = withHookGetSecret(argsObj.config, task.secrets ?? {});
 
     const fn = fnValue as (a: unknown) => unknown;
     const ret = await fn(argsObj);

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -143,6 +143,7 @@ type CustomValidateArgs = Readonly<{
   }>;
   parentResourceName?: string;
   parentCandidate?: Readonly<Record<string, unknown>> | null;
+  parentOwners?: readonly string[];
   log?: LoggerLike | undefined;
 }>;
 
@@ -634,6 +635,62 @@ async function resolveParentCandidateForValidationHook(
   };
 }
 
+function addNormalizedOwnerReference(out: Set<string>, value: unknown): void {
+  const raw = toStringSafe(value);
+  if (!raw) return;
+
+  const githubUrlMatch = /(?:github\.com|github\.tools\.sap)\/([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)/i.exec(
+    raw
+  );
+
+  if (githubUrlMatch?.[1]) {
+    out.add(normalizeLoginValue(githubUrlMatch[1]).toLowerCase());
+  }
+
+  for (const part of raw.split(/[,\s;]+/)) {
+    const cleaned = toStringSafe(part).replace(/^@+/, '').toLowerCase();
+    if (!cleaned) continue;
+
+    if (cleaned.includes('@')) {
+      out.add(cleaned);
+      continue;
+    }
+
+    if (/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(cleaned)) {
+      out.add(cleaned);
+    }
+  }
+}
+
+function collectNormalizedOwnerReferences(out: Set<string>, value: unknown): void {
+  if (value === null || value === undefined) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectNormalizedOwnerReferences(out, item);
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const item of Object.values(value)) collectNormalizedOwnerReferences(out, item);
+    return;
+  }
+
+  addNormalizedOwnerReference(out, value);
+}
+
+function resolveParentOwnersForValidationHook(parentCandidate: Record<string, unknown> | null): string[] {
+  if (!parentCandidate) return [];
+
+  const out = new Set<string>();
+
+  collectNormalizedOwnerReferences(
+    out,
+    parentCandidate['contacts'] ?? parentCandidate['contact'] ?? parentCandidate['owners'] ?? parentCandidate['owner']
+  );
+
+  return Array.from(out).filter(Boolean).sort();
+}
+
 async function buildCustomValidateContextArgs(
   context: ValidationContext,
   owner: string,
@@ -642,7 +699,9 @@ async function buildCustomValidateContextArgs(
   template: TemplateLike,
   requestCfg: RequestConfigEntry,
   resourceName: string
-): Promise<Pick<CustomValidateArgs, 'requestAuthor' | 'issue' | 'parentResourceName' | 'parentCandidate'>> {
+): Promise<
+  Pick<CustomValidateArgs, 'requestAuthor' | 'issue' | 'parentResourceName' | 'parentCandidate' | 'parentOwners'>
+> {
   const parent = await resolveParentCandidateForValidationHook(
     context,
     owner,
@@ -657,6 +716,7 @@ async function buildCustomValidateContextArgs(
     issue: buildValidationHookIssue(issue),
     parentResourceName: parent.parentResourceName,
     parentCandidate: parent.parentCandidate,
+    parentOwners: resolveParentOwnersForValidationHook(parent.parentCandidate),
   };
 }
 
@@ -3103,6 +3163,7 @@ export async function runCustomValidateForRegistryCandidate(
         },
         parentResourceName: '',
         parentCandidate: null,
+        parentOwners: [],
         log: getHookLogger(context.log),
       });
 
@@ -3134,6 +3195,7 @@ export async function runCustomValidateForRegistryCandidate(
       },
       parentResourceName: '',
       parentCandidate: null,
+      parentOwners: [],
       log: undefined,
     };
 

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -129,6 +129,20 @@ type CustomValidateArgs = Readonly<{
   form: FormData;
   api: unknown;
   config: Readonly<Record<string, string>>;
+  requestAuthor: Readonly<{
+    id: string;
+    email?: string;
+  }>;
+  issue: Readonly<{
+    number: number;
+    title: string;
+    body: string;
+    state: string;
+    author: string;
+    labels: string[];
+  }>;
+  parentResourceName?: string;
+  parentCandidate?: Readonly<Record<string, unknown>> | null;
   log?: LoggerLike | undefined;
 }>;
 
@@ -520,6 +534,130 @@ function approvalIssueLabelName(value: unknown): string {
 function toApprovalIssueLabelNames(labels: IssueLike['labels']): string[] {
   const items = Array.isArray(labels) ? labels : [];
   return items.map((label) => approvalIssueLabelName(label)).filter(Boolean);
+}
+
+function buildValidationHookIssue(issue: IssueLike): CustomValidateArgs['issue'] {
+  const author = toStringSafe(issue?.user?.login);
+
+  return {
+    number: typeof issue?.number === 'number' ? issue.number : 0,
+    title: toStringSafe(issue?.title),
+    body: toStringSafe(issue?.body),
+    state: toStringSafe(issue?.state),
+    author,
+    labels: toApprovalIssueLabelNames(issue?.labels),
+  };
+}
+
+function buildValidationHookRequestAuthor(issue: IssueLike): CustomValidateArgs['requestAuthor'] {
+  return {
+    id: toStringSafe(issue?.user?.login),
+  };
+}
+
+function resolveUpperNamespaceName(resourceName: unknown): string {
+  const parts = toStringSafe(resourceName)
+    .split('.')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length <= 2) return '';
+
+  return parts.slice(0, -1).join('.');
+}
+
+async function parseYamlObject(raw: string): Promise<Record<string, unknown> | null> {
+  try {
+    const yamlMod = (await import('yaml')) as unknown as {
+      parse?: (src: string) => unknown;
+      default?: { parse?: (src: string) => unknown };
+    };
+
+    const parse = yamlMod.parse || yamlMod.default?.parse;
+    if (typeof parse !== 'function') return null;
+
+    const parsed = parse(raw);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readRepoYamlObject(
+  context: ValidationContext,
+  owner: string,
+  repo: string,
+  basePath: string
+): Promise<Record<string, unknown> | null> {
+  for (const ext of ['yaml', 'yml']) {
+    try {
+      const res = await context.octokit.repos.getContent({
+        owner,
+        repo,
+        path: `${basePath}.${ext}`,
+      });
+
+      const data = res.data;
+      if (Array.isArray(data) || !isRepoContentFile(data)) continue;
+
+      const text = Buffer.from(data.content, (data.encoding || 'base64') as BufferEncoding).toString('utf8');
+      const parsed = await parseYamlObject(text);
+      if (parsed) return parsed;
+    } catch (e: unknown) {
+      if (getHttpStatus(e) === 404) continue;
+      throw e;
+    }
+  }
+
+  return null;
+}
+
+async function resolveParentCandidateForValidationHook(
+  context: ValidationContext,
+  owner: string,
+  repo: string,
+  template: TemplateLike,
+  requestCfg: RequestConfigEntry,
+  resourceName: string
+): Promise<{ parentResourceName: string; parentCandidate: Record<string, unknown> | null }> {
+  const parentResourceName = resolveUpperNamespaceName(resourceName);
+  if (!parentResourceName) {
+    return { parentResourceName: '', parentCandidate: null };
+  }
+
+  const root = resolveRegistryRootForTemplate(context, template, requestCfg);
+  const parentCandidate = await readRepoYamlObject(context, owner, repo, `${root}/${parentResourceName}`);
+
+  return {
+    parentResourceName,
+    parentCandidate,
+  };
+}
+
+async function buildCustomValidateContextArgs(
+  context: ValidationContext,
+  owner: string,
+  repo: string,
+  issue: IssueLike,
+  template: TemplateLike,
+  requestCfg: RequestConfigEntry,
+  resourceName: string
+): Promise<Pick<CustomValidateArgs, 'requestAuthor' | 'issue' | 'parentResourceName' | 'parentCandidate'>> {
+  const parent = await resolveParentCandidateForValidationHook(
+    context,
+    owner,
+    repo,
+    template,
+    requestCfg,
+    resourceName
+  );
+
+  return {
+    requestAuthor: buildValidationHookRequestAuthor(issue),
+    issue: buildValidationHookIssue(issue),
+    parentResourceName: parent.parentResourceName,
+    parentCandidate: parent.parentCandidate,
+  };
 }
 
 function normalizeApprovalHookErrors(value: unknown): readonly {
@@ -2531,6 +2669,16 @@ export async function validateRequestIssue(
       const runCustomValidate = async (): Promise<void> => {
         if (!hooks) return;
 
+        const customValidateContextArgs = await buildCustomValidateContextArgs(
+          context,
+          owner,
+          repo,
+          issue,
+          template,
+          requestCfg,
+          rawIdOrNs
+        );
+
         // Worker path: hooks is just a descriptor (raw code + hash)
         if (isHookDescriptor(hooks)) {
           const nameVal = candidate['name'];
@@ -2542,6 +2690,7 @@ export async function validateRequestIssue(
             form: normalizedFormData,
             api: null,
             config: hookPublicConfig,
+            ...customValidateContextArgs,
             log: undefined,
           };
 
@@ -2616,6 +2765,7 @@ export async function validateRequestIssue(
             form: normalizedFormData,
             api: hookApi,
             config: hookPublicConfig,
+            ...customValidateContextArgs,
             log: getHookLogger(context.log),
           });
 
@@ -2942,6 +3092,17 @@ export async function runCustomValidateForRegistryCandidate(
           allowedHosts,
         }),
         config: hookPublicConfig,
+        requestAuthor: { id: '' },
+        issue: {
+          number: 0,
+          title: '',
+          body: '',
+          state: '',
+          author: '',
+          labels: [],
+        },
+        parentResourceName: '',
+        parentCandidate: null,
         log: getHookLogger(context.log),
       });
 
@@ -2962,6 +3123,17 @@ export async function runCustomValidateForRegistryCandidate(
       form,
       api: null,
       config: hookPublicConfig,
+      requestAuthor: { id: '' },
+      issue: {
+        number: 0,
+        title: '',
+        body: '',
+        state: '',
+        author: '',
+        labels: [],
+      },
+      parentResourceName: '',
+      parentCandidate: null,
       log: undefined,
     };
 

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -128,6 +128,7 @@ type CustomValidateArgs = Readonly<{
   candidate: Record<string, unknown>;
   form: FormData;
   api: unknown;
+  config: Readonly<Record<string, string>>;
   log?: LoggerLike | undefined;
 }>;
 
@@ -2539,6 +2540,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: null,
+            config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
             log: undefined,
           };
 
@@ -2612,6 +2614,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: hookApi,
+            config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
             log: getHookLogger(context.log),
           });
 
@@ -2933,6 +2936,7 @@ export async function runCustomValidateForRegistryCandidate(
           secrets: coreSecrets.HOOK_SECRETS || {},
           allowedHosts,
         }),
+        config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
         log: getHookLogger(context.log),
       });
 
@@ -2952,6 +2956,7 @@ export async function runCustomValidateForRegistryCandidate(
       candidate: args.candidate,
       form,
       api: null,
+      config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
       log: undefined,
     };
 

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -18,18 +18,17 @@ const DBG = process.env.DEBUG_NS === '1';
 
 const CONFIG_BASE_DIR = '.github/registry-bot';
 
-type HookSecrets = Readonly<{
-  CLD_API_BASE_URL?: string;
-  CLD_API_KEY?: string;
+type HookSecrets = Readonly<Record<string, string | undefined>>;
 
-  STC_API_BASE_URL?: string;
-  STC_API_KEY?: string;
+type HookWorkerConfig = Readonly<Record<string, string>>;
 
-  PPMS_API_BASE_URL?: string;
-  PPMS_API_KEY?: string;
+type HookRuntimeConfig = Readonly<
+  Record<string, string | ((key: string) => string)> & {
+    getSecret: (key: string) => string;
+  }
+>;
 
-  [k: string]: string | undefined;
-}>;
+type HookConfig = HookWorkerConfig | HookRuntimeConfig;
 
 type CoreSecrets = Readonly<{
   APP_ID?: string;
@@ -118,7 +117,7 @@ type BeforeValidateArgs = Readonly<{
   requestType: string;
   form: FormData;
   api: unknown;
-  config: Readonly<Record<string, string>>;
+  config: HookConfig;
   log?: LoggerLike | undefined;
 }>;
 
@@ -128,7 +127,7 @@ type CustomValidateArgs = Readonly<{
   candidate: Record<string, unknown>;
   form: FormData;
   api: unknown;
-  config: Readonly<Record<string, string>>;
+  config: HookConfig;
   requestAuthor: Readonly<{
     id: string;
     email?: string;
@@ -371,13 +370,36 @@ function getHttpStatus(err: unknown): number | undefined {
   return typeof status === 'number' ? status : undefined;
 }
 
-function pickHookPublicConfig(secrets: HookSecrets): Readonly<Record<string, string>> {
+function normalizeHookSecretName(value: unknown): string {
+  return toStringSafe(value)
+    .replace(/^HOOK_SECRET_/i, '')
+    .trim();
+}
+
+function buildHookWorkerConfig(secrets: HookSecrets): HookWorkerConfig {
   const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(secrets || {})) {
-    if (!v) continue;
-    if (/_API_BASE_URL$/i.test(k)) out[k] = String(v).trim();
+
+  for (const [key, value] of Object.entries(secrets || {})) {
+    if (typeof value !== 'string') continue;
+
+    const secretName = normalizeHookSecretName(key);
+    const secretValue = value.trim();
+
+    if (!secretName || !secretValue) continue;
+
+    out[secretName] = secretValue;
   }
-  return out;
+
+  return Object.freeze(out);
+}
+
+function buildHookRuntimeConfig(secrets: HookSecrets): HookRuntimeConfig {
+  const values = buildHookWorkerConfig(secrets);
+
+  return Object.freeze({
+    ...values,
+    getSecret: (key: string): string => values[normalizeHookSecretName(key)] || '',
+  }) as HookRuntimeConfig;
 }
 
 function pickHookSecretsForWorker(secrets: HookSecrets): Record<string, string> {
@@ -2456,7 +2478,8 @@ export async function validateRequestIssue(
   const allowedHosts = Array.isArray(ah) ? ah : [];
 
   const workerSecrets = pickHookSecretsForWorker(coreSecrets.HOOK_SECRETS || {});
-  const hookPublicConfig = pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {});
+  const hookWorkerConfig = buildHookWorkerConfig(coreSecrets.HOOK_SECRETS || {});
+  const hookRuntimeConfig = buildHookRuntimeConfig(coreSecrets.HOOK_SECRETS || {});
 
   const hookApi = createHookApi(context, {
     secrets: coreSecrets.HOOK_SECRETS || {},
@@ -2483,7 +2506,7 @@ export async function validateRequestIssue(
         requestType,
         form: formData,
         api: null,
-        config: hookPublicConfig,
+        config: hookWorkerConfig,
         log: undefined,
       };
       const res = await runHookInWorker(
@@ -2542,7 +2565,7 @@ export async function validateRequestIssue(
           requestType,
           form: formData,
           api: hookApi,
-          config: hookPublicConfig,
+          config: hookRuntimeConfig,
           log: getHookLogger(context.log),
         });
       } catch (err: unknown) {
@@ -2689,7 +2712,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: null,
-            config: hookPublicConfig,
+            config: hookWorkerConfig,
             ...customValidateContextArgs,
             log: undefined,
           };
@@ -2764,7 +2787,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: hookApi,
-            config: hookPublicConfig,
+            config: hookRuntimeConfig,
             ...customValidateContextArgs,
             log: getHookLogger(context.log),
           });
@@ -3054,7 +3077,8 @@ export async function runCustomValidateForRegistryCandidate(
     ? context.resourceBotConfig.hooks.allowedHosts
     : [];
 
-  const hookPublicConfig = pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {});
+  const hookWorkerConfig = buildHookWorkerConfig(coreSecrets.HOOK_SECRETS || {});
+  const hookRuntimeConfig = buildHookRuntimeConfig(coreSecrets.HOOK_SECRETS || {});
 
   const form =
     args.formData && isPlainObject(args.formData)
@@ -3091,7 +3115,7 @@ export async function runCustomValidateForRegistryCandidate(
           secrets: coreSecrets.HOOK_SECRETS || {},
           allowedHosts,
         }),
-        config: hookPublicConfig,
+        config: hookRuntimeConfig,
         requestAuthor: { id: '' },
         issue: {
           number: 0,
@@ -3122,7 +3146,7 @@ export async function runCustomValidateForRegistryCandidate(
       candidate: args.candidate,
       form,
       api: null,
-      config: hookPublicConfig,
+      config: hookWorkerConfig,
       requestAuthor: { id: '' },
       issue: {
         number: 0,

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -2318,6 +2318,7 @@ export async function validateRequestIssue(
   const allowedHosts = Array.isArray(ah) ? ah : [];
 
   const workerSecrets = pickHookSecretsForWorker(coreSecrets.HOOK_SECRETS || {});
+  const hookPublicConfig = pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {});
 
   const hookApi = createHookApi(context, {
     secrets: coreSecrets.HOOK_SECRETS || {},
@@ -2344,7 +2345,7 @@ export async function validateRequestIssue(
         requestType,
         form: formData,
         api: null,
-        config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+        config: hookPublicConfig,
         log: undefined,
       };
       const res = await runHookInWorker(
@@ -2403,7 +2404,7 @@ export async function validateRequestIssue(
           requestType,
           form: formData,
           api: hookApi,
-          config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+          config: hookPublicConfig,
           log: getHookLogger(context.log),
         });
       } catch (err: unknown) {
@@ -2540,7 +2541,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: null,
-            config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+            config: hookPublicConfig,
             log: undefined,
           };
 
@@ -2614,7 +2615,7 @@ export async function validateRequestIssue(
             candidate,
             form: normalizedFormData,
             api: hookApi,
-            config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+            config: hookPublicConfig,
             log: getHookLogger(context.log),
           });
 
@@ -2893,6 +2894,8 @@ export async function runCustomValidateForRegistryCandidate(
     formData?: FormData | null;
   }
 ): Promise<string[]> {
+  await ensureStaticConfigLoaded(context);
+
   const hooks = getResourceBotHooks(context);
 
   if (!hooks) return [];
@@ -2900,6 +2903,8 @@ export async function runCustomValidateForRegistryCandidate(
   const allowedHosts = Array.isArray(context.resourceBotConfig?.hooks?.allowedHosts)
     ? context.resourceBotConfig.hooks.allowedHosts
     : [];
+
+  const hookPublicConfig = pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {});
 
   const form =
     args.formData && isPlainObject(args.formData)
@@ -2936,7 +2941,7 @@ export async function runCustomValidateForRegistryCandidate(
           secrets: coreSecrets.HOOK_SECRETS || {},
           allowedHosts,
         }),
-        config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+        config: hookPublicConfig,
         log: getHookLogger(context.log),
       });
 
@@ -2956,7 +2961,7 @@ export async function runCustomValidateForRegistryCandidate(
       candidate: args.candidate,
       form,
       api: null,
-      config: pickHookPublicConfig(coreSecrets.HOOK_SECRETS || {}),
+      config: hookPublicConfig,
       log: undefined,
     };
 

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,13 +1,4 @@
-export type HookSecrets = Readonly<{
-  CLD_API_BASE_URL?: string;
-  CLD_API_KEY?: string;
-
-  STC_API_BASE_URL?: string;
-  STC_API_KEY?: string;
-
-  PPMS_API_BASE_URL?: string;
-  PPMS_API_KEY?: string;
-}>;
+export type HookSecrets = Readonly<Record<string, string | undefined>>;
 
 export type CoreSecrets = Readonly<{
   APP_ID?: string;
@@ -19,6 +10,24 @@ export type CoreSecrets = Readonly<{
 
 export const coreSecrets: CoreSecrets = Object.freeze(loadSecrets());
 
+function collectHookSecretsFromEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith('HOOK_SECRET_')) continue;
+    if (value === undefined || value === null) continue;
+
+    const secretName = key.slice('HOOK_SECRET_'.length).trim();
+    const secretValue = String(value).trim();
+
+    if (!secretName || !secretValue) continue;
+
+    out[secretName] = secretValue;
+  }
+
+  return out;
+}
+
 export function loadSecrets(env: NodeJS.ProcessEnv = process.env): CoreSecrets {
   const get = (key: string, fallback?: string): string | undefined => {
     const value = env[key];
@@ -27,16 +36,7 @@ export function loadSecrets(env: NodeJS.ProcessEnv = process.env): CoreSecrets {
 
   const privateKeyPem = normalizePem(get('PRIVATE_KEY')) ?? decodeB64(get('PRIVATE_KEY_B64'));
 
-  const hookSecrets: HookSecrets = Object.freeze({
-    CLD_API_BASE_URL: get('CLD_API_BASE_URL'),
-    CLD_API_KEY: get('CLD_API_KEY'),
-
-    STC_API_BASE_URL: get('STC_API_BASE_URL'),
-    STC_API_KEY: get('STC_API_KEY'),
-
-    PPMS_API_BASE_URL: get('PPMS_API_BASE_URL'),
-    PPMS_API_KEY: get('PPMS_API_KEY'),
-  });
+  const hookSecrets: HookSecrets = Object.freeze(collectHookSecretsFromEnv(env));
 
   return Object.freeze({
     APP_ID: get('APP_ID'),

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -134,11 +134,13 @@ describe('src/handlers/request/constants.ts', () => {
       global: null,
       authorAction: null,
       approverAction: null,
+      parentOwnerAction: null,
       approvalRequested: null,
       approvalSuccessful: null,
       approvalRejected: null,
       autoMergeCandidate: null,
     });
+    expect(mod.DEFAULT_CONFIG.workflow?.approversPool).toBeNull();
     expect(mod.DEFAULT_CONFIG.workflow?.approvers).toBeNull();
     expect(mod.DEFAULT_CONFIG.workflow?.links).toEqual({ docs: null });
   });
@@ -161,5 +163,15 @@ describe('src/handlers/request/constants.ts', () => {
     expect(methodEnum).toEqual(
       expect.arrayContaining(['merge', 'squash', 'rebase', 'MERGE', 'SQUASH', 'REBASE', null])
     );
+    const workflowLabels = s.properties?.workflow?.properties?.labels;
+
+    expect(workflowLabels?.properties?.parentOwnerAction).toEqual(
+      expect.objectContaining({
+        type: ['string', 'null'],
+        minLength: 1,
+      })
+    );
+
+    expect(workflowLabels?.required).not.toContain('parentOwnerAction');
   });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -1984,7 +1984,26 @@ describe('parent owner approval gating', () => {
     expect(posted).toContain('@barOwner');
     expect(posted).not.toContain('@topOwner');
 
-    expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+    expect(setStateLabel).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 550,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 550,
+        assignees: ['barOwner'],
+      })
+    );
+
     expect(ensureAssigneesOnce).not.toHaveBeenCalled();
   });
 
@@ -14856,7 +14875,13 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     });
 
     const ctx = mkIssuesContext({ issue, action: 'opened', withCachedConfig: true, config: productCfg() });
-    ctx.octokit.issues.update.mockRejectedValueOnce(new Error('cannot add marker'));
+    ctx.octokit.issues.update.mockImplementation(async (args: any) => {
+      if (String(args?.body || '').includes('nsreq:parent-approval')) {
+        throw new Error('cannot add marker');
+      }
+
+      return {} as any;
+    });
     ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
       if (path === 'data/vendors/sap.yaml') {
         return {
@@ -14883,7 +14908,224 @@ describe('request orchestrator edge coverage for defensive branches', () => {
 
     expect(postedBodies()).toContain('Parent owner approval required');
     expect(postedBodies()).toContain('@parentOwner');
-    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+    expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        body: expect.stringContaining('nsreq:parent-approval'),
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        assignees: ['parentOwner'],
+      })
+    );
+
+    expect(setStateLabel).not.toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+    expect(issue.body).not.toContain('nsreq:parent-approval');
+  });
+
+  test('issues.opened: parent approval state replaces other workflow state labels', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 914,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [
+        { name: 'Requester Action' },
+        { name: 'Review Pending' },
+        { name: 'Approved' },
+        { name: 'Sub-Context Namespace' },
+      ],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    const ctx = mkIssuesContext({
+      issue,
+      action: 'opened',
+      withCachedConfig: true,
+      config: {
+        workflow: {
+          labels: {
+            approvalRequested: ['Review Pending'],
+            approvalSuccessful: ['Approved'],
+            parentOwnerAction: 'Parent Owner Action',
+          },
+          approvers: [],
+        },
+        requests: {},
+      },
+    });
+
+    ctx.octokit.issues.get.mockResolvedValue({
+      data: {
+        ...issue,
+        labels: issue.labels,
+        assignees: [],
+      },
+    });
+
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64('contacts:\n  - "@topOwner"\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64('contacts:\n  - "@parentOwner"\n'), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Requester Action',
+      })
+    );
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Review Pending',
+      })
+    );
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Approved',
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(setStateLabel).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+  });
+
+  test('issues.opened: parent owner assignment failure still posts parent approval request', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 915,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    const ctx = mkIssuesContext({ issue, action: 'opened' });
+
+    ctx.octokit.issues.addAssignees.mockRejectedValueOnce(new Error('Validation Failed'));
+
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64('contacts:\n  - "@topOwner"\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64('contacts:\n  - "@parentOwner"\n'), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 915,
+        assignees: ['parentOwner'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 915,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(postedBodies()).toContain('Parent owner approval required');
+    expect(postedBodies()).toContain('@parentOwner');
   });
 
   test('issues.labeled: routing lock treats template lookup failure for changed label as non-routing', async () => {

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -6,27 +6,52 @@ function b64(s: string): string {
 
 test('returns defaults when env is empty', () => {
   const s = loadSecrets({});
+
   expect(s).toEqual({
     APP_ID: undefined,
     WEBHOOK_SECRET: undefined,
     PRIVATE_KEY: undefined,
     DEBUG_NS: '1',
-    HOOK_SECRETS: {
-      CLD_API_BASE_URL: undefined,
-      CLD_API_KEY: undefined,
-      STC_API_BASE_URL: undefined,
-      STC_API_KEY: undefined,
-      PPMS_API_BASE_URL: undefined,
-      PPMS_API_KEY: undefined,
-    },
+    HOOK_SECRETS: {},
   });
 });
 
-test('reads core secrets and hook secrets', () => {
+test('reads core secrets and generic HOOK_SECRET_* values', () => {
   const s = loadSecrets({
     APP_ID: 'app',
     WEBHOOK_SECRET: 'wh',
     DEBUG_NS: '9',
+    HOOK_SECRET_STC_URL: ' https://stc.example ',
+    HOOK_SECRET_BASIC_AUTH: ' Basic abc123 ',
+    HOOK_SECRET_PPMS_URL: ' https://ppms.example ',
+  });
+
+  expect(s.APP_ID).toBe('app');
+  expect(s.WEBHOOK_SECRET).toBe('wh');
+  expect(s.DEBUG_NS).toBe('9');
+
+  expect(s.HOOK_SECRETS).toEqual({
+    STC_URL: 'https://stc.example',
+    BASIC_AUTH: 'Basic abc123',
+    PPMS_URL: 'https://ppms.example',
+  });
+});
+
+test('strips HOOK_SECRET_ prefix and does not expose prefixed names', () => {
+  const s = loadSecrets({
+    HOOK_SECRET_STC_URL: 'https://stc.example',
+    HOOK_SECRET_BASIC_AUTH: 'Basic secret',
+  });
+
+  expect(s.HOOK_SECRETS.STC_URL).toBe('https://stc.example');
+  expect(s.HOOK_SECRETS.BASIC_AUTH).toBe('Basic secret');
+
+  expect(s.HOOK_SECRETS.HOOK_SECRET_STC_URL).toBeUndefined();
+  expect(s.HOOK_SECRETS.HOOK_SECRET_BASIC_AUTH).toBeUndefined();
+});
+
+test('ignores old legacy hook secret env variables', () => {
+  const s = loadSecrets({
     CLD_API_BASE_URL: 'https://cld.example',
     CLD_API_KEY: 'cld',
     STC_API_BASE_URL: 'https://stc.example',
@@ -35,11 +60,46 @@ test('reads core secrets and hook secrets', () => {
     PPMS_API_KEY: 'ppms',
   });
 
-  expect(s.APP_ID).toBe('app');
-  expect(s.WEBHOOK_SECRET).toBe('wh');
-  expect(s.DEBUG_NS).toBe('9');
-  expect(s.HOOK_SECRETS.CLD_API_BASE_URL).toBe('https://cld.example');
-  expect(s.HOOK_SECRETS.PPMS_API_KEY).toBe('ppms');
+  expect(s.HOOK_SECRETS).toEqual({});
+  expect(s.HOOK_SECRETS.CLD_API_BASE_URL).toBeUndefined();
+  expect(s.HOOK_SECRETS.STC_API_BASE_URL).toBeUndefined();
+  expect(s.HOOK_SECRETS.PPMS_API_KEY).toBeUndefined();
+});
+
+test('ignores non-prefixed hook-looking variables', () => {
+  const s = loadSecrets({
+    STC_URL: 'https://stc.example',
+    BASIC_AUTH: 'Basic secret',
+    PPMS_URL: 'https://ppms.example',
+  });
+
+  expect(s.HOOK_SECRETS).toEqual({});
+});
+
+test('trims hook secret values and skips empty names or empty values', () => {
+  const s = loadSecrets({
+    HOOK_SECRET_: 'should-be-ignored',
+    HOOK_SECRET_EMPTY: '',
+    HOOK_SECRET_BLANK: '   ',
+    HOOK_SECRET_VALID: ' valid-value ',
+  });
+
+  expect(s.HOOK_SECRETS).toEqual({
+    VALID: 'valid-value',
+  });
+});
+
+test('skips nullish hook secret values defensively', () => {
+  const s = loadSecrets({
+    HOOK_SECRET_VALID: 'ok',
+    // NodeJS.ProcessEnv normally only has string | undefined.
+    // This keeps the defensive null branch covered.
+    HOOK_SECRET_NULLISH: null,
+  } as unknown as NodeJS.ProcessEnv);
+
+  expect(s.HOOK_SECRETS).toEqual({
+    VALID: 'ok',
+  });
 });
 
 test('PRIVATE_KEY wins if it looks like PEM (contains BEGIN) and is trimmed', () => {
@@ -49,7 +109,7 @@ test('PRIVATE_KEY wins if it looks like PEM (contains BEGIN) and is trimmed', ()
     PRIVATE_KEY_B64: b64('should-not-be-used'),
   });
 
-  expect(s.PRIVATE_KEY).toContain('BEGIN PRIVATE KEY');
+  expect(s.PRIVATE_KEY).toBe('-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----');
 });
 
 test('falls back to PRIVATE_KEY_B64 if PRIVATE_KEY is not a PEM', () => {
@@ -64,16 +124,21 @@ test('falls back to PRIVATE_KEY_B64 if PRIVATE_KEY is not a PEM', () => {
 
 test('PRIVATE_KEY stays undefined if neither PEM nor B64 are provided', () => {
   const s = loadSecrets({ PRIVATE_KEY: 'not-a-pem' });
+
   expect(s.PRIVATE_KEY).toBeUndefined();
 });
 
 test('DEBUG_NS empty string stays empty (no fallback)', () => {
   const s = loadSecrets({ DEBUG_NS: '' });
+
   expect(s.DEBUG_NS).toBe('');
 });
 
 test('returned objects are frozen', () => {
-  const s = loadSecrets({ APP_ID: 'x' });
+  const s = loadSecrets({
+    APP_ID: 'x',
+    HOOK_SECRET_BASIC_AUTH: 'Basic secret',
+  });
 
   expect(Object.isFrozen(s)).toBe(true);
   expect(Object.isFrozen(s.HOOK_SECRETS)).toBe(true);
@@ -85,6 +150,11 @@ test('returned objects are frozen', () => {
 
   expect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (s.HOOK_SECRETS as any).CLD_API_KEY = 'y';
+    (s.HOOK_SECRETS as any).BASIC_AUTH = 'changed';
+  }).toThrow();
+
+  expect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (s.HOOK_SECRETS as any).NEW_SECRET = 'new';
   }).toThrow();
 });


### PR DESCRIPTION
Pass CF-provided `HOOK_SECRET_*` values to registry validation hooks.

- loads only environment variables prefixed with `HOOK_SECRET_`
- strips the prefix before exposing them to hooks
- provides access through `config.getSecret('<NAME>')`
- keeps hook secrets scoped to hook execution
- removes legacy fixed CLD/STC/PPMS secret handling
- enables registry hooks to call external services without hardcoded URLs or credentials

Example:

`HOOK_SECRET_STC_URL` becomes `config.getSecret('STC_URL')`.