### PR TITLE
Improve direct PR workflow automation and state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+## Improve direct PR state handling and workflow automation
+
+- Resolve workflow labels dynamically from target `config.yaml`
+- Keep workflow state labels exclusive
+- Remove duplicate handover markers
+- Accept `Approved` comments only when the request/PR is in review state
+- Try to approve pending workflows for safe registry-only PRs
+- Add pull request event handling for workflow approval
+- Close empty no-op registry PRs
+
+Result: cleaner PR/Issue states, fewer manual steps for trusted registry PRs, and safer direct PR automation.
+
 ## [[0.1.7](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.7)] - 2026-05-08
 
 ## Registry Bot Release: Hook Secrets and Parent Owner Approval State

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
-## Improve direct PR state handling and workflow automation
+## Improve direct PR workflow automation and state handling
 
 - Resolve workflow labels dynamically from target `config.yaml`
 - Keep workflow state labels exclusive
 - Remove duplicate handover markers
 - Accept `Approved` comments only when the request/PR is in review state
 - Try to approve pending workflows for safe registry-only PRs
-- Add pull request event handling for workflow approval
+- Prioritize auto-approvable direct PRs in the sequential queue
 - Close empty no-op registry PRs
+- Auto-approve sub-context requests when the requester owns the parent namespace
 
-Result: cleaner PR/Issue states, fewer manual steps for trusted registry PRs, and safer direct PR automation.
+Result: cleaner PR/Issue states, fewer manual CPA steps, and safer direct PR automation.
 
 ## [[0.1.7](https://github.com/open-resource-discovery/global-registry-bot/releases/tag/v0.1.7)] - 2026-05-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.7",
+  "version": "0.1.8-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.8-dev.1",
+  "version": "0.1.8",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -319,11 +319,93 @@ const AUTO_MERGE_EVALUATION_INFLIGHT = new Map<string, Promise<void>>();
 const AUTO_MERGE_EVALUATION_RECENT_UNTIL = new Map<string, number>();
 const AUTO_MERGE_EVALUATION_RECENT_TTL_MS = 30_000;
 
