### PR TITLE
feat: add parent owner action state for parent approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Registry Bot Release: Hook Secrets and Parent Owner Approval State
+
+### Added
+
+- Generic hook secret support for validation hooks
+  - Loads only CF environment variables prefixed with `HOOK_SECRET_`
+  - Strips the `HOOK_SECRET_` prefix before exposing values to hooks
+  - Provides hook access via `config.getSecret('<NAME>')`
+  - Example: `HOOK_SECRET_STC_URL` becomes `config.getSecret('STC_URL')`
+
+- Dedicated parent owner approval state
+  - Adds `Parent Owner Action` as workflow state while waiting for parent owner approval
+  - Tries to assign parent owners best-effort
+  - Keeps `@mentions` as fallback if GitHub assignment is not possible
+
+### Changed
+
+- Hook secret handling is now generic
+  - Registry hooks can call external services without hardcoded URLs or credentials
+  - Secrets stay scoped to hook execution
+
+- Parent owner approval flow is clearer
+  - `Parent Owner Action` replaces generic requester/review state while waiting for parent owners
+  - The request flow continues automatically after valid parent owner approval
+
+### Result
+
+- Registry hooks are more flexible and production-ready for external service validation.
+- Parent owner approval is easier to track, safer, and less confusing in the GitHub UI.
+
 ## [[0.1.6](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.6)] - 2026-04-29
 
 ## Enhance approval flow with subcontext direct PR, system contact gate and full parent chain validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.6-dev.1",
+  "version": "0.1.7-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.7-dev.1",
+  "version": "0.1.7",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/constants.ts
+++ b/src/handlers/request/constants.ts
@@ -21,6 +21,7 @@ export type WorkflowReadableConfig = {
     labels?: {
       authorAction?: unknown;
       approverAction?: unknown;
+      parentOwnerAction?: unknown;
       [k: string]: unknown;
     } | null;
     approvers?: unknown;
@@ -56,6 +57,7 @@ export interface WorkflowLabelsConfig {
 
   authorAction: string | null;
   approverAction: string | null;
+  parentOwnerAction: string | null;
 
   approvalRequested: string[] | null;
   approvalSuccessful: string[] | null;
@@ -145,6 +147,7 @@ export const DEFAULT_CONFIG: StaticRegistryBotConfig = {
       // state labels (author vs review)
       authorAction: null,
       approverAction: null,
+      parentOwnerAction: null,
 
       // request/approval flow
       approvalRequested: null,
@@ -375,6 +378,15 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
                 minLength: 'workflow.labels.approverAction must not be empty when provided.',
               },
             },
+            parentOwnerAction: {
+              type: ['string', 'null'],
+              minLength: 1,
+              description: 'Optional workflow state label used while waiting for parent owner approval.',
+              errorMessage: {
+                type: 'workflow.labels.parentOwnerAction must be a string.',
+                minLength: 'workflow.labels.parentOwnerAction must not be empty when provided.',
+              },
+            },
             approvalRequested: {
               type: ['array', 'null'],
               items: { type: 'string' },
@@ -421,7 +433,8 @@ export const STATIC_CONFIG_SCHEMA: Record<string, unknown> = {
               approvalRejected: 'workflow.labels.approvalRejected is required when workflow.labels is configured.',
               autoMergeCandidate: 'workflow.labels.autoMergeCandidate is required when workflow.labels is configured.',
             },
-            additionalProperties: 'Only known label keys are allowed inside workflow.labels.',
+            additionalProperties:
+              'Only known label keys are allowed inside workflow.labels, including parentOwnerAction.',
           },
         },
 

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -1894,7 +1894,31 @@ async function removeReviewPendingLabelsAfterApproval(
 // Request lifecycle status labels
 const REQUEST_STATUS_LABEL_REQUESTER_ACTION = 'Requester Action';
 const REQUEST_STATUS_LABEL_REVIEW_PENDING = 'Review Pending';
+const REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION = 'Parent Owner Action';
 const REQUEST_STATUS_LABEL_REJECTED = 'Rejected';
+
+function resolveWorkflowLabel(context: BotContext<RequestEvents>, key: string, fallback: string): string {
+  const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
+  const wf = cfg?.workflow ?? {};
+
+  if (!isPlainObject(wf)) return fallback;
+
+  const labelsCfg = isPlainObject((wf as Record<string, unknown>)['labels'])
+    ? ((wf as Record<string, unknown>)['labels'] as Record<string, unknown>)
+    : {};
+
+  const raw = labelsCfg[key];
+
+  if (Array.isArray(raw)) {
+    return toStringTrim(raw[0]) || fallback;
+  }
+
+  return toStringTrim(raw) || fallback;
+}
+
+function resolveParentOwnerActionLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'parentOwnerAction', REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION);
+}
 
 const labelsMatching = (labels: string[], expected: string): string[] => {
   const expectedKey = normalizeKey(expected);
@@ -1905,6 +1929,80 @@ const labelsMatching = (labels: string[], expected: string): string[] => {
     return k === expectedKey || k.includes(expectedKey) || expectedKey.includes(k);
   });
 };
