### PR TITLE
Require trust signal for workflow approval automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.8-dev.1",
+  "version": "0.1.8",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.8",
+  "version": "0.1.8-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/index.ts
+++ b/src/handlers/request/index.ts
@@ -5063,6 +5063,82 @@ async function approveWorkflowRun(
   }
 }
 
+type WorkflowApprovalTrustSignal = {
+  trusted: boolean;
+  reason: string;
+  decision?: ApprovalDecision;
+};
+
+async function resolveWorkflowApprovalTrustSignalForRegistryPr(
+  context: BotContext<RequestEvents>,
+  repoInfo: RepoInfo,
+  pr: PullRequestLike,
+  reason: string
+): Promise<WorkflowApprovalTrustSignal> {
+  // Keep this path focused on standalone direct PRs.
+  // Linked/snapshot-managed request PRs use the normal issue approval lifecycle.
+  if (parseLinkedIssueNumberFromPr(pr, repoInfo) !== null || isSnapshotManagedRequestPr(pr)) {
+    return {
+      trusted: false,
+      reason: 'not-standalone-direct-pr',
+    };
+  }
+
+  const baseBranch = toStringTrim(pr.base?.ref);
+
+  try {
+    const decision = await evaluateDirectPrOnApproval(context, repoInfo, pr, undefined, { baseBranch });
+
+    if (decision.status === 'approved') {
+      return {
+        trusted: true,
+        reason: 'onApproval-approved',
+        decision,
+      };
+    }
+
+    const hasCurrentHeadApproval = await hasAllowedStandaloneDirectPrApprovalForCurrentHead(
+      context,
+      repoInfo,
+      pr,
+      decision,
+      { baseBranch }
+    );
+
+    if (hasCurrentHeadApproval) {
+      return {
+        trusted: true,
+        reason: 'allowed-current-head-approval',
+        decision,
+      };
+    }
+
+    return {
+      trusted: false,
+      reason: `missing-trust-signal:${toStringTrim(decision.status) || 'none'}`,
+      decision,
+    };
+  } catch (error: unknown) {
+    log(
+      context,
+      'warn',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        err: getErrorMessage(error),
+        status: getHttpStatus(error),
+        reason,
+      },
+      'workflow-approval:trust-check-failed'
+    );
+
+    return {
+      trusted: false,
+      reason: 'trust-check-failed',
+    };
+  }
+}
+
 async function maybeApprovePendingWorkflowRunsForRegistryPr(
   context: BotContext<RequestEvents>,
   repoInfo: RepoInfo,
@@ -5082,6 +5158,25 @@ async function maybeApprovePendingWorkflowRunsForRegistryPr(
         reason,
       },
       'workflow-approval:skip-not-safe-registry-only-pr'
+    );
+
+    return false;
+  }
+
+  const trustSignal = await resolveWorkflowApprovalTrustSignalForRegistryPr(context, repoInfo, pr, reason);
+
+  if (!trustSignal.trusted) {
+    log(
+      context,
+      'info',
+      {
+        prNumber: pr.number,
+        headSha: toStringTrim(pr.head?.sha),
+        trustReason: trustSignal.reason,
+        decisionStatus: toStringTrim(trustSignal.decision?.status) || 'none',
+        reason,
+      },
+      'workflow-approval:skip-missing-trust-signal'
     );
 
     return false;
@@ -5223,6 +5318,8 @@ async function maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
   if (shouldRetryWorkflowApproval(repoInfo, pr)) {
     scheduleWorkflowApprovalRetry(context, repoInfo, pr, reason);
   } else {
+    const hasRunSnapshot = WORKFLOW_APPROVAL_LAST_RUNS.has(workflowApprovalHeadKey(repoInfo, pr));
+
     log(
       context,
       'info',
@@ -5231,7 +5328,9 @@ async function maybeApprovePendingWorkflowRunsForRegistryPrWithRetry(
         headSha: toStringTrim(pr.head?.sha),
         reason,
       },
-      'workflow-approval:retry-skipped-run-already-visible'
+      hasRunSnapshot
+        ? 'workflow-approval:retry-skipped-run-already-visible'
+        : 'workflow-approval:retry-skipped-no-trust-signal'
     );
   }
 

--- a/test/request-orchestrator.more.test.ts
+++ b/test/request-orchestrator.more.test.ts
@@ -14760,6 +14760,22 @@ describe('request orchestrator edge coverage for defensive branches', () => {
       return { data: {} };
     });
 
+    extractHashFromPrBody.mockReturnValue('');
+
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from('type: system\nname: sap.agtwf01\ndescription: Workflow approval test\n', 'utf8').toString(
+          'base64'
+        ),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValue({
+      status: 'approved',
+      comment: 'trusted registry-only PR',
+    } as any);
+
     await handlers['pull_request.opened'][0](ctx);
 
     expect(ctx.octokit.request).toHaveBeenCalledWith(
@@ -14773,6 +14789,72 @@ describe('request orchestrator edge coverage for defensive branches', () => {
 
     const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
     expect(infoMsgs).toContain('workflow-approval:run-approved');
+  });
+
+  test('pull_request.opened: does not approve waiting workflow run without trust signal', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkPullRequestContext({
+      pr: {
+        number: 2004,
+        title: 'Direct registry PR without trust',
+        body: 'manual direct pr',
+        state: 'open',
+        draft: false,
+        user: { login: 'external-user' },
+        head: { ref: 'feature/untrusted-registry-pr', sha: 'sha-untrusted-waiting' },
+        base: { ref: 'main' },
+      },
+    });
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'data/namespaces/sap.untrustedwf01.yaml', status: 'added' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from(
+          'type: system\nname: sap.untrustedwf01\ndescription: Untrusted workflow approval test\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValue({} as any);
+
+    ctx.octokit.request.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 12348,
+                name: 'registry-validate',
+                status: 'waiting',
+                conclusion: null,
+                head_sha: 'sha-untrusted-waiting',
+                pull_requests: [{ number: 2004 }],
+              },
+            ],
+          },
+        };
+      }
+
+      return { data: {} };
+    });
+
+    await handlers['pull_request.opened'][0](ctx);
+
+    expect(ctx.octokit.request).not.toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve',
+      expect.anything()
+    );
+
+    const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+    expect(infoMsgs).toContain('workflow-approval:skip-missing-trust-signal');
+    expect(infoMsgs).toContain('workflow-approval:retry-skipped-no-trust-signal');
   });
 
   test('pull_request.opened: does not approve waiting workflow run for non-registry-only PR', async () => {
@@ -14873,6 +14955,23 @@ describe('request orchestrator edge coverage for defensive branches', () => {
       return { data: {} };
     });
 
+    extractHashFromPrBody.mockReturnValue('');
+
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from(
+          'type: system\nname: sap.agtwf03\ndescription: Workflow approval completed-run test\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValue({
+      status: 'approved',
+      comment: 'trusted registry-only PR',
+    } as any);
+
     await handlers['pull_request.opened'][0](ctx);
 
     const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
@@ -14880,6 +14979,74 @@ describe('request orchestrator edge coverage for defensive branches', () => {
     expect(infoMsgs).toContain('workflow-approval:no-waiting-runs');
     expect(infoMsgs).toContain('workflow-approval:retry-skipped-run-already-visible');
     expect(infoMsgs).not.toContain('workflow-approval:retry-scheduled');
+  });
+
+  test('pull_request.opened: does not approve waiting workflow run without trust signal', async () => {
+    const { app, handlers } = mkApp();
+    requestHandler(app);
+
+    const ctx = mkPullRequestContext({
+      pr: {
+        number: 2004,
+        title: 'Direct registry PR without trust',
+        body: 'manual direct pr',
+        state: 'open',
+        draft: false,
+        user: { login: 'external-user' },
+        head: { ref: 'feature/untrusted-registry-pr', sha: 'sha-untrusted-waiting' },
+        base: { ref: 'main' },
+      },
+    });
+
+    extractHashFromPrBody.mockReturnValue('');
+
+    ctx.octokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'data/namespaces/sap.untrustedwf01.yaml', status: 'added' }],
+    });
+
+    ctx.octokit.repos.getContent.mockResolvedValue({
+      data: {
+        content: Buffer.from(
+          'type: system\nname: sap.untrustedwf01\ndescription: Untrusted workflow approval test\n',
+          'utf8'
+        ).toString('base64'),
+        encoding: 'base64',
+      },
+    });
+
+    runApprovalHook.mockResolvedValue({} as any);
+
+    ctx.octokit.request.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/actions/runs') {
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 12348,
+                name: 'registry-validate',
+                status: 'waiting',
+                conclusion: null,
+                head_sha: 'sha-untrusted-waiting',
+                pull_requests: [{ number: 2004 }],
+              },
+            ],
+          },
+        };
+      }
+
+      return { data: {} };
+    });
+
+    await handlers['pull_request.opened'][0](ctx);
+
+    expect(ctx.octokit.request).not.toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve',
+      expect.anything()
+    );
+
+    const infoMsgs = ctx.log.info.mock.calls.map((call: any[]) => call[1]);
+    expect(infoMsgs).toContain('workflow-approval:skip-missing-trust-signal');
+    expect(infoMsgs).toContain('workflow-approval:retry-skipped-no-trust-signal');
   });
 
   test('check_suite.success: rejected linked direct PR closes linked PRs and reports closed PR numbers', async () => {

--- a/test/request-orchestrator.sequential.test.ts
+++ b/test/request-orchestrator.sequential.test.ts
@@ -458,6 +458,22 @@ test('check_suite.completed action_required approves waiting workflow for safe r
     return { data: {} };
   });
 
+  extractHashFromPrBody.mockReturnValue('');
+
+  ctx.octokit.repos.getContent.mockResolvedValue({
+    data: {
+      content: Buffer.from('type: system\nname: sap.agtwf04\ndescription: Workflow approval test\n', 'utf8').toString(
+        'base64'
+      ),
+      encoding: 'base64',
+    },
+  });
+
+  runApprovalHook.mockResolvedValue({
+    status: 'approved',
+    comment: 'trusted registry-only PR',
+  } as any);
+
   await handlers['check_suite.completed'][0](ctx);
 
   expect(ctx.octokit.request).toHaveBeenCalledWith(


### PR DESCRIPTION
Tighten workflow approval automation for direct registry PRs.

- require a trust signal before approving pending workflow runs
- allow workflow approval only when `onApproval` returns `approved` or a valid current-head approval exists
- keep registry-only file checks as a required safety condition
- skip workflow approval for registry-only PRs without a trust signal
- keep the change fully in bot core, without target config changes
- add tests for trusted and untrusted workflow approval paths

This prevents the bot from bypassing GitHub's manual workflow approval gate for untrusted contributors.