### PR TITLE
Keep new required issue fields compatible with legacy issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.8-dev.1",
+  "version": "0.1.8",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-registry-bot",
-  "version": "0.1.8",
+  "version": "0.1.8-dev.1",
   "private": true,
   "description": "A configurable GitHub App bot to validate and automate registry-related requests",
   "author": "SAP SE",

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -2480,6 +2480,35 @@ function isEmpty(v: unknown): boolean {
   return !s || s.toLowerCase() === 'undefined';
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function issueBodyHasTemplateFieldSection(issueBody: unknown, field: TemplateField): boolean {
+  const body = String(issueBody || '');
+  if (!body) return false;
+
+  const candidates = [toStringSafe(field?.attributes?.label), toStringSafe(field?.id)].filter(Boolean);
+
+  return candidates.some((candidate) => {
+    const re = new RegExp(`^###\\s+${escapeRegExp(candidate)}\\s*$`, 'mi');
+    return re.test(body);
+  });
+}
+
+function shouldEnforceRequiredTemplateField(issueBody: unknown, field: TemplateField, formData: FormData): boolean {
+  const id = toStringSafe(field?.id);
+  if (!id) return false;
+
+  if (!isEmpty((formData as Record<string, unknown>)[id])) {
+    return false;
+  }
+
+  // Backwards compatibility:
+  // Required fields added later must not block old issues that never had this section.
+  return issueBodyHasTemplateFieldSection(issueBody, field);
+}
+
 function inferNsType(requestType: unknown): string {
   const requestTypeLc = toStringSafe(requestType).toLowerCase();
 
@@ -2639,9 +2668,10 @@ export async function validateRequestIssue(
 
   // 5) Required field check from template
   const requiredFields = (template?.body || []).filter((f) => f?.id && f.validations?.required);
+  const issueBodyForRequiredCheck = String(issue.body || '');
 
   const missingRequired = requiredFields
-    .filter((f) => isEmpty((formData as Record<string, unknown>)?.[String(f.id)]))
+    .filter((f) => shouldEnforceRequiredTemplateField(issueBodyForRequiredCheck, f, formData))
     .map((f) => String(f?.attributes?.label || f.id));
 
   for (const label of missingRequired) {

--- a/src/handlers/request/validation/run.ts
+++ b/src/handlers/request/validation/run.ts
@@ -2496,6 +2496,10 @@ function issueBodyHasTemplateFieldSection(issueBody: unknown, field: TemplateFie
   });
 }
 
+function issueBodyHasAnyIssueFormSection(issueBody: unknown): boolean {
+  return /^###\s+\S+/m.test(String(issueBody || ''));
+}
+
 function shouldEnforceRequiredTemplateField(issueBody: unknown, field: TemplateField, formData: FormData): boolean {
   const id = toStringSafe(field?.id);
   if (!id) return false;
@@ -2504,11 +2508,19 @@ function shouldEnforceRequiredTemplateField(issueBody: unknown, field: TemplateF
     return false;
   }
 
+  const hasAnyIssueFormSection = issueBodyHasAnyIssueFormSection(issueBody);
+
+  // Unit tests / synthetic validation bodies often do not contain issue-form markdown sections.
+  // In that case this is not a legacy issue-form body, so required validation must stay strict.
+  if (!hasAnyIssueFormSection) {
+    return true;
+  }
+
   // Backwards compatibility:
-  // Required fields added later must not block old issues that never had this section.
+  // If the issue body already has issue-form sections, but this specific section is missing,
+  // treat it as an older issue created before the field was added.
   return issueBodyHasTemplateFieldSection(issueBody, field);
 }
-
 function inferNsType(requestType: unknown): string {
   const requestTypeLc = toStringSafe(requestType).toLowerCase();
 


### PR DESCRIPTION
Keep validation backwards compatible for existing request issues after issue template changes.

- do not block old issues for newly added required fields
- only enforce required fields when the section exists in the issue body
- keep required validation active for new issues and empty existing sections
- avoid false validation errors like missing `Justification & Intended Usage` on legacy issues

This allows delayed or older issues to continue through the workflow without being blocked by fields that did not exist when the issue was created.