+
+async function clearParentOwnerActionState(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  currentLabels?: string[]
+): Promise<void> {
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+
+  let labels = (currentLabels || []).slice();
+  if (!labels.length) {
+    try {
+      labels = await fetchIssueLabels(context, params);
+    } catch {
+      return;
+    }
+  }
+
+  const toRemove = labelsMatching(labels, parentOwnerActionLabel);
+  if (!toRemove.length) return;
+
+  await removeExactLabelsFromIssue(context, params, toRemove);
+}
+
+async function setParentOwnerActionState(context: BotContext<RequestEvents>, params: IssueParams): Promise<void> {
+  const eff = resolveEffectiveConstants(context);
+
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
+  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+
+  let labels: string[] = [];
+  try {
+    labels = await fetchIssueLabels(context, params);
+  } catch {
+    labels = [];
+  }
+
+  const toRemove = new Set<string>();
+
+  for (const label of [
+    authorActionLabel,
+    approverActionLabel,
+    approvedLabel,
+    REQUEST_STATUS_LABEL_REJECTED,
+    ...(eff.reviewRequestedLabels || []),
+  ]) {
+    for (const match of labelsMatching(labels, label)) {
+      if (normalizeKey(match) !== normalizeKey(parentOwnerActionLabel)) {
+        toRemove.add(match);
+      }
+    }
+  }
+
+  if (toRemove.size) {
+    await removeExactLabelsFromIssue(context, params, Array.from(toRemove));
+  }
+
+  await ensureLabelsPresentOnce(context, params, [parentOwnerActionLabel]);
+}
+
+async function assignParentOwnersForApproval(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  owners: string[]
+): Promise<void> {
+  const assignees = uniqLogins((owners || []).map(toStringTrim).filter(Boolean));
+  if (!assignees.length) return;
+
+  // Best effort only.
+  // If GitHub does not allow assignment, ensureAssigneesPresent logs and continues.
+  // The parent owners are still mentioned in the comment as fallback.
+  await ensureAssigneesPresent(context, params, assignees);
+}
 
 async function removeExactLabelsFromIssue(
   context: BotContext<RequestEvents>,
@@ -1944,9 +2042,14 @@ async function removeProgressStatusLabels(
     }
   }
 
+  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
+  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+
   const toRemove = new Set<string>([
-    ...labelsMatching(labels, REQUEST_STATUS_LABEL_REQUESTER_ACTION),
-    ...labelsMatching(labels, REQUEST_STATUS_LABEL_REVIEW_PENDING),
+    ...labelsMatching(labels, authorActionLabel),
+    ...labelsMatching(labels, approverActionLabel),
+    ...labelsMatching(labels, parentOwnerActionLabel),
   ]);
 
   if (!toRemove.size) return;
