### PR TITLE
feat(request): add async webhook dispatch layer

### DIFF
--- a/src/handlers/request/events/checks.ts
+++ b/src/handlers/request/events/checks.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 export type CheckEventDependencies<ContextType> = {
   handleCheckCompletedEvent: (context: ContextType, payload: unknown, eventName: string) => Promise<void>;
@@ -19,6 +20,6 @@ export function createCheckEventHandler<ContextType extends { payload: unknown }
 
 export function registerCheckEvents<CheckContext>(app: Probot, handler: RequestEventHandler<CheckContext>): void {
   app.on(['check_suite.completed', 'check_run.completed'], async (context): Promise<void> => {
-    await handler(context as CheckContext);
+    await dispatchWebhookHandler(context as CheckContext, handler, { eventFamily: 'checks' });
   });
 }

--- a/src/handlers/request/events/issue-comments.ts
+++ b/src/handlers/request/events/issue-comments.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 type IssueParamsBase = {
   owner: string;
@@ -279,6 +280,6 @@ export function registerIssueCommentEvents<IssueCommentContext>(
   handler: RequestEventHandler<IssueCommentContext>
 ): void {
   app.on(['issue_comment.created', 'issue_comment.edited'], async (context): Promise<void> => {
-    await handler(context as IssueCommentContext);
+    await dispatchWebhookHandler(context as IssueCommentContext, handler, { eventFamily: 'issue_comment' });
   });
 }

--- a/src/handlers/request/events/issues.ts
+++ b/src/handlers/request/events/issues.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 type IssueParamsBase = {
   owner: string;
@@ -200,14 +201,20 @@ export function registerIssueEvents<IssueLifecycleContext, IssueClosedContext, I
   handlers: IssueEventHandlers<IssueLifecycleContext, IssueClosedContext, IssueLabelContext>
 ): void {
   app.on(['issues.opened', 'issues.edited', 'issues.reopened'], async (context): Promise<void> => {
-    await handlers.handleIssueLifecycle(context as IssueLifecycleContext);
+    await dispatchWebhookHandler(context as IssueLifecycleContext, handlers.handleIssueLifecycle, {
+      eventFamily: 'issues.lifecycle',
+    });
   });
 
   app.on('issues.closed', async (context): Promise<void> => {
-    await handlers.handleIssueClosed(context as IssueClosedContext);
+    await dispatchWebhookHandler(context as IssueClosedContext, handlers.handleIssueClosed, {
+      eventFamily: 'issues.closed',
+    });
   });
 
   app.on(['issues.labeled', 'issues.unlabeled'], async (context): Promise<void> => {
-    await handlers.handleIssueLabelChange(context as IssueLabelContext);
+    await dispatchWebhookHandler(context as IssueLabelContext, handlers.handleIssueLabelChange, {
+      eventFamily: 'issues.label-change',
+    });
   });
 }

--- a/src/handlers/request/events/pull-requests.ts
+++ b/src/handlers/request/events/pull-requests.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 export type PullRequestEventDependencies<ContextType, RepoInfoType, PullRequestType> = {
   getStaticConfig: (context: ContextType) => Promise<unknown>;
@@ -47,7 +48,7 @@ export function registerPullRequestEvents<PullRequestContext>(
   app.on(
     ['pull_request.opened', 'pull_request.synchronize', 'pull_request.reopened', 'pull_request.ready_for_review'],
     async (context): Promise<void> => {
-      await handler(context as PullRequestContext);
+      await dispatchWebhookHandler(context as PullRequestContext, handler, { eventFamily: 'pull_request' });
     }
   );
 }

--- a/src/handlers/request/events/push.ts
+++ b/src/handlers/request/events/push.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 type RepoInfoBase = {
   owner: string;
@@ -115,6 +116,6 @@ export function createPushEventHandler<
 
 export function registerPushEvents<PushContext>(app: Probot, handler: RequestEventHandler<PushContext>): void {
   app.on('push', async (context): Promise<void> => {
-    await handler(context as PushContext);
+    await dispatchWebhookHandler(context as PushContext, handler, { eventFamily: 'push' });
   });
 }

--- a/src/handlers/request/events/status.ts
+++ b/src/handlers/request/events/status.ts
@@ -1,5 +1,6 @@
 import type { Probot } from 'probot';
 import type { RequestEventHandler } from './types.js';
+import { dispatchWebhookHandler } from './webhook-dispatcher.js';
 
 export type StatusEventDependencies<ContextType, RepoInfoType> = {
   isPlainObject: (value: unknown) => value is Record<string, unknown>;
@@ -30,6 +31,6 @@ export function createStatusEventHandler<ContextType extends { payload: unknown 
 
 export function registerStatusEvents<StatusContext>(app: Probot, handler: RequestEventHandler<StatusContext>): void {
   app.on('status', async (context): Promise<void> => {
-    await handler(context as StatusContext);
+    await dispatchWebhookHandler(context as StatusContext, handler, { eventFamily: 'status' });
   });
 }

--- a/src/handlers/request/events/webhook-dispatcher.ts
+++ b/src/handlers/request/events/webhook-dispatcher.ts
@@ -103,41 +103,47 @@ function drainWebhookQueue(): void {
     active += 1;
 
     setImmediate(() => {
-      const startedAt = Date.now();
+      void (async (): Promise<void> => {
+        const startedAt = Date.now();
+        let failed = false;
+        let caughtError: unknown;
 
-      void task
-        .run()
-        .then(() => {
+        try {
+          await task.run();
+        } catch (error: unknown) {
+          failed = true;
+          caughtError = error;
+        } finally {
           const durationMs = Date.now() - startedAt;
 
-          task.log?.debug?.(
-            {
-              ...task.meta,
-              durationMs,
-              active,
-              queued: queue.length,
-            },
-            'webhook:async-handler-completed'
-          );
-        })
-        .catch((error: unknown) => {
-          const durationMs = Date.now() - startedAt;
-
-          task.log?.error?.(
-            {
-              ...task.meta,
-              err: getErrorMessage(error),
-              durationMs,
-              active,
-              queued: queue.length,
-            },
-            'webhook:async-handler-failed'
-          );
-        })
-        .finally(() => {
           active -= 1;
-          drainWebhookQueue();
-        });
+
+          const logMeta = {
+            ...task.meta,
+            durationMs,
+            active,
+            queued: queue.length,
+          };
+
+          try {
+            if (failed) {
+              task.log?.error?.(
+                {
+                  ...logMeta,
+                  err: getErrorMessage(caughtError),
+                },
+                'webhook:async-handler-failed'
+              );
+            } else {
+              task.log?.debug?.(logMeta, 'webhook:async-handler-completed');
+            }
+          } catch {
+            // Ignore logger failures so queue draining is not blocked.
+          } finally {
+            drainWebhookQueue();
+          }
+        }
+      })();
     });
   }
 }

--- a/src/handlers/request/events/webhook-dispatcher.ts
+++ b/src/handlers/request/events/webhook-dispatcher.ts
@@ -1,0 +1,165 @@
+import type { RequestEventHandler } from './types.js';
+
+type LoggerLike = {
+  debug?: (obj: unknown, msg?: string) => void;
+  info?: (obj: unknown, msg?: string) => void;
+  warn?: (obj: unknown, msg?: string) => void;
+  error?: (obj: unknown, msg?: string) => void;
+};
+
+type WebhookContextLike = {
+  id?: string;
+  name?: string;
+  payload?: unknown;
+  log?: LoggerLike;
+};
+
+type WebhookTaskMeta = {
+  eventFamily: string;
+  eventName: string;
+  action: string;
+  deliveryId: string;
+  owner: string | undefined;
+  repo: string | undefined;
+};
+
+type QueuedWebhookTask = {
+  meta: WebhookTaskMeta;
+  log?: LoggerLike;
+  run: () => Promise<void>;
+};
+
+const DEFAULT_WEBHOOK_ASYNC_CONCURRENCY = 2;
+
+const queue: QueuedWebhookTask[] = [];
+let active = 0;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toStringTrim(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim();
+  return '';
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (isPlainObject(error) && typeof error['message'] === 'string') return String(error['message']);
+  return String(error);
+}
+
+function readAsyncModeEnabled(): boolean {
+  const raw = toStringTrim(process.env['REQUEST_WEBHOOK_ASYNC']).toLowerCase();
+
+  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'sync') return false;
+  if (raw === '1' || raw === 'true' || raw === 'on' || raw === 'async') return true;
+
+  if (process.env['NODE_ENV'] === 'test' || process.env['JEST_WORKER_ID']) return false;
+
+  return true;
+}
+
+function readConcurrency(): number {
+  const raw = Number(process.env['REQUEST_WEBHOOK_ASYNC_CONCURRENCY'] || '');
+  if (Number.isFinite(raw) && raw >= 1) return Math.floor(raw);
+  return DEFAULT_WEBHOOK_ASYNC_CONCURRENCY;
+}
+
+function readMeta(context: WebhookContextLike, eventFamily: string): WebhookTaskMeta {
+  const payload = context.payload;
+  const payloadObj = isPlainObject(payload) ? payload : {};
+
+  const repository = isPlainObject(payloadObj['repository']) ? payloadObj['repository'] : {};
+  const repo = toStringTrim(repository['name']) || undefined;
+
+  const ownerObj = isPlainObject(repository['owner']) ? repository['owner'] : {};
+  const owner = toStringTrim(ownerObj['login']) || undefined;
+
+  return {
+    eventFamily,
+    eventName: toStringTrim(context.name) || eventFamily,
+    action: toStringTrim(payloadObj['action']) || '',
+    deliveryId: toStringTrim(context.id),
+    owner,
+    repo,
+  };
+}
+
+function enqueueWebhookTask(task: QueuedWebhookTask): void {
+  queue.push(task);
+  drainWebhookQueue();
+}
+
+function drainWebhookQueue(): void {
+  const concurrency = readConcurrency();
+
+  while (active < concurrency && queue.length > 0) {
+    const task = queue.shift();
+    if (!task) return;
+
+    active += 1;
+
+    setImmediate(() => {
+      const startedAt = Date.now();
+
+      void task
+        .run()
+        .then(() => {
+          const durationMs = Date.now() - startedAt;
+
+          task.log?.debug?.(
+            {
+              ...task.meta,
+              durationMs,
+              active,
+              queued: queue.length,
+            },
+            'webhook:async-handler-completed'
+          );
+        })
+        .catch((error: unknown) => {
+          const durationMs = Date.now() - startedAt;
+
+          task.log?.error?.(
+            {
+              ...task.meta,
+              err: getErrorMessage(error),
+              durationMs,
+              active,
+              queued: queue.length,
+            },
+            'webhook:async-handler-failed'
+          );
+        })
+        .finally(() => {
+          active -= 1;
+          drainWebhookQueue();
+        });
+    });
+  }
+}
+
+export async function dispatchWebhookHandler<ContextType>(
+  context: ContextType,
+  handler: RequestEventHandler<ContextType>,
+  options: { eventFamily: string }
+): Promise<void> {
+  if (!readAsyncModeEnabled()) {
+    await handler(context);
+    return;
+  }
+
+  const contextLike = context as WebhookContextLike;
+  const meta = readMeta(contextLike, options.eventFamily);
+
+  enqueueWebhookTask({
+    meta,
+    log: contextLike.log,
+    run: async (): Promise<void> => {
+      await handler(context);
+    },
+  });
+}

--- a/test/webhook-dispatcher.test.ts
+++ b/test/webhook-dispatcher.test.ts
@@ -1,0 +1,143 @@
+import { jest } from '@jest/globals';
+import { dispatchWebhookHandler } from '../src/handlers/request/events/webhook-dispatcher.js';
+import type { RequestEventHandler } from '../src/handlers/request/events/types.js';
+
+type TestContext = {
+  id: string;
+  name: string;
+  payload: Record<string, unknown>;
+  log: {
+    debug: jest.Mock;
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+  };
+};
+
+function makeContext(overrides: Partial<TestContext> = {}): TestContext {
+  return {
+    id: 'delivery-1',
+    name: 'check_suite.completed',
+    payload: { repository: { name: 'my-repo', owner: { login: 'my-org' } }, action: 'completed' },
+    log: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    ...overrides,
+  };
+}
+
+function flushSetImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('dispatchWebhookHandler', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('runs handler synchronously inside Jest (NODE_ENV=test is set by default)', async () => {
+    const calls: string[] = [];
+    const handler: RequestEventHandler<TestContext> = (_ctx): Promise<void> => {
+      calls.push('handler-called');
+      return Promise.resolve();
+    };
+
+    await dispatchWebhookHandler(makeContext(), handler, { eventFamily: 'checks' });
+
+    expect(calls).toEqual(['handler-called']);
+  });
+
+  test('runs handler synchronously when REQUEST_WEBHOOK_ASYNC=0', async () => {
+    process.env['REQUEST_WEBHOOK_ASYNC'] = '0';
+    delete process.env['JEST_WORKER_ID'];
+
+    const calls: string[] = [];
+    const handler: RequestEventHandler<TestContext> = (_ctx): Promise<void> => {
+      calls.push('handler-called');
+      return Promise.resolve();
+    };
+
+    await dispatchWebhookHandler(makeContext(), handler, { eventFamily: 'checks' });
+
+    expect(calls).toEqual(['handler-called']);
+  });
+
+  test('returns before handler runs when REQUEST_WEBHOOK_ASYNC=1', async () => {
+    process.env['REQUEST_WEBHOOK_ASYNC'] = '1';
+
+    const handler = jest.fn(async (_ctx: TestContext) => {
+      /* intentionally empty */
+    });
+
+    await dispatchWebhookHandler(makeContext(), handler, { eventFamily: 'checks' });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    await flushSetImmediate();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('logs webhook:async-handler-failed and does not rethrow when async handler throws', async () => {
+    process.env['REQUEST_WEBHOOK_ASYNC'] = '1';
+
+    const boom = new Error('boom');
+    const handler: RequestEventHandler<TestContext> = (_ctx): Promise<void> => Promise.reject(boom);
+
+    const context = makeContext();
+    await expect(dispatchWebhookHandler(context, handler, { eventFamily: 'checks' })).resolves.toBeUndefined();
+
+    await flushSetImmediate();
+
+    expect(context.log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: 'boom',
+        eventFamily: 'checks',
+        deliveryId: 'delivery-1',
+        owner: 'my-org',
+        repo: 'my-repo',
+      }),
+      'webhook:async-handler-failed'
+    );
+  });
+
+  test('propagates error to caller in synchronous mode', async () => {
+    process.env['REQUEST_WEBHOOK_ASYNC'] = '0';
+    delete process.env['JEST_WORKER_ID'];
+
+    const handler: RequestEventHandler<TestContext> = (_ctx): Promise<void> => Promise.reject(new Error('sync-boom'));
+
+    await expect(dispatchWebhookHandler(makeContext(), handler, { eventFamily: 'push' })).rejects.toThrow('sync-boom');
+  });
+
+  test('logs webhook:async-handler-completed on success when REQUEST_WEBHOOK_ASYNC=1', async () => {
+    process.env['REQUEST_WEBHOOK_ASYNC'] = '1';
+
+    const handler: RequestEventHandler<TestContext> = async (_ctx) => {
+      /* intentionally empty */
+    };
+
+    const context = makeContext();
+    await dispatchWebhookHandler(context, handler, { eventFamily: 'push' });
+    await flushSetImmediate();
+
+    expect(context.log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventFamily: 'push',
+        deliveryId: 'delivery-1',
+        owner: 'my-org',
+        repo: 'my-repo',
+      }),
+      'webhook:async-handler-completed'
+    );
+  });
+});

--- a/test/webhook-dispatcher.test.ts
+++ b/test/webhook-dispatcher.test.ts
@@ -105,6 +105,8 @@ describe('dispatchWebhookHandler', () => {
         deliveryId: 'delivery-1',
         owner: 'my-org',
         repo: 'my-repo',
+        active: 0,
+        queued: 0,
       }),
       'webhook:async-handler-failed'
     );