-// Request lifecycle status labels
-const REQUEST_STATUS_LABEL_REQUESTER_ACTION = 'Requester Action';
-const REQUEST_STATUS_LABEL_REVIEW_PENDING = 'Review Pending';
-const REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION = 'Parent Owner Action';
-const REQUEST_STATUS_LABEL_REJECTED = 'Rejected';
+type WorkflowLabelKey =
+  | 'global'
+  | 'authorAction'
+  | 'approverAction'
+  | 'parentOwnerAction'
+  | 'approvalRequested'
+  | 'approvalSuccessful'
+  | 'approvalRejected'
+  | 'autoMergeCandidate';
+
+function readWorkflowLabelsConfig(context: BotContext<RequestEvents>): Record<string, unknown> {
+  const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
+  const wf = cfg?.workflow ?? {};
+
+  if (!isPlainObject(wf)) return {};
+
+  const labels = (wf as Record<string, unknown>)['labels'];
+  return isPlainObject(labels) ? labels : {};
+}
+
+function resolveWorkflowLabels(context: BotContext<RequestEvents>, key: WorkflowLabelKey): string[] {
+  const raw = readWorkflowLabelsConfig(context)[key];
+
+  if (Array.isArray(raw)) {
+    return raw.map(toStringTrim).filter(Boolean);
+  }
+
+  const single = toStringTrim(raw);
+  return single ? [single] : [];
+}
+
+function resolveWorkflowLabel(context: BotContext<RequestEvents>, key: WorkflowLabelKey): string {
+  return resolveWorkflowLabels(context, key)[0] || '';
+}
+
+function resolveAuthorActionLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'authorAction');
+}
+
+function resolveApproverActionLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'approverAction');
+}
+
+function resolveParentOwnerActionLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'parentOwnerAction');
+}
+
+function resolveApprovedLabels(context: BotContext<RequestEvents>): string[] {
+  return resolveWorkflowLabels(context, 'approvalSuccessful');
+}
+
+function resolveApprovedLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'approvalSuccessful');
+}
+
+function resolveRejectedLabels(context: BotContext<RequestEvents>): string[] {
+  return resolveWorkflowLabels(context, 'approvalRejected');
+}
+
+function resolveRejectedLabel(context: BotContext<RequestEvents>): string {
+  return resolveWorkflowLabel(context, 'approvalRejected');
+}
+
+const normalizeKey = (s: unknown): string => {
+  const base = toStringTrim(s).toLowerCase();
+  return base.replaceAll(/[^\w]+/g, '-').replaceAll(/(?:^-+|-+$)/g, '');
+};
+
+const labelsMatching = (labels: string[], expected: string): string[] => {
+  const expectedKey = normalizeKey(expected);
+  if (!expectedKey) return [];
+
+  return (labels || []).filter((l) => {
+    const k = normalizeKey(l);
+    return k === expectedKey || k.includes(expectedKey) || expectedKey.includes(k);
+  });
+};
+
+function labelsMatchingAny(labels: string[], expectedLabels: string[]): string[] {
+  const out: string[] = [];
+
+  for (const expected of expectedLabels.map(toStringTrim).filter(Boolean)) {
+    out.push(...labelsMatching(labels, expected));
+  }
+
+  return Array.from(new Set(out));
+}
 
 function normalizeSchemaFieldAlias(value: unknown): string {
   const raw = toStringTrim(value);
@@ -981,11 +1063,6 @@ function stripRegistrySuffix(msg: string): string {
   const i = msg.indexOf(' [file=');
   return (i >= 0 ? msg.slice(0, i) : msg).trim();
 }
-
-const normalizeKey = (s: unknown): string => {
-  const base = toStringTrim(s).toLowerCase();
-  return base.replaceAll(/[^\w]+/g, '-').replaceAll(/(?:^-+|-+$)/g, '');
-};
 
 function toSectionTitle(field: string): string {
   const raw = toStringTrim(field);
@@ -1826,10 +1903,11 @@ async function handoverToCpa(
 
   await ensureLabelsPresentOnce(context, params, labelsToAdd);
 
-  await enforceExclusiveWorkflowStateLabels(context, params, [
-    resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING),
-    ...(eff.reviewRequestedLabels || []),
-  ]);
+  await enforceExclusiveWorkflowStateLabels(
+    context,
+    params,
+    [resolveApproverActionLabel(context), ...(eff.reviewRequestedLabels || [])].filter(Boolean)
+  );
 
   if (eff.labelOnApproved) {
     try {
@@ -1918,55 +1996,17 @@ async function removeReviewPendingLabelsAfterApproval(
   }
 }
 
-function resolveWorkflowLabel(context: BotContext<RequestEvents>, key: string, fallback: string): string {
-  const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
-  const wf = cfg?.workflow ?? {};
-
-  if (!isPlainObject(wf)) return fallback;
-
-  const labelsCfg = isPlainObject((wf as Record<string, unknown>)['labels'])
-    ? ((wf as Record<string, unknown>)['labels'] as Record<string, unknown>)
-    : {};
-
-  const raw = labelsCfg[key];
-
-  if (Array.isArray(raw)) {
-    return toStringTrim(raw[0]) || fallback;
-  }
-
-  return toStringTrim(raw) || fallback;
-}
-
-function resolveParentOwnerActionLabel(context: BotContext<RequestEvents>): string {
-  return resolveWorkflowLabel(context, 'parentOwnerAction', REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION);
-}
-
-const labelsMatching = (labels: string[], expected: string): string[] => {
-  const expectedKey = normalizeKey(expected);
-  if (!expectedKey) return [];
-
-  return (labels || []).filter((l) => {
-    const k = normalizeKey(l);
-    return k === expectedKey || k.includes(expectedKey) || expectedKey.includes(k);
-  });
-};
-
 function collectWorkflowStateLabels(context: BotContext<RequestEvents>): string[] {
   const eff = resolveEffectiveConstants(context);
-
-  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
-  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
-  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
 
   return Array.from(
     new Set(
       [
-        authorActionLabel,
-        approverActionLabel,
-        parentOwnerActionLabel,
-        approvedLabel,
-        REQUEST_STATUS_LABEL_REJECTED,
+        resolveAuthorActionLabel(context),
+        resolveApproverActionLabel(context),
+        resolveParentOwnerActionLabel(context),
+        ...resolveApprovedLabels(context),
+        ...resolveRejectedLabels(context),
         ...(eff.reviewRequestedLabels || []),
       ]
         .map(toStringTrim)
@@ -2038,6 +2078,11 @@ async function clearParentOwnerActionState(
 async function setParentOwnerActionState(context: BotContext<RequestEvents>, params: IssueParams): Promise<void> {
   const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
 
+  if (!parentOwnerActionLabel) {
+    log(context, 'warn', { issueNumber: params.issue_number }, 'parent-owner-action-state:missing-config-label');
+    return;
+  }
+
   await enforceExclusiveWorkflowStateLabels(context, params, [parentOwnerActionLabel]);
   await ensureLabelsPresentOnce(context, params, [parentOwnerActionLabel]);
 }
@@ -2086,6 +2131,7 @@ async function removeProgressStatusLabels(
   currentLabels?: string[]
 ): Promise<void> {
   let labels = (currentLabels || []).slice();
+
   if (!labels.length) {
     try {
       labels = await fetchIssueLabels(context, params);
@@ -2094,17 +2140,22 @@ async function removeProgressStatusLabels(
     }
   }
 
-  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
-  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
-  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+  const stateLabels = [
+    resolveAuthorActionLabel(context),
+    resolveApproverActionLabel(context),
+    resolveParentOwnerActionLabel(context),
+  ].filter(Boolean);
 
-  const toRemove = new Set<string>([
-    ...labelsMatching(labels, authorActionLabel),
-    ...labelsMatching(labels, approverActionLabel),
-    ...labelsMatching(labels, parentOwnerActionLabel),
-  ]);
+  const toRemove = new Set<string>();
+
+  for (const stateLabel of stateLabels) {
+    for (const match of labelsMatching(labels, stateLabel)) {
+      toRemove.add(match);
+    }
+  }
 
   if (!toRemove.size) return;
+
   await removeExactLabelsFromIssue(context, params, Array.from(toRemove));
 }
 
@@ -2114,6 +2165,7 @@ async function removeRejectedStatusLabel(
   currentLabels?: string[]
 ): Promise<void> {
   let labels = (currentLabels || []).slice();
+
   if (!labels.length) {
     try {
       labels = await fetchIssueLabels(context, params);
@@ -2122,8 +2174,10 @@ async function removeRejectedStatusLabel(
     }
   }
 
-  const toRemove = labelsMatching(labels, REQUEST_STATUS_LABEL_REJECTED);
+  const toRemove = labelsMatchingAny(labels, resolveRejectedLabels(context));
+
   if (!toRemove.length) return;
+
   await removeExactLabelsFromIssue(context, params, toRemove);
 }
 
@@ -2268,22 +2322,25 @@ async function applyApprovedRequestState(
   params: IssueParams,
   eff: EffectiveConstants
 ): Promise<void> {
+  const approvedLabels = resolveApprovedLabels(context);
+  const approvedLabel = resolveApprovedLabel(context);
+
   try {
-    if (eff.labelOnApproved) {
-      await context.octokit.issues.addLabels({ ...params, labels: [eff.labelOnApproved] });
+    if (approvedLabel) {
+      await context.octokit.issues.addLabels({ ...params, labels: [approvedLabel] });
     }
   } catch {
     // ignore
   }
 
-  await enforceExclusiveWorkflowStateLabels(context, params, [toStringTrim(eff.labelOnApproved) || 'Approved']);
+  await enforceExclusiveWorkflowStateLabels(context, params, approvedLabels);
 
   await removeReviewPendingLabelsAfterApproval(context, params, eff);
 
   try {
     const labelsAfter = await fetchIssueLabels(context, params);
-    const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
-    if (labelsMatching(labelsAfter, approvedLabel).length) {
+
+    if (labelsMatchingAny(labelsAfter, approvedLabels).length) {
       await removeProgressStatusLabels(context, params, labelsAfter);
       await removeRejectedStatusLabel(context, params, labelsAfter);
     }
@@ -2534,7 +2591,9 @@ async function addApprovedLabelToPr(
   options: { skipStateCleanup?: boolean } = {}
 ): Promise<void> {
   const eff = resolveEffectiveConstants(context);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+  const approvedLabel = resolveApprovedLabel(context);
+  const approvedLabels = resolveApprovedLabels(context);
+
   if (!approvedLabel) return;
 
   const params: IssueParams = {
@@ -2552,7 +2611,7 @@ async function addApprovedLabelToPr(
     return;
   }
 
-  await enforceExclusiveWorkflowStateLabels(context, params, [approvedLabel]);
+  await enforceExclusiveWorkflowStateLabels(context, params, approvedLabels);
 
   // Standalone cross-repo direct PRs must stay PR-only here.
   // Reading the PR as an issue would break the no-linked-issue guarantee.
@@ -2724,9 +2783,8 @@ async function hasApprovedLabelOnPr(
   repoInfo: RepoInfo,
   prNumber: number
 ): Promise<boolean> {
-  const eff = resolveEffectiveConstants(context);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
-  if (!approvedLabel) return false;
+  const approvedLabels = resolveApprovedLabels(context);
+  if (!approvedLabels.length) return false;
 
   try {
     const labels = await fetchIssueLabels(context, {
@@ -2735,7 +2793,7 @@ async function hasApprovedLabelOnPr(
       issue_number: prNumber,
     });
 
-    return labelsMatching(labels, approvedLabel).length > 0;
+    return labelsMatchingAny(labels, approvedLabels).length > 0;
   } catch {
     return false;
   }
@@ -6341,10 +6399,11 @@ async function handoverStandaloneDirectPrToReview(
   const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
   await ensureLabelsPresentOnce(context, params, labelsToAdd);
 
-  await enforceExclusiveWorkflowStateLabels(context, params, [
-    resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING),
-    ...(eff.reviewRequestedLabels || []),
-  ]);
+  await enforceExclusiveWorkflowStateLabels(
+    context,
+    params,
+    [resolveApproverActionLabel(context), ...(eff.reviewRequestedLabels || [])].filter(Boolean)
+  );
 
   if (eff.labelOnApproved) {
     try {
@@ -8898,8 +8957,9 @@ export default function requestHandler(app: Probot): void {
     const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
     if (!isRequestIssue(context, template, parsedFormData)) return;
 
-    const eff = resolveEffectiveConstants(context);
-    const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+    const approvedLabel = resolveApprovedLabel(context);
+    const rejectedLabel = resolveRejectedLabel(context);
+    const rejectedLabels = resolveRejectedLabels(context);
 
     let labels: string[] = [];
     try {
@@ -8908,7 +8968,8 @@ export default function requestHandler(app: Probot): void {
       labels = toLabelNames(issue.labels);
     }
 
-    const hasApproved = labelsMatching(labels, approvedLabel).length > 0;
+    const approvedLabels = resolveApprovedLabels(context);
+    const hasApproved = labelsMatchingAny(labels, approvedLabels).length > 0;
 
     // If approved, keep it clean
     if (hasApproved) {
@@ -8918,18 +8979,19 @@ export default function requestHandler(app: Probot): void {
     }
 
     // Closed but not approved -> mark as rejected
-    const hasRejected = labelsMatching(labels, REQUEST_STATUS_LABEL_REJECTED).length > 0;
-    if (!hasRejected) {
+    const hasRejected = labelsMatchingAny(labels, rejectedLabels).length > 0;
+
+    if (rejectedLabel && !hasRejected) {
       try {
         await context.octokit.issues.addLabels({
           ...params,
-          labels: [REQUEST_STATUS_LABEL_REJECTED],
+          labels: [rejectedLabel],
         });
       } catch (e: unknown) {
         log(
           context,
           'warn',
-          { err: e instanceof Error ? e.message : String(e), label: REQUEST_STATUS_LABEL_REJECTED },
+          { err: e instanceof Error ? e.message : String(e), label: rejectedLabel },
           'failed to add rejected status label'
         );
       }
@@ -8942,13 +9004,14 @@ export default function requestHandler(app: Probot): void {
       // best effort
     }
 
-    if (labelsMatching(labels, REQUEST_STATUS_LABEL_REJECTED).length) {
+    if (labelsMatchingAny(labels, rejectedLabels).length) {
       await removeProgressStatusLabels(context, params, labels);
 
-      // enforce mutual exclusivity
-      const approvedMatches = labelsMatching(labels, approvedLabel);
-      if (approvedMatches.length) {
-        await removeExactLabelsFromIssue(context, params, approvedMatches);
+      if (approvedLabel) {
+        const approvedMatches = labelsMatchingAny(labels, approvedLabels);
+        if (approvedMatches.length) {
+          await removeExactLabelsFromIssue(context, params, approvedMatches);
+        }
       }
     }
   });
@@ -9006,25 +9069,20 @@ export default function requestHandler(app: Probot): void {
 
       const eff = resolveEffectiveConstants(context);
 
-      // Allow manual switching of progress-state labels (authorAction / approverAction).
-      const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
-      const wf = cfg?.workflow ?? {};
-      const labelsCfg =
-        isPlainObject(wf) && isPlainObject((wf as Record<string, unknown>)['labels'])
-          ? ((wf as Record<string, unknown>)['labels'] as Record<string, unknown>)
-          : {};
+      const authorActionLabel = resolveAuthorActionLabel(context);
+      const approverActionLabel = resolveApproverActionLabel(context);
+      const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
 
-      const authorActionLabel = toStringTrim(labelsCfg['authorAction']) || REQUEST_STATUS_LABEL_REQUESTER_ACTION;
-      const approverActionLabel = toStringTrim(labelsCfg['approverAction']) || REQUEST_STATUS_LABEL_REVIEW_PENDING;
+      const approvedLabels = resolveApprovedLabels(context);
 
-      const parentOwnerActionLabel =
-        toStringTrim(labelsCfg['parentOwnerAction']) || REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION;
+      const rejectedLabel = resolveRejectedLabel(context);
+      const rejectedLabels = resolveRejectedLabels(context);
 
-      const authorActionKey = normalizeKey(authorActionLabel);
-      const approverActionKey = normalizeKey(approverActionLabel);
-      const isProgressStateLabel = (k: string): boolean => k === authorActionKey || k === approverActionKey;
+      const progressStateKeys = new Set(
+        [authorActionLabel, approverActionLabel, parentOwnerActionLabel].map(normalizeKey).filter(Boolean)
+      );
 
-      const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+      const isProgressStateLabel = (k: string): boolean => progressStateKeys.has(k);
 
       const lockedKeys = resolveLockedWorkflowLabelKeys(context);
       const changedKey = normalizeKey(changedLabel);
@@ -9052,8 +9110,8 @@ export default function requestHandler(app: Probot): void {
         authorActionLabel,
         approverActionLabel,
         parentOwnerActionLabel,
-        approvedLabel,
-        REQUEST_STATUS_LABEL_REJECTED,
+        ...approvedLabels,
+        ...rejectedLabels,
       ]) {
         const key = normalizeKey(label);
         if (key) managedWorkflowKeys.add(key);
@@ -9067,7 +9125,8 @@ export default function requestHandler(app: Probot): void {
 
       if (changedKey && lockedKeys.has(changedKey) && !isProgressStateLabel(changedKey)) {
         // Let the existing "Approved label" guard handle manual approval attempts.
-        const isManualApprovedAdd = action === 'labeled' && labelsMatching([changedLabel], approvedLabel).length > 0;
+        const isManualApprovedAdd =
+          action === 'labeled' && labelsMatchingAny([changedLabel], approvedLabels).length > 0;
 
         if (!isManualApprovedAdd) {
           if (action === 'labeled') {
@@ -9092,8 +9151,8 @@ export default function requestHandler(app: Probot): void {
       }
 
       // 3) Manual "Approved" label => rollback
-      if (action === 'labeled' && labelsMatching([changedLabel], approvedLabel).length) {
-        const approvedMatches = labelsMatching(labels, approvedLabel);
+      if (action === 'labeled' && labelsMatchingAny([changedLabel], approvedLabels).length) {
+        const approvedMatches = labelsMatchingAny(labels, approvedLabels);
         await removeExactLabelsFromIssue(context, params, approvedMatches);
 
         // Best effort: keep existing progress label
@@ -9113,16 +9172,16 @@ export default function requestHandler(app: Probot): void {
       // 4) Manual "Rejected" on open issues => rollback
       if (
         action === 'labeled' &&
-        labelsMatching([changedLabel], REQUEST_STATUS_LABEL_REJECTED).length &&
+        labelsMatchingAny([changedLabel], rejectedLabels).length &&
         toStringTrim(issue.state).toLowerCase() !== 'closed'
       ) {
-        const rejectedMatches = labelsMatching(labels, REQUEST_STATUS_LABEL_REJECTED);
+        const rejectedMatches = labelsMatchingAny(labels, rejectedLabels);
         await removeExactLabelsFromIssue(context, params, rejectedMatches);
 
         await postOnce(
           context,
           params,
-          'Rejected label change reverted. Rejected is set automatically when a request is closed without approval.',
+          `Label "${changedLabel}" change reverted. Rejected state is managed automatically when a request is closed without approval.`,
           { minimizeTag: 'nsreq:label-guard' }
         );
         return;
@@ -9137,7 +9196,7 @@ export default function requestHandler(app: Probot): void {
           // ignore
         }
 
-        const hasApproved = labelsMatching(latest, approvedLabel).length > 0;
+        const hasApproved = labelsMatchingAny(latest, approvedLabels).length > 0;
 
         if (hasApproved) {
           await removeRejectedStatusLabel(context, params, latest);
@@ -9145,12 +9204,13 @@ export default function requestHandler(app: Probot): void {
           return;
         }
 
-        const hasRejected = labelsMatching(latest, REQUEST_STATUS_LABEL_REJECTED).length > 0;
-        if (!hasRejected) {
+        const hasRejected = labelsMatchingAny(latest, rejectedLabels).length > 0;
+
+        if (rejectedLabel && !hasRejected) {
           try {
             await context.octokit.issues.addLabels({
               ...params,
-              labels: [REQUEST_STATUS_LABEL_REJECTED],
+              labels: [rejectedLabel],
             });
           } catch {
             // ignore
@@ -9166,7 +9226,7 @@ export default function requestHandler(app: Probot): void {
         await removeProgressStatusLabels(context, params, latest);
 
         // mutual exclusivity
-        const approvedMatches = labelsMatching(latest, approvedLabel);
+        const approvedMatches = labelsMatchingAny(latest, approvedLabels);
         if (approvedMatches.length) {
           await removeExactLabelsFromIssue(context, params, approvedMatches);
         }

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -322,6 +322,24 @@ const AUTO_MERGE_EVALUATION_RECENT_TTL_MS = 30_000;
 const WORKFLOW_APPROVAL_RETRY_INFLIGHT = new Map<string, NodeJS.Timeout>();
 const WORKFLOW_APPROVAL_RETRY_DELAYS_MS = [10_000, 30_000];
 
+const WORKFLOW_APPROVAL_LAST_RUNS = new Map<string, WorkflowRunLike[]>();
+
+function workflowApprovalHeadKey(repoInfo: RepoInfo, pr: PullRequestLike): string {
+  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}`.toLowerCase();
+}
+
+function rememberWorkflowApprovalRuns(repoInfo: RepoInfo, pr: PullRequestLike, runs: WorkflowRunLike[]): void {
+  WORKFLOW_APPROVAL_LAST_RUNS.set(workflowApprovalHeadKey(repoInfo, pr), runs || []);
+}
+
+function shouldRetryWorkflowApproval(repoInfo: RepoInfo, pr: PullRequestLike): boolean {
+  const runs = WORKFLOW_APPROVAL_LAST_RUNS.get(workflowApprovalHeadKey(repoInfo, pr));
+
+  // Retry only when no run was visible yet. If GitHub already returned queued/completed/failed runs,
+  // there is no pending approval run to wait for.
+  return Array.isArray(runs) && runs.length === 0;
+}
+
 function workflowApprovalRetryKey(repoInfo: RepoInfo, pr: PullRequestLike, attempt: number): string {
   return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}:${attempt}`.toLowerCase();
 }
@@ -5070,6 +5088,8 @@ async function maybeApprovePendingWorkflowRunsForRegistryPr(
   }
 
   const runs = await listWorkflowRunsForPullRequestHead(context, repoInfo, pr);
+  rememberWorkflowApprovalRuns(repoInfo, pr, runs);
+
   const waitingRuns = runs.filter(isWorkflowRunWaitingForApproval);
 
   if (!waitingRuns.length) {
@@ -5198,11 +5218,24 @@ async function maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
 ): Promise<boolean> {
   const approved = await maybeApprovePendingWorkflowRunsForRegistryPr(context, repoInfo, pr, reason);
 
-  if (!approved) {
+  if (approved) return true;
+
+  if (shouldRetryWorkflowApproval(repoInfo, pr)) {
     scheduleWorkflowApprovalRetry(context, repoInfo, pr, reason);
+  } else {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        reason,
+      },
+      'workflow-approval:retry-skipped-run-already-visible'
+    );
   }
 
-  return approved;
+  return false;
 }
 
 async function maybeApprovePendingWorkflowRunsForPrNumbers(

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -319,6 +319,13 @@ const AUTO_MERGE_EVALUATION_INFLIGHT = new Map<string, Promise<void>>();
 const AUTO_MERGE_EVALUATION_RECENT_UNTIL = new Map<string, number>();
 const AUTO_MERGE_EVALUATION_RECENT_TTL_MS = 30_000;
 
+const WORKFLOW_APPROVAL_RETRY_INFLIGHT = new Map<string, NodeJS.Timeout>();
+const WORKFLOW_APPROVAL_RETRY_DELAYS_MS = [10_000, 30_000];
+
+function workflowApprovalRetryKey(repoInfo: RepoInfo, pr: PullRequestLike, attempt: number): string {
+  return `${repoInfo.owner}/${repoInfo.repo}#${pr.number}:${toStringTrim(pr.head?.sha)}:${attempt}`.toLowerCase();
+}
+
 const CHANGED_FILES_CONTEXT_CACHE = new WeakMap<object, Map<string, Promise<PullRequestFileLike[]>>>();
 
 function changedFilesCacheKey(repoInfo: RepoInfo, prNumber: number): string {
@@ -5112,6 +5119,117 @@ async function maybeApprovePendingWorkflowRunsForRegistryPr(
   return approvedAny;
 }
 
+function scheduleWorkflowApprovalRetry(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string,
+  attempt = 0
+): void {
+  const delay = WORKFLOW_APPROVAL_RETRY_DELAYS_MS[attempt];
+  if (delay === undefined) return;
+
+  const key = workflowApprovalRetryKey(repoInfo, pr, attempt);
+  if (WORKFLOW_APPROVAL_RETRY_INFLIGHT.has(key)) return;
+
+  const originalHeadSha = toStringTrim(pr.head?.sha);
+
+  const timer = setTimeout(() => {
+    WORKFLOW_APPROVAL_RETRY_INFLIGHT.delete(key);
+
+    void (async (): Promise<void> => {
+      const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
+      const freshHeadSha = toStringTrim(freshPr.head?.sha);
+
+      if (!isPullRequestOpen(freshPr)) return;
+      if (originalHeadSha && freshHeadSha && originalHeadSha !== freshHeadSha) return;
+
+      const approved = await maybeApprovePendingWorkflowRunsForRegistryPr(
+        context,
+        repoInfo,
+        freshPr,
+        `${reason}:retry-${attempt + 1}`
+      );
+
+      if (!approved) {
+        scheduleWorkflowApprovalRetry(context, repoInfo, freshPr, reason, attempt + 1);
+      }
+    })().catch((error: unknown) => {
+      log(
+        context,
+        'warn',
+        {
+          prNumber: pr.number,
+          err: getErrorMessage(error),
+          status: getHttpStatus(error),
+          reason,
+          attempt: attempt + 1,
+        },
+        'workflow-approval:retry-failed'
+      );
+    });
+  }, delay);
+
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+
+  WORKFLOW_APPROVAL_RETRY_INFLIGHT.set(key, timer);
+
+  log(
+    context,
+    'info',
+    {
+      prNumber: pr.number,
+      headSha: originalHeadSha,
+      delayMs: delay,
+      attempt: attempt + 1,
+      reason,
+    },
+    'workflow-approval:retry-scheduled'
+  );
+}
+
+async function maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<boolean> {
+  const approved = await maybeApprovePendingWorkflowRunsForRegistryPr(context, repoInfo, pr, reason);
+
+  if (!approved) {
+    scheduleWorkflowApprovalRetry(context, repoInfo, pr, reason);
+  }
+
+  return approved;
+}
+
+async function maybeApprovePendingWorkflowRunsForPrNumbers(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumbers: number[],
+  headSha: string,
+  reason: string
+): Promise<boolean> {
+  const sha = toStringTrim(headSha);
+  const uniquePrNumbers = Array.from(new Set((prNumbers || []).filter((n) => Number.isFinite(n))));
+
+  for (const prNumber of uniquePrNumbers) {
+    const pr = await readFreshPullRequest(context, repoInfo, prNumber);
+    if (!pr || !isPullRequestOpen(pr)) continue;
+
+    const prHeadSha = toStringTrim(pr.head?.sha);
+    if (sha && prHeadSha && prHeadSha !== sha) continue;
+
+    const approved = await maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(context, repoInfo, pr, reason);
+
+    if (approved) return true;
+  }
+
+  return false;
+}
+
 async function isPullRequestBehindCurrentBase(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -5549,7 +5667,12 @@ async function collectSequentialDirectRegistryPrCandidates(
       continue;
     }
 
-    await maybeApprovePendingWorkflowRunsForRegistryPr(context, repoInfo, pr, `${reason}:approve-pending-workflow`);
+    await maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
+      context,
+      repoInfo,
+      pr,
+      `${reason}:approve-pending-workflow`
+    );
 
     const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
     const freshHeadSha = toStringTrim(freshPr.head?.sha);
@@ -5617,6 +5740,53 @@ async function collectSequentialDirectRegistryPrCandidates(
   return candidates;
 }
 
+async function isLikelyAutoApprovableStandaloneDirectPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  baseBranch: string,
+  reason: string
+): Promise<boolean> {
+  if (parseLinkedIssueNumberFromPr(pr, repoInfo) !== null) return false;
+
+  try {
+    const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr, undefined, { baseBranch });
+
+    if (decision.status === 'approved') {
+      log(
+        context,
+        'info',
+        {
+          prNumber: pr.number,
+          headSha: toStringTrim(pr.head?.sha),
+          reason,
+        },
+        'sequential-registry-pr:auto-approvable-candidate'
+      );
+
+      return true;
+    }
+
+    return await hasAllowedStandaloneDirectPrApprovalForCurrentHead(context, repoInfo, pr, decision, {
+      baseBranch,
+    });
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+        reason,
+      },
+      'sequential-registry-pr:auto-approval-priority-check-failed'
+    );
+
+    return false;
+  }
+}
+
 async function runOneSequentialDirectRegistryPrMaintenance(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -5671,6 +5841,12 @@ async function runOneSequentialDirectRegistryPrMaintenance(
       markSequentialRegistryPrHeadSkipped(context, repoInfo, candidate.freshPr, 'branch-update-request-failed');
     }
 
+    const greenCandidates: {
+      candidate: SequentialRegistryPrCandidate;
+      autoApprovable: boolean;
+      headSha: string;
+    }[] = [];
+
     for (const candidate of candidates.filter((item) => !item.mustUpdate)) {
       const headSha = toStringTrim(candidate.freshPr.head?.sha);
       const greenResult = headSha
@@ -5705,7 +5881,42 @@ async function runOneSequentialDirectRegistryPrMaintenance(
         continue;
       }
 
-      await processPullRequestForAutoMerge(context, repoInfo, candidate.freshPr);
+      const autoApprovable = await isLikelyAutoApprovableStandaloneDirectPr(
+        context,
+        repoInfo,
+        candidate.freshPr,
+        baseBranch,
+        reason
+      );
+
+      greenCandidates.push({
+        candidate,
+        autoApprovable,
+        headSha,
+      });
+    }
+
+    greenCandidates.sort((left, right) => {
+      if (left.autoApprovable !== right.autoApprovable) return left.autoApprovable ? -1 : 1;
+      return right.candidate.freshPr.number - left.candidate.freshPr.number;
+    });
+
+    const selected = greenCandidates[0];
+
+    if (selected) {
+      log(
+        context,
+        'info',
+        {
+          prNumber: selected.candidate.freshPr.number,
+          headSha: selected.headSha,
+          autoApprovable: selected.autoApprovable,
+          reason,
+        },
+        'sequential-registry-pr:selected-green-candidate'
+      );
+
+      await processPullRequestForAutoMerge(context, repoInfo, selected.candidate.freshPr);
       return { updated: false, processed: true, blockedByActive: false };
     }
 
@@ -9635,7 +9846,7 @@ export default function requestHandler(app: Probot): void {
 
       if (!isPullRequestOpen(pr)) return;
 
-      await maybeApprovePendingWorkflowRunsForRegistryPr(
+      await maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
         context,
         repoInfo,
         pr,
@@ -9716,6 +9927,18 @@ export default function requestHandler(app: Probot): void {
         if (conclusion && conclusion !== 'success') {
           if (isBlockingCheckConclusion(conclusion)) {
             await getStaticConfig(context);
+
+            if (conclusion === 'action_required') {
+              const approvedWorkflow = await maybeApprovePendingWorkflowRunsForPrNumbers(
+                context,
+                repoInfo,
+                prNumbers,
+                headShaStr,
+                `check-run:${conclusion}`
+              );
+
+              if (approvedWorkflow) return;
+            }
 
             await handleBlockingRegistryHeadConclusion(
               context,
@@ -9798,6 +10021,18 @@ export default function requestHandler(app: Probot): void {
 
       if (isBlockingCheckConclusion(conclusion)) {
         await getStaticConfig(context);
+
+        if (conclusion === 'action_required') {
+          const approvedWorkflow = await maybeApprovePendingWorkflowRunsForPrNumbers(
+            context,
+            { owner: ownerLogin, repo: repoName },
+            prNumbers,
+            headShaStr,
+            `check-suite:${conclusion}`
+          );
+
+          if (approvedWorkflow) return;
+        }
 
         await handleBlockingRegistryHeadConclusion(
           context,

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -319,6 +319,50 @@ const AUTO_MERGE_EVALUATION_INFLIGHT = new Map<string, Promise<void>>();
 const AUTO_MERGE_EVALUATION_RECENT_UNTIL = new Map<string, number>();
 const AUTO_MERGE_EVALUATION_RECENT_TTL_MS = 30_000;
 
+const CHANGED_FILES_CONTEXT_CACHE = new WeakMap<object, Map<string, Promise<PullRequestFileLike[]>>>();
+
+function changedFilesCacheKey(repoInfo: RepoInfo, prNumber: number): string {
+  return `${repoInfo.owner}/${repoInfo.repo}#${prNumber}`.toLowerCase();
+}
+
+async function listAllChangedFilesForPrCached(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<PullRequestFileLike[]> {
+  let perContext = CHANGED_FILES_CONTEXT_CACHE.get(context as object);
+
+  if (!perContext) {
+    perContext = new Map<string, Promise<PullRequestFileLike[]>>();
+    CHANGED_FILES_CONTEXT_CACHE.set(context as object, perContext);
+  }
+
+  const key = changedFilesCacheKey(repoInfo, prNumber);
+  const existing = perContext.get(key);
+  if (existing) return await existing;
+
+  const pending = (async (): Promise<PullRequestFileLike[]> => {
+    const out: PullRequestFileLike[] = [];
+    let page = 1;
+
+    while (true) {
+      const files = await listChangedYamlFilesPage(context, repoInfo, prNumber, page);
+      if (!files.length) break;
+
+      out.push(...files);
+
+      if (files.length < 100) break;
+      page += 1;
+      if (page > 20) break;
+    }
+
+    return out;
+  })();
+
+  perContext.set(key, pending);
+  return await pending;
+}
+
 type WorkflowLabelKey =
   | 'global'
   | 'authorAction'
@@ -1948,54 +1992,6 @@ async function ensureReviewLabelsPresentOnIssue(
   });
 }
 
-async function removeReviewPendingLabelsAfterApproval(
-  context: BotContext<RequestEvents>,
-  params: IssueParams,
-  eff: EffectiveConstants
-): Promise<void> {
-  const approvedCfg = toStringTrim(eff.labelOnApproved);
-  const pendingCfg = (eff.reviewRequestedLabels || []).map(toStringTrim).filter(Boolean);
-
-  if (!approvedCfg || !pendingCfg.length) return;
-
-  let labels: string[] = [];
-  try {
-    labels = await fetchIssueLabels(context, params);
-  } catch {
-    return;
-  }
-
-  const approvedKey = normalizeKey(approvedCfg);
-  const hasApproved = labels.some((l) => {
-    const k = normalizeKey(l);
-    return k === approvedKey || k.includes(approvedKey) || approvedKey.includes(k);
-  });
-
-  if (!hasApproved) return;
-
-  const pendingKeys = pendingCfg.map(normalizeKey);
-
-  const toRemove = labels.filter((l) => {
-    const k = normalizeKey(l);
-    return pendingKeys.some((pk) => k === pk || k.includes(pk) || pk.includes(k));
-  });
-
-  for (const label of toRemove) {
-    try {
-      await context.octokit.issues.removeLabel({ ...params, name: label });
-    } catch (e: unknown) {
-      if (getHttpStatus(e) !== 404) {
-        log(
-          context,
-          'warn',
-          { err: e instanceof Error ? e.message : String(e), label },
-          'failed to remove review pending label after approval'
-        );
-      }
-    }
-  }
-}
-
 function collectWorkflowStateLabels(context: BotContext<RequestEvents>): string[] {
   const eff = resolveEffectiveConstants(context);
 
@@ -2320,10 +2316,10 @@ ${leadBlock}${issuesBlock}Closing this request automatically.`;
 async function applyApprovedRequestState(
   context: BotContext<RequestEvents>,
   params: IssueParams,
-  eff: EffectiveConstants
+  _eff: EffectiveConstants
 ): Promise<void> {
-  const approvedLabels = resolveApprovedLabels(context);
   const approvedLabel = resolveApprovedLabel(context);
+  const approvedLabels = resolveApprovedLabels(context);
 
   try {
     if (approvedLabel) {
@@ -2334,8 +2330,6 @@ async function applyApprovedRequestState(
   }
 
   await enforceExclusiveWorkflowStateLabels(context, params, approvedLabels);
-
-  await removeReviewPendingLabelsAfterApproval(context, params, eff);
 
   try {
     const labelsAfter = await fetchIssueLabels(context, params);
@@ -2590,7 +2584,6 @@ async function addApprovedLabelToPr(
   prNumber: number,
   options: { skipStateCleanup?: boolean } = {}
 ): Promise<void> {
-  const eff = resolveEffectiveConstants(context);
   const approvedLabel = resolveApprovedLabel(context);
   const approvedLabels = resolveApprovedLabels(context);
 
@@ -2611,18 +2604,16 @@ async function addApprovedLabelToPr(
     return;
   }
 
-  await enforceExclusiveWorkflowStateLabels(context, params, approvedLabels);
-
   // Standalone cross-repo direct PRs must stay PR-only here.
   // Reading the PR as an issue would break the no-linked-issue guarantee.
   if (options.skipStateCleanup) return;
 
-  await removeReviewPendingLabelsAfterApproval(context, params, eff);
+  await enforceExclusiveWorkflowStateLabels(context, params, approvedLabels);
 
   try {
     const labelsAfter = await fetchIssueLabels(context, params);
 
-    if (labelsMatching(labelsAfter, approvedLabel).length) {
+    if (labelsMatchingAny(labelsAfter, approvedLabels).length) {
       await removeProgressStatusLabels(context, params, labelsAfter);
       await removeRejectedStatusLabel(context, params, labelsAfter);
     }
@@ -3917,6 +3908,10 @@ async function processPullRequestForAutoMerge(
     }
   }
 
+  if (isSequentialRegistryPrHeadSkipped(repoInfo, pr)) {
+    return;
+  }
+
   const issueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
 
   if (issueNumber === null) {
@@ -4488,21 +4483,14 @@ async function listChangedYamlFilesForPr(
   repoInfo: RepoInfo,
   prNumber: number
 ): Promise<string[]> {
+  const files = await listAllChangedFilesForPrCached(context, repoInfo, prNumber);
   const out: string[] = [];
-  let page = 1;
 
-  while (true) {
-    const files = await listChangedYamlFilesPage(context, repoInfo, prNumber, page);
-    if (!files.length) break;
-
-    for (const file of files) {
-      const filename = isChangedYamlCandidate(file);
-      if (filename && isRegistryEntryPath(context, filename)) out.push(filename);
+  for (const file of files) {
+    const filename = isChangedYamlCandidate(file);
+    if (filename && isRegistryEntryPath(context, filename)) {
+      out.push(filename);
     }
-
-    if (files.length < 100) break;
-    page += 1;
-    if (page > 20) break;
   }
 
   return Array.from(new Set(out));
@@ -4862,21 +4850,7 @@ async function listChangedFilesForPr(
   repoInfo: RepoInfo,
   prNumber: number
 ): Promise<PullRequestFileLike[]> {
-  const out: PullRequestFileLike[] = [];
-  let page = 1;
-
-  while (true) {
-    const files = await listChangedYamlFilesPage(context, repoInfo, prNumber, page);
-    if (!files.length) break;
-
-    out.push(...files);
-
-    if (files.length < 100) break;
-    page += 1;
-    if (page > 20) break;
-  }
-
-  return out;
+  return await listAllChangedFilesForPrCached(context, repoInfo, prNumber);
 }
 
 function isLikelyBotManagedRegistryPr(pr: PullRequestLike): boolean {
@@ -5421,6 +5395,8 @@ async function isSequentialDirectRegistryPr(
       },
       'sequential-registry-pr:changed-files-lookup-failed'
     );
+
+    markSequentialRegistryPrHeadSkipped(context, repoInfo, pr, 'changed-files-lookup-failed');
 
     return false;
   }
@@ -8957,7 +8933,7 @@ export default function requestHandler(app: Probot): void {
     const parsedFormData = template ? parseForm(readIssueBodyForProcessing(issue.body), template) : {};
     if (!isRequestIssue(context, template, parsedFormData)) return;
 
-    const approvedLabel = resolveApprovedLabel(context);
+    const approvedLabels = resolveApprovedLabels(context);
     const rejectedLabel = resolveRejectedLabel(context);
     const rejectedLabels = resolveRejectedLabels(context);
 
@@ -8968,7 +8944,6 @@ export default function requestHandler(app: Probot): void {
       labels = toLabelNames(issue.labels);
     }
 
-    const approvedLabels = resolveApprovedLabels(context);
     const hasApproved = labelsMatchingAny(labels, approvedLabels).length > 0;
 
     // If approved, keep it clean
@@ -9007,11 +8982,9 @@ export default function requestHandler(app: Probot): void {
     if (labelsMatchingAny(labels, rejectedLabels).length) {
       await removeProgressStatusLabels(context, params, labels);
 
-      if (approvedLabel) {
-        const approvedMatches = labelsMatchingAny(labels, approvedLabels);
-        if (approvedMatches.length) {
-          await removeExactLabelsFromIssue(context, params, approvedMatches);
-        }
+      const approvedMatches = labelsMatchingAny(labels, approvedLabels);
+      if (approvedMatches.length) {
+        await removeExactLabelsFromIssue(context, params, approvedMatches);
       }
     }
   });
@@ -9128,7 +9101,12 @@ export default function requestHandler(app: Probot): void {
         const isManualApprovedAdd =
           action === 'labeled' && labelsMatchingAny([changedLabel], approvedLabels).length > 0;
 
-        if (!isManualApprovedAdd) {
+        const isManualRejectedAdd =
+          action === 'labeled' &&
+          labelsMatchingAny([changedLabel], rejectedLabels).length > 0 &&
+          toStringTrim(issue.state).toLowerCase() !== 'closed';
+
+        if (!isManualApprovedAdd && !isManualRejectedAdd) {
           if (action === 'labeled') {
             await removeExactLabelsFromIssue(context, params, [changedLabel]);
           } else if (action === 'unlabeled') {

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -29,6 +29,10 @@ type RequestEvents =
   | 'issues.unlabeled'
   | 'issue_comment.created'
   | 'issue_comment.edited'
+  | 'pull_request.opened'
+  | 'pull_request.synchronize'
+  | 'pull_request.reopened'
+  | 'pull_request.ready_for_review'
   | 'check_suite.completed'
   | 'check_run.completed'
   | 'status'
@@ -314,6 +318,12 @@ const AUTO_MERGE_EVALUATION_INFLIGHT = new Map<string, Promise<void>>();
 
 const AUTO_MERGE_EVALUATION_RECENT_UNTIL = new Map<string, number>();
 const AUTO_MERGE_EVALUATION_RECENT_TTL_MS = 30_000;
+
+// Request lifecycle status labels
+const REQUEST_STATUS_LABEL_REQUESTER_ACTION = 'Requester Action';
+const REQUEST_STATUS_LABEL_REVIEW_PENDING = 'Review Pending';
+const REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION = 'Parent Owner Action';
+const REQUEST_STATUS_LABEL_REJECTED = 'Rejected';
 
 function normalizeSchemaFieldAlias(value: unknown): string {
   const raw = toStringTrim(value);
@@ -790,6 +800,20 @@ type CheckSuiteLike = {
   head_sha?: string | null;
   head_branch?: string | null;
   pull_requests?: CheckSuitePullRequestRef[] | null;
+};
+
+type WorkflowRunPullRequestRef = {
+  number?: number | null;
+};
+
+type WorkflowRunLike = {
+  id?: number | null;
+  name?: string | null;
+  path?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  head_sha?: string | null;
+  pull_requests?: WorkflowRunPullRequestRef[] | null;
 };
 
 function readCheckSuiteFromPayload(payload: unknown): CheckSuiteLike | null {
@@ -1755,9 +1779,7 @@ function buildReviewHandoverBody(
 
 ---
 
-${instruction}${docsSection}${snapshotMarker}
-
-<!-- nsreq:handover -->`;
+${instruction}${docsSection}${snapshotMarker}`;
 }
 
 async function handoverToCpa(
@@ -1803,6 +1825,11 @@ async function handoverToCpa(
   const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
 
   await ensureLabelsPresentOnce(context, params, labelsToAdd);
+
+  await enforceExclusiveWorkflowStateLabels(context, params, [
+    resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING),
+    ...(eff.reviewRequestedLabels || []),
+  ]);
 
   if (eff.labelOnApproved) {
     try {
@@ -1891,12 +1918,6 @@ async function removeReviewPendingLabelsAfterApproval(
   }
 }
 
-// Request lifecycle status labels
-const REQUEST_STATUS_LABEL_REQUESTER_ACTION = 'Requester Action';
-const REQUEST_STATUS_LABEL_REVIEW_PENDING = 'Review Pending';
-const REQUEST_STATUS_LABEL_PARENT_OWNER_ACTION = 'Parent Owner Action';
-const REQUEST_STATUS_LABEL_REJECTED = 'Rejected';
-
 function resolveWorkflowLabel(context: BotContext<RequestEvents>, key: string, fallback: string): string {
   const cfg: NormalizedStaticConfig = context.resourceBotConfig ?? DEFAULT_CONFIG;
   const wf = cfg?.workflow ?? {};
@@ -1930,6 +1951,68 @@ const labelsMatching = (labels: string[], expected: string): string[] => {
   });
 };
 
+function collectWorkflowStateLabels(context: BotContext<RequestEvents>): string[] {
+  const eff = resolveEffectiveConstants(context);
+
+  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
+  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
+  const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
+  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
+
+  return Array.from(
+    new Set(
+      [
+        authorActionLabel,
+        approverActionLabel,
+        parentOwnerActionLabel,
+        approvedLabel,
+        REQUEST_STATUS_LABEL_REJECTED,
+        ...(eff.reviewRequestedLabels || []),
+      ]
+        .map(toStringTrim)
+        .filter(Boolean)
+    )
+  );
+}
+
+async function enforceExclusiveWorkflowStateLabels(
+  context: BotContext<RequestEvents>,
+  params: IssueParams,
+  keepLabels: string[],
+  currentLabels?: string[]
+): Promise<void> {
+  const keepKeys = new Set((keepLabels || []).map(normalizeKey).filter(Boolean));
+  if (!keepKeys.size) return;
+
+  let labels = (currentLabels || []).slice();
+
+  if (!labels.length) {
+    try {
+      labels = await fetchIssueLabels(context, params);
+    } catch {
+      return;
+    }
+  }
+
+  const toRemove = new Set<string>();
+
+  for (const stateLabel of collectWorkflowStateLabels(context)) {
+    const stateKey = normalizeKey(stateLabel);
+    if (!stateKey || keepKeys.has(stateKey)) continue;
+
+    for (const match of labelsMatching(labels, stateLabel)) {
+      const matchKey = normalizeKey(match);
+      if (matchKey && !keepKeys.has(matchKey)) {
+        toRemove.add(match);
+      }
+    }
+  }
+
+  if (!toRemove.size) return;
+
+  await removeExactLabelsFromIssue(context, params, Array.from(toRemove));
+}
+
 async function clearParentOwnerActionState(
   context: BotContext<RequestEvents>,
   params: IssueParams,
@@ -1953,40 +2036,9 @@ async function clearParentOwnerActionState(
 }
 
 async function setParentOwnerActionState(context: BotContext<RequestEvents>, params: IssueParams): Promise<void> {
-  const eff = resolveEffectiveConstants(context);
-
   const parentOwnerActionLabel = resolveParentOwnerActionLabel(context);
-  const authorActionLabel = resolveWorkflowLabel(context, 'authorAction', REQUEST_STATUS_LABEL_REQUESTER_ACTION);
-  const approverActionLabel = resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING);
-  const approvedLabel = toStringTrim(eff.labelOnApproved) || 'Approved';
 
-  let labels: string[] = [];
-  try {
-    labels = await fetchIssueLabels(context, params);
-  } catch {
-    labels = [];
-  }
-
-  const toRemove = new Set<string>();
-
-  for (const label of [
-    authorActionLabel,
-    approverActionLabel,
-    approvedLabel,
-    REQUEST_STATUS_LABEL_REJECTED,
-    ...(eff.reviewRequestedLabels || []),
-  ]) {
-    for (const match of labelsMatching(labels, label)) {
-      if (normalizeKey(match) !== normalizeKey(parentOwnerActionLabel)) {
-        toRemove.add(match);
-      }
-    }
-  }
-
-  if (toRemove.size) {
-    await removeExactLabelsFromIssue(context, params, Array.from(toRemove));
-  }
-
+  await enforceExclusiveWorkflowStateLabels(context, params, [parentOwnerActionLabel]);
   await ensureLabelsPresentOnce(context, params, [parentOwnerActionLabel]);
 }
 
@@ -2223,6 +2275,8 @@ async function applyApprovedRequestState(
   } catch {
     // ignore
   }
+
+  await enforceExclusiveWorkflowStateLabels(context, params, [toStringTrim(eff.labelOnApproved) || 'Approved']);
 
   await removeReviewPendingLabelsAfterApproval(context, params, eff);
 
@@ -2497,6 +2551,8 @@ async function addApprovedLabelToPr(
   } catch {
     return;
   }
+
+  await enforceExclusiveWorkflowStateLabels(context, params, [approvedLabel]);
 
   // Standalone cross-repo direct PRs must stay PR-only here.
   // Reading the PR as an issue would break the no-linked-issue guarantee.
@@ -3806,6 +3862,11 @@ async function processPullRequestForAutoMerge(
   const issueNumber = parseLinkedIssueNumberFromPr(pr, repoInfo);
 
   if (issueNumber === null) {
+    const noopClosed = await maybeCloseNoopRegistryPullRequest(context, repoInfo, pr, 'auto-merge:no-op-check');
+    if (noopClosed) return;
+  }
+
+  if (issueNumber === null) {
     const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
     const standaloneOutcome = await maybeHandleStandaloneDirectPrApproval(context, repoInfo, freshPr, {
       baseBranch: toStringTrim(freshPr.base?.ref),
@@ -4738,6 +4799,287 @@ async function listChangedYamlFilesForPrWithFallback(
   return fromTreeDiff;
 }
 
+async function listChangedFilesForPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  prNumber: number
+): Promise<PullRequestFileLike[]> {
+  const out: PullRequestFileLike[] = [];
+  let page = 1;
+
+  while (true) {
+    const files = await listChangedYamlFilesPage(context, repoInfo, prNumber, page);
+    if (!files.length) break;
+
+    out.push(...files);
+
+    if (files.length < 100) break;
+    page += 1;
+    if (page > 20) break;
+  }
+
+  return out;
+}
+
+function isLikelyBotManagedRegistryPr(pr: PullRequestLike): boolean {
+  const title = toStringTrim(pr.title).toLowerCase();
+  const body = toStringTrim(pr.body).toLowerCase();
+  const author = normalizeLogin(pr.user?.login).toLowerCase();
+
+  return (
+    author.includes('bot') ||
+    author.includes('serviceuser') ||
+    title.includes('namespace') ||
+    body.includes('this pr registers')
+  );
+}
+
+async function maybeCloseNoopRegistryPullRequest(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<boolean> {
+  const files = await listChangedFilesForPr(context, repoInfo, pr.number);
+
+  if (files.length > 0) return false;
+  if (!isLikelyBotManagedRegistryPr(pr)) return false;
+
+  await postOnce(
+    context,
+    { owner: repoInfo.owner, repo: repoInfo.repo, issue_number: pr.number },
+    `This PR has no changed files and appears to be a duplicate/no-op registry PR. Closing it automatically.`,
+    { minimizeTag: 'nsreq:no-op-pr' }
+  );
+
+  try {
+    await context.octokit.pulls.update({
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      pull_number: pr.number,
+      state: 'closed',
+    });
+
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        reason,
+      },
+      'direct-pr:no-op-closed'
+    );
+
+    return true;
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+        reason,
+      },
+      'direct-pr:no-op-close-failed'
+    );
+
+    return false;
+  }
+}
+
+function isSafeRegistryWorkflowApprovalFile(context: BotContext<RequestEvents>, file: PullRequestFileLike): boolean {
+  const filename = normalizeRepoPath(file?.filename);
+  const status = toStringTrim(file?.status).toLowerCase();
+
+  if (!filename) return false;
+  if (status === 'removed') return false;
+  if (!isYamlPath(filename)) return false;
+  if (!isRegistryEntryPath(context, filename)) return false;
+
+  return true;
+}
+
+async function isSafeRegistryOnlyPullRequest(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<boolean> {
+  const files = await listChangedFilesForPr(context, repoInfo, pr.number);
+  if (!files.length) return false;
+
+  return files.every((file) => isSafeRegistryWorkflowApprovalFile(context, file));
+}
+
+function isWorkflowRunWaitingForApproval(run: WorkflowRunLike): boolean {
+  const status = toStringTrim(run?.status).toLowerCase();
+  const conclusion = toStringTrim(run?.conclusion).toLowerCase();
+
+  return status === 'waiting' || conclusion === 'action_required';
+}
+
+function workflowRunTargetsPullRequest(run: WorkflowRunLike, pr: PullRequestLike): boolean {
+  const headSha = toStringTrim(pr.head?.sha);
+  const runHeadSha = toStringTrim(run?.head_sha);
+
+  if (headSha && runHeadSha && headSha === runHeadSha) return true;
+
+  const prs = Array.isArray(run?.pull_requests) ? run.pull_requests : [];
+  return prs.some((item) => item?.number === pr.number);
+}
+
+async function listWorkflowRunsForPullRequestHead(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike
+): Promise<WorkflowRunLike[]> {
+  const headSha = toStringTrim(pr.head?.sha);
+  if (!headSha) return [];
+
+  try {
+    const client = context.octokit as unknown as {
+      request: (route: string, args: Record<string, unknown>) => Promise<{ data?: unknown }>;
+    };
+
+    const res = await client.request('GET /repos/{owner}/{repo}/actions/runs', {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      head_sha: headSha,
+      per_page: 100,
+    });
+
+    const data = isPlainObject(res?.data) ? res.data : {};
+    const runs = Array.isArray(data['workflow_runs']) ? data['workflow_runs'] : [];
+
+    return (runs as WorkflowRunLike[]).filter((run) => workflowRunTargetsPullRequest(run, pr));
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        prNumber: pr.number,
+        headSha,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'workflow-approval:runs-read-failed'
+    );
+
+    return [];
+  }
+}
+
+async function approveWorkflowRun(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  runId: number
+): Promise<boolean> {
+  try {
+    const client = context.octokit as unknown as {
+      request: (route: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    await client.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve', {
+      owner: repoInfo.owner,
+      repo: repoInfo.repo,
+      run_id: runId,
+    });
+
+    return true;
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        owner: repoInfo.owner,
+        repo: repoInfo.repo,
+        runId,
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+      },
+      'workflow-approval:approve-run-failed'
+    );
+
+    return false;
+  }
+}
+
+async function maybeApprovePendingWorkflowRunsForRegistryPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<boolean> {
+  if (!isPullRequestOpen(pr)) return false;
+  if (pr.draft === true) return false;
+
+  const safeRegistryOnly = await isSafeRegistryOnlyPullRequest(context, repoInfo, pr);
+  if (!safeRegistryOnly) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        reason,
+      },
+      'workflow-approval:skip-not-safe-registry-only-pr'
+    );
+
+    return false;
+  }
+
+  const runs = await listWorkflowRunsForPullRequestHead(context, repoInfo, pr);
+  const waitingRuns = runs.filter(isWorkflowRunWaitingForApproval);
+
+  if (!waitingRuns.length) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        runs: runs.map((run) => ({
+          id: run.id,
+          name: toStringTrim(run.name),
+          status: toStringTrim(run.status),
+          conclusion: toStringTrim(run.conclusion),
+        })),
+        reason,
+      },
+      'workflow-approval:no-waiting-runs'
+    );
+
+    return false;
+  }
+
+  let approvedAny = false;
+
+  for (const run of waitingRuns) {
+    const runId = typeof run.id === 'number' && Number.isFinite(run.id) ? run.id : 0;
+    if (!runId) continue;
+
+    const approved = await approveWorkflowRun(context, repoInfo, runId);
+    approvedAny = approvedAny || approved;
+
+    log(
+      context,
+      approved ? 'info' : 'warn',
+      {
+        prNumber: pr.number,
+        runId,
+        runName: toStringTrim(run.name),
+        headSha: toStringTrim(pr.head?.sha),
+        reason,
+      },
+      approved ? 'workflow-approval:run-approved' : 'workflow-approval:run-approval-failed'
+    );
+  }
+
+  return approvedAny;
+}
+
 async function isPullRequestBehindCurrentBase(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -5172,6 +5514,8 @@ async function collectSequentialDirectRegistryPrCandidates(
       );
       continue;
     }
+
+    await maybeApprovePendingWorkflowRunsForRegistryPr(context, repoInfo, pr, `${reason}:approve-pending-workflow`);
 
     const freshPr = (await readFreshPullRequest(context, repoInfo, pr.number)) || pr;
     const freshHeadSha = toStringTrim(freshPr.head?.sha);
@@ -5996,6 +6340,11 @@ async function handoverStandaloneDirectPrToReview(
 
   const labelsToAdd = [...(eff.globalLabels || []), ...(eff.reviewRequestedLabels || [])].filter(Boolean);
   await ensureLabelsPresentOnce(context, params, labelsToAdd);
+
+  await enforceExclusiveWorkflowStateLabels(context, params, [
+    resolveWorkflowLabel(context, 'approverAction', REQUEST_STATUS_LABEL_REVIEW_PENDING),
+    ...(eff.reviewRequestedLabels || []),
+  ]);
 
   if (eff.labelOnApproved) {
     try {
@@ -9226,6 +9575,36 @@ export default function requestHandler(app: Probot): void {
       await updateApprovedOpenPullRequestBranchesAfterDefaultBranchPushWithRetry(context, repoInfo, baseBranch);
     }
   });
+
+  app.on(
+    ['pull_request.opened', 'pull_request.synchronize', 'pull_request.reopened', 'pull_request.ready_for_review'],
+    async (
+      context: BotContext<
+        'pull_request.opened' | 'pull_request.synchronize' | 'pull_request.reopened' | 'pull_request.ready_for_review'
+      >
+    ): Promise<void> => {
+      await getStaticConfig(context);
+
+      const payload = context.payload as unknown;
+      const repoInfo = readRepoInfoFromPayload(payload);
+
+      if (!repoInfo) return;
+
+      const prRaw = isPlainObject(payload) ? payload['pull_request'] : null;
+      if (!isPlainObject(prRaw)) return;
+
+      const pr = prRaw as unknown as PullRequestLike;
+
+      if (!isPullRequestOpen(pr)) return;
+
+      await maybeApprovePendingWorkflowRunsForRegistryPr(
+        context,
+        repoInfo,
+        pr,
+        `pull-request:${toStringTrim((payload as Record<string, unknown>)['action']) || 'event'}`
+      );
+    }
+  );
 
   app.on(
     ['check_suite.completed', 'check_run.completed'],

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -8497,6 +8497,20 @@ async function maybeRequireParentOwnerApproval(
 
   const { parent, owners } = await resolveParentOwnerLoginsForTarget(context, params, template, target, requestType);
 
+  log(
+    context,
+    'info',
+    {
+      issueNumber: issue.number,
+      requester,
+      parent,
+      target,
+      owners,
+      requestType,
+    },
+    'parent-approval:owners-resolved'
+  );
+
   if (!parent || owners.length === 0) {
     await ensureParentApprovalMarker(context, params, issue, null);
     await clearParentOwnerActionState(context, params);
@@ -8509,10 +8523,23 @@ async function maybeRequireParentOwnerApproval(
         context,
         'debug',
         { issue: issue.number, requester, parent, target, owners },
-        'parent-approval:skip (requester is parent owner)'
+        'parent-approval:auto-approved (requester is parent owner)'
       );
     }
-    await ensureParentApprovalMarker(context, params, issue, null);
+
+    if (isSubContextRequestType(requestType)) {
+      await ensureParentApprovalMarker(context, params, issue, {
+        v: 1,
+        parent,
+        target,
+        owners,
+        approvedBy: requester,
+        approvedAt: new Date().toISOString(),
+      });
+    } else {
+      await ensureParentApprovalMarker(context, params, issue, null);
+    }
+
     await clearParentOwnerActionState(context, params);
     return false;
   }

--- a/test/request-orchestrator.auto-merge.test.ts
+++ b/test/request-orchestrator.auto-merge.test.ts
@@ -30,7 +30,12 @@ const DEFAULT_CONFIG = {
   },
   workflow: {
     labels: {
+      authorAction: 'Requester Action',
+      approverAction: 'Review Pending',
+      parentOwnerAction: 'Parent Owner Action',
+      approvalRequested: ['Review Pending'],
       approvalSuccessful: ['Approved'],
+      approvalRejected: ['Rejected'],
     },
     approvers: [],
   },

--- a/test/request-orchestrator.coverage.test.ts
+++ b/test/request-orchestrator.coverage.test.ts
@@ -173,10 +173,28 @@ type CreateRequestPr = (
 
 type TryMergeIfGreen = (ctx: unknown, args: { owner: string; repo: string; prNumber: number }) => Promise<void>;
 
-const DEFAULT_CONFIG_MOCK: StaticConfig = {
+const TEST_WORKFLOW_LABELS = {
+  authorAction: 'Requester Action',
+  approverAction: 'Review Pending',
+  parentOwnerAction: 'Parent Owner Action',
+  approvalRequested: ['Review Pending'],
+  approvalSuccessful: ['Approved'],
+  approvalRejected: ['Rejected'],
+};
+
+function withWorkflowLabels<T extends StaticConfig>(cfg: T): T {
+  cfg.workflow.labels = {
+    ...TEST_WORKFLOW_LABELS,
+    ...(cfg.workflow.labels || {}),
+  };
+
+  return cfg;
+}
+
+const DEFAULT_CONFIG_MOCK: StaticConfig = withWorkflowLabels({
   workflow: { labels: {}, approvers: [] },
   requests: {},
-};
+});
 
 const setStateLabel = jest.fn<SetStateLabel>(async () => {});
 const ensureAssigneesOnce = jest.fn<EnsureAssigneesOnce>(async () => {});
@@ -300,7 +318,7 @@ function mkCtx(args: {
     octokit: args.octokit ?? mkOctokit(),
     log: args.log ?? mkLogger(),
     issue: () => mkIssueParams(owner, repo, issueNumber),
-    resourceBotConfig: args.config,
+    resourceBotConfig: args.config ? withWorkflowLabels(args.config) : undefined,
     resourceBotHooks: {},
     resourceBotHooksSource: 'mock',
   };
@@ -684,7 +702,6 @@ describe('request-orchestrator additional coverage', () => {
     await expect(handlers['issue_comment.created']?.(ctx)).resolves.toBeUndefined();
 
     const warnMsgs = ctx.log.warn.mock.calls.map((c) => String(c[1] ?? '')).join('\n');
-    expect(warnMsgs).toContain('failed to remove review pending label after approval');
     expect(warnMsgs).toContain('failed to remove label');
 
     const removed = octokit.issues.removeLabel.mock.calls.map((c) => String(c[0]?.name ?? '')).sort();
@@ -700,6 +717,8 @@ describe('request-orchestrator additional coverage', () => {
       workflow: {
         labels: {
           approvalSuccessful: 'ship it',
+          approvalRequested: ['Review Pending'],
+          approverAction: 'Review Pending',
         },
         approvers: [],
       },
@@ -710,7 +729,7 @@ describe('request-orchestrator additional coverage', () => {
       title: 'Request',
       body: '### Namespace\nsap.ok',
       state: 'open',
-      labels: [],
+      labels: [{ name: 'Review Pending' }],
       user: { login: 'author' },
     };
 

--- a/test/request-orchestrator.current-head.test.ts
+++ b/test/request-orchestrator.current-head.test.ts
@@ -32,7 +32,18 @@ const loadStaticConfig = jest.fn(async () => ({}));
 const getDocLinksFromConfig = jest.fn(() => '');
 
 const DEFAULT_CONFIG = {
-  workflow: { labels: {}, approvers: [] },
+  workflow: {
+    labels: {
+      authorAction: 'Requester Action',
+      approverAction: 'Review Pending',
+      parentOwnerAction: 'Parent Owner Action',
+      approvalRequested: ['Review Pending'],
+      approvalSuccessful: ['Approved'],
+      approvalRejected: ['Rejected'],
+    },
+    approvers: [],
+  },
+  requests: {},
 } as any;
 
 let requestHandler: any;

--- a/test/request-orchestrator.labels-lock.test.ts
+++ b/test/request-orchestrator.labels-lock.test.ts
@@ -186,17 +186,32 @@ const loadStaticConfig = jest.fn() as unknown as jest.MockedFunction<
 >;
 const getDocLinksFromConfig = jest.fn() as unknown as jest.MockedFunction<(cfg: StaticConfig) => string>;
 
+const TEST_WORKFLOW_LABELS = {
+  authorAction: 'Requester Action',
+  approverAction: 'Review Pending',
+  parentOwnerAction: 'Parent Owner Action',
+  approvalRequested: ['Review Pending'],
+  approvalSuccessful: ['Approved'],
+  approvalRejected: ['Rejected'],
+};
+
+function withWorkflowLabels<T extends StaticConfig>(cfg: T): T {
+  cfg.workflow = cfg.workflow || {};
+  cfg.workflow.labels = {
+    ...TEST_WORKFLOW_LABELS,
+    ...(cfg.workflow.labels || {}),
+  };
+  return cfg;
+}
+
 // Provide a DEFAULT_CONFIG for the module import
-const DEFAULT_CONFIG: StaticConfig = {
+const DEFAULT_CONFIG: StaticConfig = withWorkflowLabels({
   workflow: {
-    labels: {
-      approvalSuccessful: ['Approved'],
-    },
+    labels: {},
     approvers: [],
   },
-
   requests: {},
-};
+});
 
 jest.unstable_mockModule('../src/handlers/request/state.js', () => ({
   setStateLabel,
@@ -340,7 +355,7 @@ function mkCtx(args: {
     issue: () => ({ owner: 'o', repo: 'r', issue_number: args.issue.number }),
     log: mkLogger(),
     // Cache config to skip loadStaticConfig
-    resourceBotConfig: args.config,
+    resourceBotConfig: withWorkflowLabels(args.config),
     resourceBotHooks: null,
     resourceBotHooksSource: 'test',
   };
@@ -887,7 +902,7 @@ describe('request handler label guards (workflow-label-lock + routing label lock
     expect(postOnce).toHaveBeenCalledTimes(1);
     const msg = postOnce.mock.calls[0]?.[2] ?? '';
     const opts = postOnce.mock.calls[0]?.[3];
-    expect(String(msg)).toContain('Rejected label change reverted');
+    expect(String(msg)).toContain('Rejected state is managed automatically');
     expect(opts?.minimizeTag).toBe('nsreq:label-guard');
   });
 

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -2097,7 +2097,7 @@ describe('parent owner approval gating', () => {
     expect(ensureAssigneesOnce).not.toHaveBeenCalled();
   });
 
-  test('does not gate when the requester is already an owner of the parent namespace', async () => {
+  test('issues.opened: subcontext requester who owns parent namespace creates PR without CPA review', async () => {
     const { app, handlers: h } = mkApp();
     requestHandler(app);
 
@@ -2112,7 +2112,11 @@ describe('parent owner approval gating', () => {
     };
 
     const tpl = {
-      _meta: { requestType: 'subContextNamespace', root: '/data/namespaces', schema: 'x' },
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
       title: 'Sub-Context Namespace',
       labels: ['Sub-Context Namespace'],
       body: [],
@@ -2131,25 +2135,144 @@ describe('parent owner approval gating', () => {
       formData: { identifier: target, description: 'x' },
     });
 
+    findOpenIssuePrs.mockResolvedValue([]);
+    createRequestPr.mockResolvedValue({ number: 777 });
+
     const ctx = mkIssuesContext({ issue, action: 'opened' });
-    const parentYaml = `contacts:\n  - "@barOwner"\n`;
 
     (ctx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
       if (path === 'data/vendors/sap.yaml') {
         return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
       }
+
       if (path === 'data/namespaces/sap.css.yaml') {
-        return { data: { content: b64(parentYaml), encoding: 'base64' } };
+        return {
+          data: {
+            content: b64('contacts:\n  - "@barOwner"\n'),
+            encoding: 'base64',
+          },
+        };
       }
+
       throw Object.assign(new Error('Not Found'), { status: 404 });
     });
 
     await h['issues.opened'][0](ctx);
 
-    const posted = postedBodies();
-    expect(posted).not.toContain('Parent owner approval required');
-    expect(ensureAssigneesOnce).toHaveBeenCalled();
-    expect(setStateLabel).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), 'review');
+    expect(postedBodies()).not.toContain('Parent owner approval required');
+    expect(postedBodies()).not.toContain('### ➡️ Routing to an approver for review');
+
+    expect(issue.body).toContain('nsreq:parent-approval');
+    expect(issue.body).toContain('"parent":"sap.css"');
+    expect(issue.body).toContain(`"target":"${target}"`);
+    expect(issue.body).toContain('"approvedBy":"barOwner"');
+
+    const createRequestPrCalls = (createRequestPr as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+
+    expect(createRequestPrCalls).toHaveLength(1);
+
+    expect(createRequestPrCalls[0]).toEqual([
+      expect.anything(),
+      { owner: 'o', repo: 'r' },
+      expect.objectContaining({ number: 551 }),
+      expect.objectContaining({ identifier: target }),
+      expect.objectContaining({ template: tpl }),
+    ]);
+
+    expect(postedBodies()).toContain('Approved by parent namespace owner @barOwner');
+    expect(postedBodies()).toContain('Opened PR: #777');
+
+    expect(ctx.octokit.issues.addLabels).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: ['Parent Owner Action'],
+      })
+    );
+
+    expect(postOnce.mock.calls.some((call) => call[3]?.minimizeTag === 'nsreq:handover')).toBe(false);
+  });
+
+  test('issue_comment: requester update creates subcontext PR when requester owns parent namespace', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const target = 'sap.css.bar';
+    const issue = {
+      number: 552,
+      title: 'Sub-Context Namespace',
+      body: `### Namespace\n\n${target}\n`,
+      labels: [{ name: 'Sub-Context Namespace' }],
+      user: { type: 'User', login: 'barOwner' },
+      state: 'open',
+    };
+
+    const tpl = {
+      _meta: {
+        requestType: 'subContextNamespace',
+        root: '/data/namespaces',
+        schema: '.github/registry-bot/request-schemas/sub-context-namespace.schema.json',
+      },
+      title: 'Sub-Context Namespace',
+      labels: ['Sub-Context Namespace'],
+      body: [],
+    };
+
+    loadTemplate.mockResolvedValue(tpl);
+    parseForm.mockReturnValue({ identifier: target, description: 'x' });
+    validateRequestIssue.mockResolvedValue({
+      errors: [],
+      errorsGrouped: {},
+      errorsFormatted: '',
+      errorsFormattedSingle: '',
+      namespace: target,
+      nsType: 'subContextNamespace',
+      template: tpl,
+      formData: { identifier: target, description: 'x' },
+    });
+
+    findOpenIssuePrs.mockResolvedValue([]);
+    createRequestPr.mockResolvedValue({ number: 778 });
+
+    const ctx = mkCommentContext({
+      event: 'issue_comment.created',
+      issue,
+      comment: { body: 'updated', user: { login: 'barOwner' } },
+      sender: { type: 'User', login: 'barOwner' },
+      withCachedConfig: true,
+      config: withWorkflowLabels({
+        requests: {
+          subContextNamespace: {
+            folderName: 'data/namespaces',
+            schema: 'schema.json',
+            issueTemplate: 'template.yml',
+          },
+        },
+        workflow: { labels: {}, approvers: [] },
+      } as any),
+    });
+
+    (ctx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return { data: { content: b64('name: sap\n'), encoding: 'base64' } };
+      }
+
+      if (path === 'data/namespaces/sap.css.yaml') {
+        return {
+          data: {
+            content: b64('contacts:\n  - "@barOwner"\n'),
+            encoding: 'base64',
+          },
+        };
+      }
+
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    });
+
+    await handlers['issue_comment.created'][0](ctx);
+
+    expect(createRequestPr).toHaveBeenCalled();
+    expect(postedBodies()).toContain('Approved by parent namespace owner @barOwner');
+    expect(postedBodies()).toContain('Opened PR: #778');
+    expect(postedBodies()).not.toContain('### ➡️ Routing to an approver for review');
   });
 
   test('gates sub-namespace request when parent owner email resolves via GraphQL fallback', async () => {

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -49,14 +49,58 @@ const tryMergeIfGreen = jest.fn(async (_ctx: any, _opts: any) => {});
 const loadStaticConfig = jest.fn(async () => ({}));
 const getDocLinksFromConfig = jest.fn(() => '');
 
-const DEFAULT_CONFIG = {
+type TestConfig = {
+  workflow?: {
+    labels?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+const TEST_WORKFLOW_LABELS = {
+  authorAction: 'Requester Action',
+  approverAction: 'Review Pending',
+  parentOwnerAction: 'Parent Owner Action',
+  approvalRequested: ['Review Pending'],
+  approvalSuccessful: ['Approved'],
+  approvalRejected: ['Rejected'],
+};
+
+function withWorkflowLabels<T extends TestConfig>(cfg: T): T {
+  cfg.workflow = {
+    ...(cfg.workflow || {}),
+    labels: {
+      ...TEST_WORKFLOW_LABELS,
+      ...(cfg.workflow?.labels || {}),
+    },
+  };
+
+  return cfg;
+}
+
+const DEFAULT_CONFIG = withWorkflowLabels({
   workflow: { labels: {}, approvers: [] },
-} as any;
+} as any);
 
 let requestHandler: any;
 
 function postedBodies(): string {
   return postOnce.mock.calls.map((call) => call[2] ?? '').join('\n');
+}
+
+function reviewLabels(): { name: string }[] {
+  return [{ name: 'Review Pending' }];
+}
+
+function inReview<T extends { labels?: any[] }>(issue: T): T {
+  return {
+    ...issue,
+    labels: [...(Array.isArray(issue.labels) ? issue.labels : []), ...reviewLabels()],
+  };
+}
+
+function expectHandoverPosted(): void {
+  expect(postOnce.mock.calls.some((call) => call[3]?.minimizeTag === 'nsreq:handover')).toBe(true);
 }
 
 function httpErr(status: number): Error & { status: number } {
@@ -174,11 +218,12 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
           },
         }),
       },
+      request: jest.fn(async () => ({ data: { workflow_runs: [] } })),
     },
   };
 
   if (args.withCachedConfig) {
-    ctx.resourceBotConfig = args.config ?? DEFAULT_CONFIG;
+    ctx.resourceBotConfig = withWorkflowLabels(args.config ?? DEFAULT_CONFIG);
     ctx.resourceBotHooks = null;
     ctx.resourceBotHooksSource = null;
   }
@@ -544,7 +589,7 @@ test('issue_comment: approval ignored for self-approve when no approvers configu
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'bob' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'bob' } }),
     comment: { body: 'Approved', user: { login: 'bob' } },
     withCachedConfig: true,
     config: cfg,
@@ -571,7 +616,7 @@ test('issue_comment: approval keyword from config triggers approval detection', 
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: '> quote\n\nShip it', user: { login: 'alice' } },
     withCachedConfig: true,
     config: cfg,
@@ -595,7 +640,7 @@ test('issue_comment: approval fails when resource name missing', async () => {
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'Approved', user: { login: 'alice' } },
     withCachedConfig: true,
     config: cfg,
@@ -617,7 +662,7 @@ test('issue_comment: approval short-circuits when PR already exists', async () =
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'Approved', user: { login: 'alice' } },
     withCachedConfig: true,
   });
@@ -661,7 +706,7 @@ test('issue_comment: approval with existing PR only adds hook approvers missing 
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'Approved', user: { login: 'alice' } },
     withCachedConfig: true,
     config: cfg,
@@ -682,7 +727,7 @@ test('issue_comment: approval with existing PR only adds hook approvers missing 
         number: 1,
         title: 't',
         body: 'b',
-        labels: [],
+        labels: reviewLabels(),
         user: { login: 'author' },
       },
     };
@@ -707,7 +752,7 @@ test('issue_comment: approval create PR failure -> posts error', async () => {
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'Approved', user: { login: 'alice' } },
     withCachedConfig: true,
   });
@@ -735,7 +780,7 @@ test('issue_comment: author update comment triggers revalidation errors -> posts
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'updated', user: { login: 'author' } },
     withCachedConfig: true,
   });
@@ -765,7 +810,7 @@ test('issue_comment: author update revalidation maps machine-readable validation
 
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
-    issue: { number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } },
+    issue: inReview({ number: 1, title: 't', body: 'b', labels: [], user: { login: 'author' } }),
     comment: { body: 'updated', user: { login: 'author' } },
     withCachedConfig: true,
   });
@@ -2541,6 +2586,14 @@ describe('parent owner approval gating', () => {
     const barYaml = `contacts:\n  - "@barOwner"\n`;
 
     (openCtx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+      if (path === 'data/vendors/sap.yaml') {
+        return {
+          data: {
+            content: Buffer.from('type: vendor\nname: sap\n', 'utf8').toString('base64'),
+            encoding: 'base64',
+          },
+        };
+      }
       if (path === 'data/namespaces/sap.css.yaml') {
         return { data: { content: b64(topYaml), encoding: 'base64' } };
       }
@@ -6297,7 +6350,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('<!-- nsreq:snapshot:');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
     expect(posted).toContain('manual review required');
     expect(posted).toContain('<summary>Decision details</summary>');
   });
@@ -6418,7 +6471,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('Manual review required because onApproval did not approve all changed registry files.');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('check_suite.success: standalone direct PR onApproval unknown assigns only hook manual approvers and not approversPool', async () => {
@@ -6687,7 +6740,7 @@ public
         error: jest.fn(),
         debug: jest.fn(),
       },
-      resourceBotConfig: cfg,
+      resourceBotConfig: withWorkflowLabels(cfg),
       resourceBotHooks: {},
       resourceBotHooksSource: 'test',
     };
@@ -6905,7 +6958,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('<!-- nsreq:snapshot:');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
     expect(posted).toContain('manual review required');
     expect(posted).toContain('<summary>Decision details</summary>');
   });
@@ -6927,14 +6980,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 162,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
@@ -7024,14 +7077,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 1621,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
@@ -7126,14 +7179,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 16215,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const sharedPr = {
         number: 16215,
@@ -7243,14 +7296,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 1622,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
@@ -7339,14 +7392,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 163,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
@@ -7423,14 +7476,14 @@ public
       const { app, handlers } = mkApp();
       requestHandler(app);
 
-      const issue = {
+      const issue = inReview({
         number: 1623,
         title: 'Direct PR',
         body: 'manual direct pr',
         labels: [],
         user: { login: 'requester' },
         pull_request: {},
-      };
+      });
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
@@ -7875,7 +7928,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('<!-- nsreq:snapshot:');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
   test('issues.opened: onApproval unknown manual approvers override assignment pool only', async () => {
     const cfg = {
@@ -7990,7 +8043,7 @@ public
     expect(posted).toContain('manual review required');
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
     expect(posted).toContain('<summary>Decision details</summary>');
   });
 
@@ -8089,7 +8142,7 @@ public
     );
 
     expect(postedBodies()).toContain('manual review required');
-    expect(postedBodies()).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('issues.opened: handover still auto-adds review labels when label refresh fails', async () => {
@@ -8179,7 +8232,7 @@ public
         call.some((arg: unknown) => String(arg ?? '').includes('failed to ensure labels'))
       )
     ).toBe(false);
-    expect(postedBodies()).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('issues.opened: handover logs when auto-adding review labels fails with non-404', async () => {
@@ -8270,7 +8323,7 @@ public
         call.some((arg: unknown) => String(arg ?? '').includes('failed to ensure labels'))
       )
     ).toBe(true);
-    expect(postedBodies()).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('issues.opened: concurrent unknown approvals dedupe the unknown-feedback post', async () => {
@@ -8820,7 +8873,7 @@ public
         error: jest.fn(),
         debug: jest.fn(),
       },
-      resourceBotConfig: cfg,
+      resourceBotConfig: withWorkflowLabels(cfg),
       resourceBotHooks: {},
       resourceBotHooksSource: 'test',
     };
@@ -8914,7 +8967,7 @@ public
         error: jest.fn(),
         debug: jest.fn(),
       },
-      resourceBotConfig: cfg,
+      resourceBotConfig: withWorkflowLabels(cfg),
       resourceBotHooks: {},
       resourceBotHooksSource: 'test',
     };
@@ -9028,7 +9081,7 @@ public
         error: jest.fn(),
         debug: jest.fn(),
       },
-      resourceBotConfig: cfg,
+      resourceBotConfig: withWorkflowLabels(cfg),
       resourceBotHooks: {},
       resourceBotHooksSource: 'test',
     };
@@ -9173,7 +9226,7 @@ public
         error: jest.fn(),
         debug: jest.fn(),
       },
-      resourceBotConfig: cfg,
+      resourceBotConfig: withWorkflowLabels(cfg),
       resourceBotHooks: {},
       resourceBotHooksSource: 'test',
     };
@@ -9327,7 +9380,7 @@ public
           error: jest.fn(),
           debug: jest.fn(),
         },
-        resourceBotConfig: cfg,
+        resourceBotConfig: withWorkflowLabels(cfg),
         resourceBotHooks: {},
         resourceBotHooksSource: 'test',
       };
@@ -9484,7 +9537,7 @@ public
           error: jest.fn(),
           debug: jest.fn(),
         },
-        resourceBotConfig: cfg,
+        resourceBotConfig: withWorkflowLabels(cfg),
         resourceBotHooks: {},
         resourceBotHooksSource: 'test',
       };
@@ -9717,7 +9770,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('Once reviewed, please comment `Approved` to approve this PR for merge.');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('issue_comment.created: standalone direct PR fallback allows any request-type pool approver, not only assigned one', async () => {
@@ -10799,7 +10852,7 @@ public
     expect(posted).toContain('### ✅ No issues detected');
     expect(posted).toContain('### ➡️ Routing to an approver for review');
     expect(posted).toContain('Manual review required because onApproval did not approve all changed registry files.');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('issue_comment.created: product standalone direct PR approval by request-type pool requester creates approval review and merges', async () => {
@@ -11054,7 +11107,7 @@ public
     const posted = postedBodies();
 
     expect(posted).toContain('manual review required by hook');
-    expect(posted).toContain('<!-- nsreq:handover -->');
+    expectHandoverPosted();
   });
 
   test('check_suite.failure: registry validate annotations are grouped and posted to matching PR', async () => {
@@ -13813,14 +13866,14 @@ test('issue_comment: already-existing resource retry failure reports stale branc
   requestHandler(app);
 
   const handler = handlers['issue_comment.created'][0];
-  const issue = {
+  const issue = inReview({
     number: 77,
     title: 'Request',
     body: '### Product ID\nproduct-stale',
     labels: [],
     state: 'open',
     user: { login: 'author' },
-  };
+  });
   const ctx = mkCommentContext({
     event: 'issue_comment.created',
     issue,
@@ -14180,6 +14233,14 @@ test('issue_comment: parent-owner approval posts validation fallback errors and 
 
   const openCtx = mkIssuesContext({ issue, action: 'opened' });
   (openCtx.octokit.repos.getContent as jest.Mock).mockImplementation(async ({ path }: any) => {
+    if (path === 'data/vendors/sap.yaml') {
+      return {
+        data: {
+          content: Buffer.from('type: vendor\nname: sap\n', 'utf8').toString('base64'),
+          encoding: 'base64',
+        },
+      };
+    }
     if (path === 'data/namespaces/sap.css.yaml') {
       return {
         data: { content: Buffer.from('contacts:\n  - "@barOwner"\n', 'utf8').toString('base64'), encoding: 'base64' },
@@ -14224,17 +14285,15 @@ describe('request orchestrator edge coverage for defensive branches', () => {
   const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64');
 
   function productCfg(extraLabels: Record<string, any> = {}) {
-    return {
+    return withWorkflowLabels({
       requests: { product: { folderName: 'resources' } },
       workflow: {
         labels: {
-          approvalRequested: ['Review Pending'],
-          approvalSuccessful: ['Approved'],
           ...extraLabels,
         },
         approvers: ['approver'],
       },
-    } as any;
+    } as any);
   }
 
   test('check_suite.completed failure paginates registry annotations until a partial page', async () => {
@@ -14292,14 +14351,14 @@ describe('request orchestrator edge coverage for defensive branches', () => {
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
-        issue: {
+        issue: inReview({
           number: 902,
           title: 'Direct PR',
           body: 'manual direct pr',
           labels: [],
           user: { login: 'requester' },
           pull_request: {},
-        },
+        }),
         comment: { body: 'Approved', user: { login: 'reviewer1' } },
         sender: { type: 'User', login: 'reviewer1' },
         withCachedConfig: true,
@@ -14356,14 +14415,14 @@ describe('request orchestrator edge coverage for defensive branches', () => {
 
       const ctx = mkCommentContext({
         event: 'issue_comment.created',
-        issue: {
+        issue: inReview({
           number: 9021,
           title: 'Direct PR ordered rejection',
           body: 'manual direct pr',
           labels: [],
           user: { login: 'requester' },
           pull_request: {},
-        },
+        }),
         comment: { body: 'Approved', user: { login: 'reviewer1' } },
         sender: { type: 'User', login: 'reviewer1' },
         withCachedConfig: true,

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -277,6 +277,51 @@ function mkIssuesContext(args: {
   return ctx;
 }
 
+function mkPullRequestContext(args: {
+  action?: 'opened' | 'synchronize' | 'reopened' | 'ready_for_review';
+  pr?: any;
+  config?: any;
+}) {
+  const pr = args.pr ?? {
+    number: 2001,
+    title: 'Direct registry PR',
+    body: 'manual direct pr',
+    state: 'open',
+    draft: false,
+    user: { login: 'external-user' },
+    head: { ref: 'feature/registry-pr', sha: 'sha-workflow-waiting' },
+    base: { ref: 'main' },
+  };
+
+  const ctx = mkBaseContext({
+    owner: 'o',
+    repo: 'r',
+    issue: { number: pr.number, title: pr.title, body: pr.body, labels: [], user: pr.user },
+    withCachedConfig: true,
+    config:
+      args.config ??
+      withWorkflowLabels({
+        requests: {
+          systemNamespace: {
+            folderName: 'data/namespaces',
+            schema: 'schema.json',
+            issueTemplate: 'template.yml',
+          },
+        },
+        workflow: { labels: {}, approvers: [] },
+      } as any),
+  });
+
+  ctx.name = `pull_request.${args.action ?? 'opened'}`;
+  ctx.payload = {
+    action: args.action ?? 'opened',
+    repository: { name: 'r', owner: { login: 'o' } },
+    pull_request: pr,
+  };
+
+  return ctx;
+}
+
 function mkCheckSuiteContext(args: {
   event: 'check_suite.completed' | 'check_run.completed';
   conclusion: string;
@@ -12747,7 +12792,7 @@ test('push: direct registry PR runs approval after reevaluation when branch is a
     hooks: null,
     hooksSource: null,
   });
-  extractHashFromPrBody.mockReturnValueOnce('');
+  extractHashFromPrBody.mockReturnValue('');
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
     if (typeof callback === 'function') callback();
@@ -12780,14 +12825,14 @@ test('push: direct registry PR runs approval after reevaluation when branch is a
     data: [{ filename: 'resources/product-direct-green.yaml', status: 'modified' }],
   });
 
-  ctx.octokit.repos.getContent.mockResolvedValueOnce({
+  ctx.octokit.repos.getContent.mockResolvedValue({
     data: {
       content: Buffer.from('type: product\nname: product-direct-green\n', 'utf8').toString('base64'),
       encoding: 'base64',
     },
   });
 
-  ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+  ctx.octokit.pulls.listCommits.mockResolvedValue({
     data: [{ committer: { login: 'direct-green-user' } }],
   });
 
@@ -12804,7 +12849,7 @@ test('push: direct registry PR runs approval after reevaluation when branch is a
     },
   });
 
-  runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved after push reevaluation' } as any);
+  runApprovalHook.mockResolvedValue({ status: 'approved', comment: 'approved after push reevaluation' } as any);
 
   await handler(ctx);
 
@@ -12857,7 +12902,7 @@ test('push: direct registry PR polls mergeability repeatedly before merging on t
     hooks: null,
     hooksSource: null,
   });
-  extractHashFromPrBody.mockReturnValueOnce('');
+  extractHashFromPrBody.mockReturnValue('');
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
     if (typeof callback === 'function') callback();
@@ -12890,14 +12935,14 @@ test('push: direct registry PR polls mergeability repeatedly before merging on t
     data: [{ filename: 'resources/product-direct-mergeability-poll.yaml', status: 'modified' }],
   });
 
-  ctx.octokit.repos.getContent.mockResolvedValueOnce({
+  ctx.octokit.repos.getContent.mockResolvedValue({
     data: {
       content: Buffer.from('type: product\nname: product-direct-mergeability-poll\n', 'utf8').toString('base64'),
       encoding: 'base64',
     },
   });
 
-  ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+  ctx.octokit.pulls.listCommits.mockResolvedValue({
     data: [{ committer: { login: 'direct-mergeability-poll-user' } }],
   });
 
@@ -12914,7 +12959,7 @@ test('push: direct registry PR polls mergeability repeatedly before merging on t
     },
   });
 
-  runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved after mergeability polling' } as any);
+  runApprovalHook.mockResolvedValue({ status: 'approved', comment: 'approved after mergeability polling' } as any);
 
   await handler(ctx);
 
@@ -12955,7 +13000,7 @@ test('push: direct registry PR creates an approval review when prior review look
     hooks: null,
     hooksSource: null,
   });
-  extractHashFromPrBody.mockReturnValueOnce('');
+  extractHashFromPrBody.mockReturnValue('');
 
   const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
     if (typeof callback === 'function') callback();
@@ -12988,7 +13033,7 @@ test('push: direct registry PR creates an approval review when prior review look
     data: [{ filename: 'resources/product-direct-green-review-fetch-failed.yaml', status: 'modified' }],
   });
 
-  ctx.octokit.repos.getContent.mockResolvedValueOnce({
+  ctx.octokit.repos.getContent.mockResolvedValue({
     data: {
       content: Buffer.from('type: product\nname: product-direct-green-review-fetch-failed\n', 'utf8').toString(
         'base64'
@@ -12997,7 +13042,7 @@ test('push: direct registry PR creates an approval review when prior review look
     },
   });
 
-  ctx.octokit.pulls.listCommits.mockResolvedValueOnce({
+  ctx.octokit.pulls.listCommits.mockResolvedValue({
     data: [{ committer: { login: 'direct-green-review-fetch-failed-user' } }],
   });
 
@@ -13015,7 +13060,7 @@ test('push: direct registry PR creates an approval review when prior review look
   });
   ctx.octokit.pulls.listReviews.mockRejectedValueOnce(httpErr(500));
 
-  runApprovalHook.mockResolvedValueOnce({ status: 'approved', comment: 'approved after review lookup failure' } as any);
+  runApprovalHook.mockResolvedValue({ status: 'approved', comment: 'approved after review lookup failure' } as any);
 
   await handler(ctx);
 
@@ -14544,6 +14589,174 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     );
     expect(ctx.octokit.pulls.createReview).not.toHaveBeenCalled();
     expect(tryMergeIfGreen).not.toHaveBeenCalled();
+  });
+
+  test('pull_request.opened: approves waiting workflow run for safe registry-only PR', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkPullRequestContext({
+      pr: {
+        number: 2001,
+        title: 'Direct registry PR',
+        body: 'manual direct pr',
+        state: 'open',
+        draft: false,
+        user: { login: 'external-user' },
+        head: { ref: 'feature/registry-pr', sha: 'sha-workflow-waiting' },
+        base: { ref: 'main' },
+      },
+    });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'data/namespaces/sap.agtwf01.yaml', status: 'added' }],
+    });
+
+    ctx.octokit.request.mockImplementation(async (route: string, _args: any) => {
+      if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 12345,
+                name: 'registry-validate',
+                status: 'waiting',
+                conclusion: null,
+                head_sha: 'sha-workflow-waiting',
+                pull_requests: [{ number: 2001 }],
+              },
+            ],
+          },
+        };
+      }
+
+      if (route === 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve') {
+        return { data: {} };
+      }
+
+      return { data: {} };
+    });
+
+    await handlers['pull_request.opened'][0](ctx);
+
+    expect(ctx.octokit.request).toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve',
+      expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        run_id: 12345,
+      })
+    );
+
+    const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+    expect(infoMsgs).toContain('workflow-approval:run-approved');
+  });
+
+  test('pull_request.opened: does not approve waiting workflow run for non-registry-only PR', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkPullRequestContext({
+      pr: {
+        number: 2002,
+        title: 'Mixed PR',
+        body: 'manual mixed pr',
+        state: 'open',
+        draft: false,
+        user: { login: 'external-user' },
+        head: { ref: 'feature/mixed-pr', sha: 'sha-mixed-waiting' },
+        base: { ref: 'main' },
+      },
+    });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        { filename: 'data/namespaces/sap.agtwf02.yaml', status: 'added' },
+        { filename: 'README.md', status: 'modified' },
+      ],
+    });
+
+    ctx.octokit.request.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 12346,
+                name: 'registry-validate',
+                status: 'waiting',
+                conclusion: null,
+                head_sha: 'sha-mixed-waiting',
+                pull_requests: [{ number: 2002 }],
+              },
+            ],
+          },
+        };
+      }
+
+      return { data: {} };
+    });
+
+    await handlers['pull_request.opened'][0](ctx);
+
+    expect(ctx.octokit.request).not.toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve',
+      expect.anything()
+    );
+
+    const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+    expect(infoMsgs).toContain('workflow-approval:skip-not-safe-registry-only-pr');
+  });
+
+  test('pull_request.opened: does not schedule retry when workflow run is already visible and completed', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkPullRequestContext({
+      pr: {
+        number: 2003,
+        title: 'Direct registry PR',
+        body: 'manual direct pr',
+        state: 'open',
+        draft: false,
+        user: { login: 'external-user' },
+        head: { ref: 'feature/completed-run', sha: 'sha-completed-run' },
+        base: { ref: 'main' },
+      },
+    });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'data/namespaces/sap.agtwf03.yaml', status: 'added' }],
+    });
+
+    ctx.octokit.request.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 12347,
+                name: 'registry-validate',
+                status: 'completed',
+                conclusion: 'success',
+                head_sha: 'sha-completed-run',
+                pull_requests: [{ number: 2003 }],
+              },
+            ],
+          },
+        };
+      }
+
+      return { data: {} };
+    });
+
+    await handlers['pull_request.opened'][0](ctx);
+
+    const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+
+    expect(infoMsgs).toContain('workflow-approval:no-waiting-runs');
+    expect(infoMsgs).toContain('workflow-approval:retry-skipped-run-already-visible');
+    expect(infoMsgs).not.toContain('workflow-approval:retry-scheduled');
   });
 
   test('check_suite.success: rejected linked direct PR closes linked PRs and reports closed PR numbers', async () => {

--- a/test/request-orchestrator.sequential.test.ts
+++ b/test/request-orchestrator.sequential.test.ts
@@ -197,6 +197,7 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
           },
         }),
       },
+      request: jest.fn(async () => ({ data: { workflow_runs: [] } })),
     },
   };
 