@@ -7746,6 +7849,7 @@ async function maybeRequireParentOwnerApproval(
   const rt = toStringTrim(requestType).toLowerCase();
   if (!rt.includes('namespace')) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7757,6 +7861,7 @@ async function maybeRequireParentOwnerApproval(
 
   if (parts.length <= 2) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7766,6 +7871,7 @@ async function maybeRequireParentOwnerApproval(
 
   if (!parent || owners.length === 0) {
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7779,6 +7885,7 @@ async function maybeRequireParentOwnerApproval(
       );
     }
     await ensureParentApprovalMarker(context, params, issue, null);
+    await clearParentOwnerActionState(context, params);
     return false;
   }
 
@@ -7789,9 +7896,15 @@ async function maybeRequireParentOwnerApproval(
     normalizeKey(current.target) === normalizeKey(target) &&
     Boolean(normalizeLogin(current.approvedBy));
 
-  if (alreadyApproved) return false;
+  if (alreadyApproved) {
+    await clearParentOwnerActionState(context, params);
+    return false;
+  }
 
   await ensureParentApprovalMarker(context, params, issue, { v: 1, parent, target, owners });
+
+  await setParentOwnerActionState(context, params);
+  await assignParentOwnersForApproval(context, params, owners);
 
   const mentions = owners.map((o) => `@${o}`).join(' ');
   const tag = `nsreq:parent-approval:${normalizeKey(parent)}:${normalizeKey(target)}`;
@@ -7809,7 +7922,6 @@ Please confirm by commenting \`Approved\`. After that, the bot will continue wit
     { minimizeTag: tag }
   );
 
-  await setStateLabel(context, params, issue, 'author');
   return true;
 }
 
@@ -7832,6 +7944,9 @@ async function handleParentOwnerApprovalIfNeeded(
   const tagBase = `nsreq:parent-approval:${normalizeKey(meta.parent)}:${normalizeKey(meta.target)}`;
 
   if (!isOwner) {
+    await setParentOwnerActionState(context, params);
+    await assignParentOwnersForApproval(context, params, owners);
+
     const mentions = owners.map((o) => `@${o}`).join(' ');
     await postOnce(
       context,
@@ -7868,6 +7983,7 @@ ${mentions}`,
         minimizeTag: 'nsreq:validation',
       }
     );
+    await clearParentOwnerActionState(context, params);
     await setStateLabel(context, params, issue, 'author');
     return true;
   }