@@ -136,6 +138,8 @@ describe('dispatchWebhookHandler', () => {
         deliveryId: 'delivery-1',
         owner: 'my-org',
         repo: 'my-repo',
+        active: 0,
+        queued: 0,
       }),
       'webhook:async-handler-completed'
     );


### PR DESCRIPTION
## Summary

Adds an in-process async dispatch layer for request webhooks.

This lets production webhook handlers ACK GitHub deliveries quickly and continue
processing in the background, while keeping test execution synchronous by default.

## Changes

- Add `webhook-dispatcher.ts`
  - introduces `dispatchWebhookHandler(context, handler, { eventFamily })`
  - uses a `setImmediate` queue for async execution
  - supports configurable concurrency via `REQUEST_WEBHOOK_ASYNC_CONCURRENCY`
  - defaults concurrency to `2`
  - supports explicit mode control via `REQUEST_WEBHOOK_ASYNC`
  - defaults to sync mode in `NODE_ENV=test` or Jest worker environments
  - defaults to async mode outside test/Jest environments
  - logs async success as `webhook:async-handler-completed`
  - logs async failures as `webhook:async-handler-failed`
  - does not rethrow async handler failures after the webhook has been ACKed

- Route request event registrations through `dispatchWebhookHandler`
  - checks
  - issues
  - issue comments
  - pull requests
  - push
  - status

- Add unit coverage for dispatcher behavior
  - sync default in Jest/test mode
  - forced sync mode
  - async mode returns before handler execution
  - async errors are logged and not rethrown
  - sync errors still propagate
  - async success completion is logged