@@ -386,6 +387,97 @@ test('check_run.completed failure marks failed sequential registry heads and adv
     expect.objectContaining({ owner: 'o1', repo: 'r1', pull_number: 916 })
   );
   expect(tryMergeIfGreen).not.toHaveBeenCalled();
+});
+
+test('check_suite.completed action_required approves waiting workflow for safe registry-only PR', async () => {
+  const { app, handlers } = mkApp();
+  requestHandler(app);
+
+  const cfg = withWorkflowLabels({
+    requests: {
+      systemNamespace: {
+        folderName: 'data/namespaces',
+        schema: 'schema.json',
+        issueTemplate: 'template.yml',
+      },
+    },
+    workflow: { labels: {}, approvers: [] },
+  } as any);
+
+  const ctx = mkCheckSuiteContext({
+    event: 'check_suite.completed',
+    conclusion: 'action_required',
+    sha: 'sha-action-required',
+    ownerLogin: 'o',
+    repoName: 'r',
+    withCachedConfig: true,
+    config: cfg,
+  });
+
+  ctx.payload.check_suite.pull_requests = [{ number: 77 }];
+
+  ctx.octokit.pulls.get.mockResolvedValue({
+    data: {
+      number: 77,
+      title: 'Direct registry PR',
+      body: 'manual direct pr',
+      state: 'open',
+      draft: false,
+      user: { login: 'external-user' },
+      head: { ref: 'feature/action-required', sha: 'sha-action-required' },
+      base: { ref: 'main' },
+    },
+  });
+
+  ctx.octokit.pulls.listFiles.mockResolvedValue({
+    data: [{ filename: 'data/namespaces/sap.agtwf04.yaml', status: 'added' }],
+  });
+
+  ctx.octokit.request.mockImplementation(async (route: string) => {
+    if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+      return {
+        data: {
+          workflow_runs: [
+            {
+              id: 45678,
+              name: 'registry-validate',
+              status: 'waiting',
+              conclusion: null,
+              head_sha: 'sha-action-required',
+              pull_requests: [{ number: 77 }],
+            },
+          ],
+        },
+      };
+    }
+
+    if (route === 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve') {
+      return { data: {} };
+    }
+
+    return { data: {} };
+  });
+
+  await handlers['check_suite.completed'][0](ctx);
+
+  expect(ctx.octokit.request).toHaveBeenCalledWith(
+    'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve',
+    expect.objectContaining({
+      owner: 'o',
+      repo: 'r',
+      run_id: 45678,
+    })
+  );
+
+  const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+  expect(infoMsgs).toContain('workflow-approval:run-approved');
+
+  const allLogMsgs = [
+    ...ctx.log.info.mock.calls.map((call: any[]) => call[1]),
+    ...ctx.log.warn.mock.calls.map((call: any[]) => call[1]),
+  ];
+
+  expect(allLogMsgs).not.toContain('sequential-registry-pr:failed-head-marked');
 });
 
 test('check_run.completed success releases active sequential PR when green head is not approved', async () => {

--- a/test/request-orchestrator.sequential.test.ts
+++ b/test/request-orchestrator.sequential.test.ts
@@ -50,9 +50,38 @@ const tryMergeIfGreen = jest.fn(async (_ctx: any, _opts: any) => {});
 const loadStaticConfig = jest.fn(async () => ({}));
 const getDocLinksFromConfig = jest.fn(() => '');
 
-const DEFAULT_CONFIG = {
+type TestConfig = {
+  workflow?: {
+    labels?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+const TEST_WORKFLOW_LABELS = {
+  authorAction: 'Requester Action',
+  approverAction: 'Review Pending',
+  parentOwnerAction: 'Parent Owner Action',
+  approvalRequested: ['Review Pending'],
+  approvalSuccessful: ['Approved'],
+  approvalRejected: ['Rejected'],
+};
+
+function withWorkflowLabels<T extends TestConfig>(cfg: T): T {
+  cfg.workflow = {
+    ...(cfg.workflow || {}),
+    labels: {
+      ...TEST_WORKFLOW_LABELS,
+      ...(cfg.workflow?.labels || {}),
+    },
+  };
+
+  return cfg;
+}
+
+const DEFAULT_CONFIG = withWorkflowLabels({
   workflow: { labels: {}, approvers: [] },
-} as any;
+} as any);
 
 let requestHandler: any;
 
@@ -172,7 +201,7 @@ function mkBaseContext(args: { owner?: string; repo?: string; issue?: any; withC
   };
 
   if (args.withCachedConfig) {
-    ctx.resourceBotConfig = args.config ?? DEFAULT_CONFIG;
+    ctx.resourceBotConfig = withWorkflowLabels(args.config ?? DEFAULT_CONFIG);
     ctx.resourceBotHooks = null;
     ctx.resourceBotHooksSource = null;
   }
@@ -514,7 +543,6 @@ test('check_run.completed success handles sequential changed-file lookup failure
   const warnMessages = checkCtx.log.warn.mock.calls.map((call: any[]) => String(call[1] ?? call[0] ?? '')).join('\n');
 
   expect(warnMessages).toContain('sequential-registry-pr:changed-files-lookup-failed');
-  expect(warnMessages).toContain('direct-pr:on-approval:registry-doc-read-failed');
   expect(warnMessages).not.toContain('auto-merge candidate processing failed');
   expect(tryMergeIfGreen).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
Improve direct registry PR automation and workflow state handling.

- resolve workflow labels dynamically from target `config.yaml`
- keep workflow state labels exclusive
- remove duplicate handover markers
- accept `Approved` comments only when the request/PR is in review state
- try to approve pending workflows for safe registry-only PRs
- add pull request and check-suite handling for workflow approval
- prioritize auto-approvable direct PRs in the sequential queue
- close empty no-op registry PRs
- auto-approve sub-context requests when the requester owns the parent namespace

This reduces manual CPA work for trusted registry PRs, keeps GitHub UI state cleaner, and avoids unsafe approval or merge behavior.