@@ -7886,6 +8002,8 @@ ${mentions}`,
     approvedBy: commenterLogin,
     approvedAt: new Date().toISOString(),
   });
+
+  await clearParentOwnerActionState(context, params);
 
   const approvalOutcome = await maybeHandleApprovalDecision(
     context,
@@ -8550,6 +8668,9 @@ export default function requestHandler(app: Probot): void {
       const authorActionLabel = toStringTrim(labelsCfg['authorAction']) || REQUEST_STATUS_LABEL_REQUESTER_ACTION;
       const approverActionLabel = toStringTrim(labelsCfg['approverAction']) || REQUEST_STATUS_LABEL_REVIEW_PENDING;
 
+      const parentOwnerActionLabel =
+        toStringTrim(labelsCfg['parentOwnerAction']) || REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION;
+
       const authorActionKey = normalizeKey(authorActionLabel);
       const approverActionKey = normalizeKey(approverActionLabel);
       const isProgressStateLabel = (k: string): boolean => k === authorActionKey || k === approverActionKey;
@@ -8558,6 +8679,9 @@ export default function requestHandler(app: Probot): void {
 
       const lockedKeys = resolveLockedWorkflowLabelKeys(context);
       const changedKey = normalizeKey(changedLabel);
+
+      const parentOwnerActionKey = normalizeKey(parentOwnerActionLabel);
+      if (parentOwnerActionKey) lockedKeys.add(parentOwnerActionKey);
 
       const effectiveRequestType = template ? resolveEffectiveRequestType(template, parsedFormData) : '';
       const approverRouting = effectiveRequestType
@@ -8575,7 +8699,13 @@ export default function requestHandler(app: Probot): void {
       const senderIsConfiguredApprover = isConfiguredApprover(sender?.login, approverRouting.approvalUsernames);
 
       const managedWorkflowKeys = new Set<string>(Array.from(lockedKeys));
-      for (const label of [authorActionLabel, approverActionLabel, approvedLabel, REQUEST_STATUS_LABEL_REJECTED]) {
+      for (const label of [
+        authorActionLabel,
+        approverActionLabel,
+        parentOwnerActionLabel,
+        approvedLabel,
+        REQUEST_STATUS_LABEL_REJECTED,
+      ]) {
         const key = normalizeKey(label);
         if (key) managedWorkflowKeys.add(key);
       }

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -143,6 +143,7 @@ type CustomValidateArgs = Readonly<{
   }>;
   parentResourceName?: string;
   parentCandidate?: Readonly<Record<string, unknown>> | null;
+  parentOwners?: readonly string[];
   log?: LoggerLike | undefined;
 }>;
 
@@ -634,6 +635,62 @@ async function resolveParentCandidateForValidationHook(
   };
 }
 
+function addNormalizedOwnerReference(out: Set<string>, value: unknown): void {
+  const raw = toStringSafe(value);
+  if (!raw) return;
+
+  const githubUrlMatch = /(?:github\.com|github\.tools\.sap)\/([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)/i.exec(
+    raw
+  );
+
+  if (githubUrlMatch?.[1]) {
+    out.add(normalizeLoginValue(githubUrlMatch[1]).toLowerCase());
+  }
+
+  for (const part of raw.split(/[,\s;]+/)) {
+    const cleaned = toStringSafe(part).replace(/^@+/, '').toLowerCase();
+    if (!cleaned) continue;
+
+    if (cleaned.includes('@')) {
+      out.add(cleaned);
+      continue;
+    }
+
+    if (/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(cleaned)) {
+      out.add(cleaned);
+    }
+  }
+}
+
+function collectNormalizedOwnerReferences(out: Set<string>, value: unknown): void {
+  if (value === null || value === undefined) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectNormalizedOwnerReferences(out, item);
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const item of Object.values(value)) collectNormalizedOwnerReferences(out, item);
+    return;
+  }
+
+  addNormalizedOwnerReference(out, value);
+}
+
+function resolveParentOwnersForValidationHook(parentCandidate: Record<string, unknown> | null): string[] {
+  if (!parentCandidate) return [];
+
+  const out = new Set<string>();
+
+  collectNormalizedOwnerReferences(
+    out,
+    parentCandidate['contacts'] ?? parentCandidate['contact'] ?? parentCandidate['owners'] ?? parentCandidate['owner']
+  );
+
+  return Array.from(out).filter(Boolean).sort();
+}
+
 async function buildCustomValidateContextArgs(
   context: ValidationContext,
   owner: string,
@@ -642,7 +699,9 @@ async function buildCustomValidateContextArgs(
   template: TemplateLike,
   requestCfg: RequestConfigEntry,
   resourceName: string
-): Promise<Pick<CustomValidateArgs, 'requestAuthor' | 'issue' | 'parentResourceName' | 'parentCandidate'>> {
+): Promise<
+  Pick<CustomValidateArgs, 'requestAuthor' | 'issue' | 'parentResourceName' | 'parentCandidate' | 'parentOwners'>
+> {
   const parent = await resolveParentCandidateForValidationHook(
     context,
     owner,
@@ -657,6 +716,7 @@ async function buildCustomValidateContextArgs(
     issue: buildValidationHookIssue(issue),
     parentResourceName: parent.parentResourceName,
     parentCandidate: parent.parentCandidate,
+    parentOwners: resolveParentOwnersForValidationHook(parent.parentCandidate),
   };
 }
 
@@ -3103,6 +3163,7 @@ export async function runCustomValidateForRegistryCandidate(
         },
         parentResourceName: '',
         parentCandidate: null,
+        parentOwners: [],
         log: getHookLogger(context.log),
       });
 
@@ -3134,6 +3195,7 @@ export async function runCustomValidateForRegistryCandidate(
       },
       parentResourceName: '',
       parentCandidate: null,
+      parentOwners: [],
       log: undefined,
     };
 

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -134,11 +134,13 @@ describe('src/handlers/request/constants.ts', () => {
       global: null,
       authorAction: null,
       approverAction: null,
+      parentOwnerAction: null,
       approvalRequested: null,
       approvalSuccessful: null,
       approvalRejected: null,
       autoMergeCandidate: null,
     });
+    expect(mod.DEFAULT_CONFIG.workflow?.approversPool).toBeNull();
     expect(mod.DEFAULT_CONFIG.workflow?.approvers).toBeNull();
     expect(mod.DEFAULT_CONFIG.workflow?.links).toEqual({ docs: null });
   });
@@ -161,5 +163,15 @@ describe('src/handlers/request/constants.ts', () => {
     expect(methodEnum).toEqual(
       expect.arrayContaining(['merge', 'squash', 'rebase', 'MERGE', 'SQUASH', 'REBASE', null])
     );
+    const workflowLabels = s.properties?.workflow?.properties?.labels;
+
+    expect(workflowLabels?.properties?.parentOwnerAction).toEqual(
+      expect.objectContaining({
+        type: ['string', 'null'],
+        minLength: 1,
+      })
+    );
+
+    expect(workflowLabels?.required).not.toContain('parentOwnerAction');
   });
 });

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -1984,7 +1984,26 @@ describe('parent owner approval gating', () => {
     expect(posted).toContain('@barOwner');
     expect(posted).not.toContain('@topOwner');
 
-    expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+    expect(setStateLabel).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 550,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 550,
+        assignees: ['barOwner'],
+      })
+    );
+
     expect(ensureAssigneesOnce).not.toHaveBeenCalled();
   });
 
@@ -14856,7 +14875,13 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     });
 
     const ctx = mkIssuesContext({ issue, action: 'opened', withCachedConfig: true, config: productCfg() });
-    ctx.octokit.issues.update.mockRejectedValueOnce(new Error('cannot add marker'));
+    ctx.octokit.issues.update.mockImplementation(async (args: any) => {
+      if (String(args?.body || '').includes('nsreq:parent-approval')) {
+        throw new Error('cannot add marker');
+      }
+
+      return {} as any;
+    });
     ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
       if (path === 'data/vendors/sap.yaml') {
         return {
@@ -14883,7 +14908,224 @@ describe('request orchestrator edge coverage for defensive branches', () => {
 
     expect(postedBodies()).toContain('Parent owner approval required');
     expect(postedBodies()).toContain('@parentOwner');
-    expect(setStateLabel).toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+    expect(ctx.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        body: expect.stringContaining('nsreq:parent-approval'),
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        issue_number: 913,
+        assignees: ['parentOwner'],
+      })
+    );
+
+    expect(setStateLabel).not.toHaveBeenCalledWith(ctx, expect.anything(), issue, 'author');
+    expect(issue.body).not.toContain('nsreq:parent-approval');
+  });
+
+  test('issues.opened: parent approval state replaces other workflow state labels', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 914,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [
+        { name: 'Requester Action' },
+        { name: 'Review Pending' },
+        { name: 'Approved' },
+        { name: 'Sub-Context Namespace' },
+      ],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    const ctx = mkIssuesContext({
+      issue,
+      action: 'opened',
+      withCachedConfig: true,
+      config: {
+        workflow: {
+          labels: {
+            approvalRequested: ['Review Pending'],
+            approvalSuccessful: ['Approved'],
+            parentOwnerAction: 'Parent Owner Action',
+          },
+          approvers: [],
+        },
+        requests: {},
+      },
+    });
+
+    ctx.octokit.issues.get.mockResolvedValue({
+      data: {
+        ...issue,
+        labels: issue.labels,
+        assignees: [],
+      },
+    });
+
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64('contacts:\n  - "@topOwner"\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64('contacts:\n  - "@parentOwner"\n'), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Requester Action',
+      })
+    );
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Review Pending',
+      })
+    );
+
+    expect(ctx.octokit.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        name: 'Approved',
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 914,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(setStateLabel).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'author');
+  });
+
+  test('issues.opened: parent owner assignment failure still posts parent approval request', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar.foo';
+    const issue = {
+      number: 915,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { login: 'requester' },
+      state: 'open',
+    };
+
+    const tpl = {
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    const ctx = mkIssuesContext({ issue, action: 'opened' });
+
+    ctx.octokit.issues.addAssignees.mockRejectedValueOnce(new Error('Validation Failed'));
+
+    ctx.octokit.repos.getContent.mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return { data: { content: b64('contacts:\n  - "@topOwner"\n'), encoding: 'base64' } };
+      }
+      if (path === 'data/namespaces/sap.css.bar.yaml') {
+        return { data: { content: b64('contacts:\n  - "@parentOwner"\n'), encoding: 'base64' } };
+      }
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await handlers['issues.opened'][0](ctx);
+
+    expect(ctx.octokit.issues.addAssignees).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 915,
+        assignees: ['parentOwner'],
+      })
+    );
+
+    expect(ctx.octokit.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 915,
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(postedBodies()).toContain('Parent owner approval required');
+    expect(postedBodies()).toContain('@parentOwner');
   });
 
   test('issues.labeled: routing lock treats template lookup failure for changed label as non-routing', async () => {


### PR DESCRIPTION
Adds a dedicated workflow state for parent owner approval.

- sets `Parent Owner Action` while waiting for parent owner approval
- tries to assign parent owners best-effort
- keeps owner mentions as fallback when assignment is not possible
- removes the parent owner state after approval or when the gate no longer applies
- keeps the flow moving after parent owner approval